### PR TITLE
Use `DEPLOYMENT_ROLES` for Migration Controllers

### DIFF
--- a/contracts/deploy/02_UnlockedMigrationController.ts
+++ b/contracts/deploy/02_UnlockedMigrationController.ts
@@ -1,5 +1,5 @@
 import { artifacts, execute } from "@rocketh";
-import { ROLES } from "../script/deploy-constants.js";
+import { DEPLOYMENT_ROLES } from "../script/deploy-constants.js";
 
 export default execute(
   async ({ deploy, execute: write, get, namedAccounts: { deployer } }) => {
@@ -19,7 +19,10 @@ export default execute(
     await write(ethRegistry, {
       account: deployer,
       functionName: "grantRootRoles",
-      args: [ROLES.REGISTRY.REGISTER_RESERVED, migrationController.address],
+      args: [
+        DEPLOYMENT_ROLES.MIGRATION_CONTROLLER_ROOT,
+        migrationController.address,
+      ],
     });
   },
   {

--- a/contracts/deploy/04_LockedMigrationController.ts
+++ b/contracts/deploy/04_LockedMigrationController.ts
@@ -1,5 +1,5 @@
 import { artifacts, execute } from "@rocketh";
-import { ROLES } from "../script/deploy-constants.js";
+import { DEPLOYMENT_ROLES } from "../script/deploy-constants.js";
 
 export default execute(
   async ({ deploy, execute: write, get, namedAccounts: { deployer } }) => {
@@ -31,7 +31,10 @@ export default execute(
     await write(ethRegistry, {
       account: deployer,
       functionName: "grantRootRoles",
-      args: [ROLES.REGISTRY.REGISTER_RESERVED, migrationController.address],
+      args: [
+        DEPLOYMENT_ROLES.MIGRATION_CONTROLLER_ROOT,
+        migrationController.address,
+      ],
     });
   },
   {

--- a/contracts/script/deploy-constants.ts
+++ b/contracts/script/deploy-constants.ts
@@ -56,9 +56,9 @@ export const ROLES = {
   ADMIN,
 } as const;
 
-/** Role bitmaps for static deployment per README Static Deployment Permissions. */
+// Role bitmaps for static deployment per README Static Deployment Permissions.
 export const DEPLOYMENT_ROLES = {
-  /** RootRegistry root: REGISTRAR✓✓, REGISTER_RESERVED✓✓, SET_PARENT✓✓, RENEW✓✓ */
+  // RootRegistry root: REGISTRAR✓✓, REGISTER_RESERVED✓✓, SET_PARENT✓✓, RENEW✓✓
   ROOT_REGISTRY_ROOT:
     ROLES.REGISTRY.REGISTRAR |
     ROLES.ADMIN.REGISTRY.REGISTRAR |
@@ -68,24 +68,25 @@ export const DEPLOYMENT_ROLES = {
     ROLES.ADMIN.REGISTRY.SET_PARENT |
     ROLES.REGISTRY.RENEW |
     ROLES.ADMIN.REGISTRY.RENEW,
-  /** .eth token: SET_SUBREGISTRY AR, SET_RESOLVER AR */
+  // .eth token: SET_SUBREGISTRY AR, SET_RESOLVER AR
   ETH_TOKEN:
     ROLES.REGISTRY.SET_SUBREGISTRY |
     ROLES.ADMIN.REGISTRY.SET_SUBREGISTRY |
     ROLES.REGISTRY.SET_RESOLVER |
     ROLES.ADMIN.REGISTRY.SET_RESOLVER,
-  /**
-   * Full registry role bitmap for ReverseRegistry root, .reverse token, and .addr token.
-   * Granting all roles is harmless; some (e.g. REGISTRAR) are root-only and don't apply to tokens.
-   */
+  // Full registry role bitmap for ReverseRegistry root, .reverse token, and .addr token.
+  // Granting all roles is harmless; some (e.g. REGISTRAR) are root-only and don't apply to tokens.
   REVERSE_AND_ADDR: FLAGS.ALL,
-  /** ETHRegistry root deployer: REGISTRAR✓, REGISTER_RESERVED✓, SET_PARENT✓✓, RENEW✓ */
+  // ETHRegistry root deployer: REGISTRAR✓, REGISTER_RESERVED✓, SET_PARENT✓✓, RENEW✓
   ETH_REGISTRY_ROOT:
     ROLES.ADMIN.REGISTRY.REGISTRAR |
     ROLES.ADMIN.REGISTRY.REGISTER_RESERVED |
     ROLES.REGISTRY.SET_PARENT |
     ROLES.ADMIN.REGISTRY.SET_PARENT |
     ROLES.ADMIN.REGISTRY.RENEW,
+  // UnlockedMigrationController and LockedMigrationController
+  // only need to register() pre-migrated reservations on ETHRegistry (see: "ENSv2 Migration Case Study")
+  MIGRATION_CONTROLLER_ROOT: ROLES.REGISTRY.REGISTER_RESERVED,
 } as const;
 
 // see: IPermissionedRegistry.sol

--- a/contracts/script/runDevnet.ts
+++ b/contracts/script/runDevnet.ts
@@ -45,7 +45,13 @@ process.once("uncaughtException", async (err) => {
 
 console.log();
 console.log("Available Named Accounts:");
-console.table(env.accounts.map((x) => ({ Name: x.name, Address: x.address })));
+console.table(
+  Object.values(env.namedAccounts).map((x) => ({
+    Name: x.name,
+    Address: x.address,
+    Resolver: x.resolver.address,
+  })),
+);
 
 console.table(
   Object.entries(env.rocketh.deployments).map(([name, { address }]) => ({


### PR DESCRIPTION
- added `DEPLOYMENT_ROLES.MIGRATION_CONTROLLER_ROOT`
- included "OwnedResolver" per account in devnet console output