### PR TITLE
Add OG Gasless DNSSEC Support

### DIFF
--- a/contracts/src/L1/dns/DNSTXTResolver.sol
+++ b/contracts/src/L1/dns/DNSTXTResolver.sol
@@ -157,6 +157,16 @@ contract DNSTXTResolver is ERC165, IERC7996, IExtendedDNSResolver {
         uint256 coinType,
         bool useDefault
     ) internal pure returns (bytes memory v) {
+        if (context.length == 42 && bytes2(context) == "0x") {
+            (address a, bool valid) = HexUtils.hexToAddress(context, 2, 42);
+            if (valid) {
+                // support og version
+                if (coinType == COIN_TYPE_ETH) {
+                    v = abi.encodePacked(a);
+                }
+                return v;
+            }
+        }
         if (ENSIP19.isEVMCoinType(coinType)) {
             v = DNSTXTParserLib.find(
                 context,
@@ -194,7 +204,7 @@ contract DNSTXTResolver is ERC165, IERC7996, IExtendedDNSResolver {
     function _parse0xString(bytes memory s) internal pure returns (bytes memory v) {
         if (s.length > 0) {
             bool valid;
-            if (s.length >= 2 && s[0] == "0" && s[1] == "x") {
+            if (s.length >= 2 && bytes2(s) == "0x") {
                 (v, valid) = HexUtils.hexToBytes(s, 2, s.length);
             }
             if (!valid) {

--- a/contracts/test/integration/l1/dns/DNSTLDResolver.test.ts
+++ b/contracts/test/integration/l1/dns/DNSTLDResolver.test.ts
@@ -367,6 +367,22 @@ describe("DNSTLDResolver", () => {
         ]);
     });
 
+    it("og: just addr(60)", async () => {
+      const F = await network.networkHelpers.loadFixture(fixture);
+      const name = "og.com";
+      await F.mockDNSSEC.write.setResponse([
+        encodeRRs([makeTXT(name, `ENS1 ${dnsnameResolver} ${testAddress}`)]),
+      ]);
+      await F.expectGasless({
+        name,
+        addresses: [
+          { coinType: COIN_TYPE_ETH, value: testAddress },
+          { coinType: COIN_TYPE_DEFAULT, value: "0x" },
+          { coinType: 0n, value: "0x" },
+        ],
+      });
+    });
+
     it("addr()", async () => {
       const F = await network.networkHelpers.loadFixture(fixture);
       await F.mockDNSSEC.write.setResponse([encodedRRs]);


### PR DESCRIPTION
* make `DNSTLDResolver` support `ENS1 dnsname.ens.eth 0x51050ec063d393217B436747617aD1C2285Aeeee`