### PR TITLE
Fix `PermissionedRegistry._update()` when `amount = 0`

### DIFF
--- a/contracts/src/erc1155/ERC1155Singleton.sol
+++ b/contracts/src/erc1155/ERC1155Singleton.sol
@@ -255,11 +255,11 @@ abstract contract ERC1155Singleton is
         if (to != address(0)) {
             address operator = _msgSender();
             if (batch) {
+                ERC1155Utils.checkOnERC1155BatchReceived(operator, from, to, ids, values, data);
+            } else {
                 uint256 id = ids.unsafeMemoryAccess(0);
                 uint256 value = values.unsafeMemoryAccess(0);
                 ERC1155Utils.checkOnERC1155Received(operator, from, to, id, value, data);
-            } else {
-                ERC1155Utils.checkOnERC1155BatchReceived(operator, from, to, ids, values, data);
             }
         }
     }

--- a/contracts/src/erc1155/ERC1155Singleton.sol
+++ b/contracts/src/erc1155/ERC1155Singleton.sol
@@ -239,6 +239,7 @@ abstract contract ERC1155Singleton is
     /// @param ids Token IDs to update.
     /// @param values Amounts for each token ID.
     /// @param data Additional calldata passed to receiver hooks.
+    /// @param batch `true` if a batch operation.
     /// @dev Calls `_update` before external receiver callbacks.
     /// @dev If `to` is a contract, this calls `onERC1155Received` or `onERC1155BatchReceived`.
     /// @dev Overriding is discouraged because post-callback state writes can introduce reentrancy bugs.
@@ -247,12 +248,13 @@ abstract contract ERC1155Singleton is
         address to,
         uint256[] memory ids,
         uint256[] memory values,
-        bytes memory data
+        bytes memory data,
+        bool batch
     ) internal virtual {
         _update(from, to, ids, values);
         if (to != address(0)) {
             address operator = _msgSender();
-            if (ids.length == 1) {
+            if (batch) {
                 uint256 id = ids.unsafeMemoryAccess(0);
                 uint256 value = values.unsafeMemoryAccess(0);
                 ERC1155Utils.checkOnERC1155Received(operator, from, to, id, value, data);
@@ -286,7 +288,7 @@ abstract contract ERC1155Singleton is
             revert ERC1155InvalidSender(address(0));
         }
         (uint256[] memory ids, uint256[] memory values) = _asSingletonArrays(id, value);
-        _updateWithAcceptanceCheck(from, to, ids, values, data);
+        _updateWithAcceptanceCheck(from, to, ids, values, data, false);
     }
 
     /// @notice Safely transfer multiple token IDs from `from` to `to`.
@@ -313,7 +315,7 @@ abstract contract ERC1155Singleton is
         if (from == address(0)) {
             revert ERC1155InvalidSender(address(0));
         }
-        _updateWithAcceptanceCheck(from, to, ids, values, data);
+        _updateWithAcceptanceCheck(from, to, ids, values, data, true);
     }
 
     /// @notice Mint `value` tokens of token ID `id` to `to`.
@@ -329,7 +331,7 @@ abstract contract ERC1155Singleton is
             revert ERC1155InvalidReceiver(address(0));
         }
         (uint256[] memory ids, uint256[] memory values) = _asSingletonArrays(id, value);
-        _updateWithAcceptanceCheck(address(0), to, ids, values, data);
+        _updateWithAcceptanceCheck(address(0), to, ids, values, data, false);
     }
 
     /// @notice Mint multiple token IDs to `to`.
@@ -350,7 +352,7 @@ abstract contract ERC1155Singleton is
         if (to == address(0)) {
             revert ERC1155InvalidReceiver(address(0));
         }
-        _updateWithAcceptanceCheck(address(0), to, ids, values, data);
+        _updateWithAcceptanceCheck(address(0), to, ids, values, data, true);
     }
 
     /// @notice Burn `value` tokens of token ID `id` from `from`.
@@ -365,7 +367,7 @@ abstract contract ERC1155Singleton is
             revert ERC1155InvalidSender(address(0));
         }
         (uint256[] memory ids, uint256[] memory values) = _asSingletonArrays(id, value);
-        _updateWithAcceptanceCheck(from, address(0), ids, values, "");
+        _updateWithAcceptanceCheck(from, address(0), ids, values, "", false);
     }
 
     /// @notice Burn multiple token IDs from `from`.
@@ -380,7 +382,7 @@ abstract contract ERC1155Singleton is
         if (from == address(0)) {
             revert ERC1155InvalidSender(address(0));
         }
-        _updateWithAcceptanceCheck(from, address(0), ids, values, "");
+        _updateWithAcceptanceCheck(from, address(0), ids, values, "", true);
     }
 
     /// @notice Set or clear approval for `operator` to manage all tokens owned by `owner`.

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -400,28 +400,28 @@ contract PermissionedRegistry is
     // Internal Functions
     ////////////////////////////////////////////////////////////////////////
 
-    /// @dev Override the base registry _update function to transfer the roles to the new owner when the token is transferred.
+    /// @dev Override `ERC1155Singleton._update()` to transfer the roles to the new owner if the token is transferred.
     function _update(
         address from,
         address to,
         uint256[] memory tokenIds,
-        uint256[] memory values
+        uint256[] memory amounts
     ) internal virtual override {
-        // note: from is token owner
-        bool externalTransfer = to != address(0) && from != address(0);
+        bool externalTransfer = to != address(0) && from != address(0); // skip mint and burn
         if (externalTransfer) {
-            // Check ROLE_CAN_TRANSFER for actual transfers only
-            // Skip check for mints (from == address(0)) and burns (to == address(0))
+            // only check ROLE_CAN_TRANSFER_ADMIN on token owner (from)
             for (uint256 i; i < tokenIds.length; ++i) {
                 if (!hasRoles(tokenIds[i], RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, from)) {
                     revert TransferDisallowed(tokenIds[i], from);
                 }
             }
         }
-        super._update(from, to, tokenIds, values);
+        super._update(from, to, tokenIds, amounts); // ensures amounts[i] is 0 or 1
         if (externalTransfer) {
             for (uint256 i; i < tokenIds.length; ++i) {
-                _transferRoles(getResource(tokenIds[i]), from, to, false);
+                if (amounts[i] > 0) {
+                    _transferRoles(getResource(tokenIds[i]), from, to, false);
+                }
             }
         }
     }

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -594,8 +594,9 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
     function test_safeTransferFrom() external {
         testRoles = RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
         uint256 tokenId = this._register();
+        StrictERC1155Holder r = new StrictERC1155Holder(false);
         vm.prank(user1);
-        registry.safeTransferFrom(user1, user2, tokenId, 1, "");
+        registry.safeTransferFrom(user1, address(r), tokenId, 1, "");
     }
 
     function test_safeTransferFrom_noop() external {
@@ -676,8 +677,9 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         uint256[] memory amounts = new uint256[](2);
         amounts[0] = 1;
         amounts[1] = 1;
+        StrictERC1155Holder r = new StrictERC1155Holder(true);
         vm.prank(user1);
-        registry.safeBatchTransferFrom(user1, user2, tokenIds, amounts, "");
+        registry.safeBatchTransferFrom(user1, address(r), tokenIds, amounts, "");
     }
 
     function test_safeBatchTransferFrom_oneError() external {
@@ -1269,5 +1271,32 @@ contract MockPermissionedRegistry is PermissionedRegistry {
     ) PermissionedRegistry(hcaFactory, metadata, ownerAddress, ownerRoles) {}
     function getEntry(uint256 anyId) external view returns (PermissionedRegistry.Entry memory) {
         return _entry(anyId);
+    }
+}
+
+contract StrictERC1155Holder is ERC1155Holder {
+    bool immutable BATCH;
+    constructor(bool batch) {
+        BATCH = batch;
+    }
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 value,
+        bytes memory data
+    ) public override returns (bytes4) {
+        require(!BATCH);
+        return super.onERC1155Received(operator, from, id, value, data);
+    }
+    function onERC1155BatchReceived(
+        address operator,
+        address from,
+        uint256[] memory ids,
+        uint256[] memory values,
+        bytes memory data
+    ) public override returns (bytes4) {
+        require(BATCH);
+        return super.onERC1155BatchReceived(operator, from, ids, values, data);
     }
 }

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -598,6 +598,32 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         registry.safeTransferFrom(user1, user2, tokenId, 1, "");
     }
 
+    function test_safeTransferFrom_noop() external {
+        testRoles = RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
+        uint256 tokenId = this._register();
+        vm.recordLogs();
+        vm.prank(user1);
+        registry.safeTransferFrom(user1, user2, tokenId, 0, "");
+        _expectNoEmit(vm.getRecordedLogs(), IEnhancedAccessControl.EACRolesChanged.selector);
+    }
+
+    function test_safeTransferFrom_multiple(uint256 amount) external {
+        vm.assume(amount >= 2);
+        testRoles = RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
+        uint256 tokenId = this._register();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC1155Errors.ERC1155InsufficientBalance.selector,
+                user1,
+                1,
+                amount,
+                tokenId
+            )
+        );
+        vm.prank(user1);
+        registry.safeTransferFrom(user1, user2, tokenId, amount, "");
+    }
+
     function test_safeTransferFrom_notAuthorized() external {
         uint256 tokenId = this._register();
         vm.expectRevert(


### PR DESCRIPTION
Bug 1: `ERC1155Singleton` allows transfer of `amount = 0` but `PermissionedRegistry` roles are <ins>always</ins> transferred &mdash; h/t yoginth.eth
```solidity
// this test passes on main
function test_safeTransferFrom_noop() external {
    testRoles = RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
    uint256 tokenId = this._register();
    vm.expectEmit();
    emit IEnhancedAccessControl.EACRolesChanged(tokenId, user1, testRoles, 0);
    vm.prank(user1);
    registry.safeTransferFrom(user1, user2, tokenId, 0, "");
}
```
```diff
- super._update(from, to, tokenIds, values);
+ super._update(from, to, tokenIds, amounts); // ensures amounts[i] is 0 or 1
  if (externalTransfer) {
      for (uint256 i; i < tokenIds.length; ++i) {
+         if (amounts[i] > 0) {
              _transferRoles(getResource(tokenIds[i]), from, to, false);
+         }
      }
  }

```

Bug 2: `ERC1155Singleton` routes batch of `length = 1` to non-batch receiver ([more info](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/6170))

```diff
- if (ids.length == 1) {
+ if (batch) {
```

---

- changed `PermissionedRegistry`
     - added `amount[i] > 0` check to `_update()`
     - added `test_safeTransferFrom_noop`
     - added `test_safeTransferFrom_multiple`
- changed `ERC1155Singleton`
     - added `bool batch` to `_updateWithAcceptanceCheck()` to track operation type
     - updated `test_safeTransferFrom` to use `StrictERC1155Holder`
     - updated `test_safeBatchTransferFrom` to use `StrictERC1155Holder`
 