### PR TITLE
Add `ITokenizedRegistry`, `ITemporalRegistry`, and `IOwnedRegistry`

### DIFF
--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -12,6 +12,7 @@ import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
 import {ILabelStore} from "../utils/interfaces/ILabelStore.sol";
 import {LibLabel} from "../utils/LibLabel.sol";
 
+import {IOwnedRegistry} from "./interfaces/IOwnedRegistry.sol";
 import {IPermissionedRegistry} from "./interfaces/IPermissionedRegistry.sol";
 import {IRegistry} from "./interfaces/IRegistry.sol";
 import {IRegistryMetadata} from "./interfaces/IRegistryMetadata.sol";
@@ -150,6 +151,12 @@ contract PermissionedRegistry is
     /// @inheritdoc ITemporalRegistry
     function findExpiry(string calldata label) external view returns (uint64) {
         return getExpiry(LibLabel.id(label));
+    }
+
+    /// @inheritdoc IOwnedRegistry
+    function findOwner(string calldata label) external view returns (address) {
+        uint256 labelId = LibLabel.id(label);
+        return ownerOf(_constructTokenId(labelId, _entry(labelId)));
     }
 
     /// @inheritdoc ITokenizedRegistry

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -16,6 +16,8 @@ import {IPermissionedRegistry} from "./interfaces/IPermissionedRegistry.sol";
 import {IRegistry} from "./interfaces/IRegistry.sol";
 import {IRegistryMetadata} from "./interfaces/IRegistryMetadata.sol";
 import {IStandardRegistry} from "./interfaces/IStandardRegistry.sol";
+import {ITemporalRegistry} from "./interfaces/ITemporalRegistry.sol";
+import {ITokenizedRegistry} from "./interfaces/ITokenizedRegistry.sol";
 import {RegistryRolesLib} from "./libraries/RegistryRolesLib.sol";
 import {MetadataMixin} from "./MetadataMixin.sol";
 
@@ -134,6 +136,8 @@ contract PermissionedRegistry is
     {
         return
             interfaceId == type(IPermissionedRegistry).interfaceId ||
+            interfaceId == type(ITokenizedRegistry).interfaceId ||
+            interfaceId == type(ITemporalRegistry).interfaceId ||
             interfaceId == type(IStandardRegistry).interfaceId ||
             interfaceId == type(IRegistry).interfaceId ||
             super.supportsInterface(interfaceId);
@@ -142,6 +146,17 @@ contract PermissionedRegistry is
     ////////////////////////////////////////////////////////////////////////
     // Implementation
     ////////////////////////////////////////////////////////////////////////
+
+    /// @inheritdoc ITemporalRegistry
+    function findExpiry(string calldata label) external view returns (uint64) {
+        return getExpiry(LibLabel.id(label));
+    }
+
+    /// @inheritdoc ITokenizedRegistry
+    function findTokenId(string calldata label) external view returns (uint256 tokenId) {
+        tokenId = LibLabel.id(label);
+        tokenId = _constructTokenId(tokenId, _entry(tokenId));
+    }
 
     /// @inheritdoc IStandardRegistry
     function setSubregistry(uint256 anyId, IRegistry registry) public virtual {

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -137,9 +137,10 @@ contract PermissionedRegistry is
     {
         return
             interfaceId == type(IPermissionedRegistry).interfaceId ||
+            interfaceId == type(IStandardRegistry).interfaceId ||
             interfaceId == type(ITokenizedRegistry).interfaceId ||
             interfaceId == type(ITemporalRegistry).interfaceId ||
-            interfaceId == type(IStandardRegistry).interfaceId ||
+            interfaceId == type(IOwnedRegistry).interfaceId ||
             interfaceId == type(IRegistry).interfaceId ||
             super.supportsInterface(interfaceId);
     }

--- a/contracts/src/registry/interfaces/IOwnedRegistry.sol
+++ b/contracts/src/registry/interfaces/IOwnedRegistry.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import {IRegistry} from "./IRegistry.sol";
+
+/// @notice A registry with owners.
+/// @dev Interface selector: `0x63560a8e`
+interface IOwnedRegistry is IRegistry {
+    /// @notice Fetches the label owner.
+    /// @param label The label to query.
+    /// @return The owner of the label.
+    function findOwner(string calldata label) external view returns (address);
+}

--- a/contracts/src/registry/interfaces/IStandardRegistry.sol
+++ b/contracts/src/registry/interfaces/IStandardRegistry.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-import {IERC1155Singleton} from "../../erc1155/interfaces/IERC1155Singleton.sol";
-
 import {IRegistry} from "./IRegistry.sol";
+import {ITemporalRegistry} from "./ITemporalRegistry.sol";
+import {ITokenizedRegistry} from "./ITokenizedRegistry.sol";
 
 /// @title IStandardRegistry
-/// @notice A tokenized registry.
+/// @notice A tokenized registry with registrations that expire.
 /// @dev Interface selector: `0xb844ab6c`
-interface IStandardRegistry is IRegistry, IERC1155Singleton {
+interface IStandardRegistry is ITemporalRegistry, ITokenizedRegistry {
     ////////////////////////////////////////////////////////////////////////
     // Errors
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/src/registry/interfaces/ITemporalRegistry.sol
+++ b/contracts/src/registry/interfaces/ITemporalRegistry.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import {IRegistry} from "./IRegistry.sol";
+
+/// @notice A registry with expirations.
+/// @dev Interface selector: `0x6f537c72`
+interface ITemporalRegistry is IRegistry {
+    /// @notice Fetches the label expiry.
+    /// @param label The label to query.
+    /// @return The expiry of the label.
+    function findExpiry(string calldata label) external view returns (uint64);
+}

--- a/contracts/src/registry/interfaces/ITokenizedRegistry.sol
+++ b/contracts/src/registry/interfaces/ITokenizedRegistry.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import {IERC1155Singleton} from "../../erc1155/interfaces/IERC1155Singleton.sol";
+
+import {IRegistry} from "./IRegistry.sol";
+
+/// @notice A tokenized registry.
+/// @dev Interface selector: `0x91b3c037`
+interface ITokenizedRegistry is IRegistry, IERC1155Singleton {
+    /// @notice Fetches the token ID for a label.
+    /// @param label The label to query.
+    /// @return The token ID of the label.
+    function findTokenId(string calldata label) external view returns (uint256);
+}

--- a/contracts/src/registry/interfaces/ITokenizedRegistry.sol
+++ b/contracts/src/registry/interfaces/ITokenizedRegistry.sol
@@ -3,11 +3,11 @@ pragma solidity >=0.8.13;
 
 import {IERC1155Singleton} from "../../erc1155/interfaces/IERC1155Singleton.sol";
 
-import {IRegistry} from "./IRegistry.sol";
+import {IOwnedRegistry} from "./IOwnedRegistry.sol";
 
 /// @notice A tokenized registry.
 /// @dev Interface selector: `0x91b3c037`
-interface ITokenizedRegistry is IRegistry, IERC1155Singleton {
+interface ITokenizedRegistry is IOwnedRegistry, IERC1155Singleton {
     /// @notice Fetches the token ID for a label.
     /// @param label The label to query.
     /// @return The token ID of the label.

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -16,6 +16,8 @@ import {
     IPermissionedRegistry,
     IEnhancedAccessControl,
     IRegistry,
+    ITokenizedRegistry,
+    ITemporalRegistry,
     IStandardRegistry,
     IRegistryMetadata,
     IHCAFactoryBasic,
@@ -81,6 +83,14 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         assertTrue(
             registry.supportsInterface(type(IStandardRegistry).interfaceId),
             "IStandardRegistry"
+        );
+        assertTrue(
+            registry.supportsInterface(type(ITokenizedRegistry).interfaceId),
+            "ITokenizedRegistry"
+        );
+        assertTrue(
+            registry.supportsInterface(type(ITemporalRegistry).interfaceId),
+            "ITemporalRegistry"
         );
         assertTrue(
             registry.supportsInterface(type(IPermissionedRegistry).interfaceId),
@@ -1008,6 +1018,30 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         vm.warp(testExpiry);
         (counts, ) = registry.getAssigneeCount(anyId, testRoles);
         assertEq(counts, 0);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Low-level Interfaces
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_findExpiry() external {
+        assertEq(registry.findExpiry(testLabel), 0);
+        uint256 tokenId = this._register();
+        assertEq(registry.findExpiry(testLabel), testExpiry);
+        registry.unregister(tokenId);
+        assertEq(registry.findExpiry(testLabel), block.timestamp, "burn");
+        this._register();
+        assertEq(registry.findExpiry(testLabel), testExpiry, "again");
+    }
+
+    function test_findTokenId() external {
+        assertEq(registry.findTokenId(testLabel), LibLabel.withVersion(LibLabel.id(testLabel), 0));
+        uint256 tokenId = this._register();
+        assertEq(registry.findTokenId(testLabel), tokenId);
+        registry.unregister(tokenId);
+        assertEq(registry.findTokenId(testLabel), tokenId + 1, "burn");
+        tokenId = this._register();
+        assertEq(registry.findTokenId(testLabel), tokenId, "again");
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -10,26 +10,24 @@ import {IERC1155Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
 
+import {LibLabel} from "~src/utils/LibLabel.sol";
+import {IEnhancedAccessControl} from "~src/access-control/interfaces/IEnhancedAccessControl.sol";
 import {EACBaseRolesLib} from "~src/access-control/libraries/EACBaseRolesLib.sol";
-import {
-    PermissionedRegistry,
-    IPermissionedRegistry,
-    IEnhancedAccessControl,
-    IRegistry,
-    ITokenizedRegistry,
-    ITemporalRegistry,
-    IStandardRegistry,
-    IRegistryMetadata,
-    IHCAFactoryBasic,
-    RegistryRolesLib,
-    LibLabel
-} from "~src/registry/PermissionedRegistry.sol";
+import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
 import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
+import {IOwnedRegistry} from "~src/registry/interfaces/IOwnedRegistry.sol";
+import {IStandardRegistry} from "~src/registry/interfaces/IStandardRegistry.sol";
+import {ITemporalRegistry} from "~src/registry/interfaces/ITemporalRegistry.sol";
+import {ITokenizedRegistry} from "~src/registry/interfaces/ITokenizedRegistry.sol";
+import {IRegistryMetadata} from "~src/registry/interfaces/IRegistryMetadata.sol";
+import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
+import {IHCAFactoryBasic} from "~src/hca/interfaces/IHCAFactoryBasic.sol";
+import {PermissionedRegistry, IPermissionedRegistry} from "~src/registry/PermissionedRegistry.sol";
 import {SimpleRegistryMetadata} from "~src/registry/SimpleRegistryMetadata.sol";
 import {LabelStore, ILabelStore} from "~src/utils/LabelStore.sol";
 import {MockHCAFactoryBasic} from "~test/mocks/MockHCAFactoryBasic.sol";
 
-uint256 constant ROOT_ROLES = EACBaseRolesLib.ALL_ROLES;
+uint256 constant DEFAULT_ROLE_BITMAP = EACBaseRolesLib.ALL_ROLES;
 
 contract PermissionedRegistryTest is Test, ERC1155Holder {
     MockPermissionedRegistry registry;
@@ -48,7 +46,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
     uint64 testExpiry = uint64(block.timestamp + 1000);
     IRegistry testRegistry = IRegistry(makeAddr("registry"));
 
-    function setUp() public {
+    function setUp() external {
         hcaFactory = new MockHCAFactoryBasic();
         metadata = new SimpleRegistryMetadata(hcaFactory);
         labelStore = new LabelStore();
@@ -60,7 +58,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
             metadata,
             labelStore,
             address(this),
-            ROOT_ROLES
+            DEFAULT_ROLE_BITMAP
         );
     }
 
@@ -75,7 +73,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         assertEq(address(registry.METADATA_PROVIDER()), address(metadata), "METADATA_PROVIDER");
         assertEq(address(registry.LABEL_STORE()), address(labelStore), "LABEL_STORE");
 
-        assertTrue(registry.hasRootRoles(ROOT_ROLES, address(this)));
+        assertTrue(registry.hasRootRoles(DEFAULT_ROLE_BITMAP, address(this)));
     }
 
     function test_supportsInterface() external view {
@@ -84,6 +82,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
             registry.supportsInterface(type(IStandardRegistry).interfaceId),
             "IStandardRegistry"
         );
+        assertTrue(registry.supportsInterface(type(IOwnedRegistry).interfaceId), "IOwnedRegistry");
         assertTrue(
             registry.supportsInterface(type(ITokenizedRegistry).interfaceId),
             "ITokenizedRegistry"
@@ -235,11 +234,11 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
 
     function test_reserve_canSetPastExpiry() external {
         vm.warp(2);
-        testExpiry = uint64(block.timestamp) - 1;
+        testExpiry = 1;
         this._reserve();
     }
 
-    function test_reserve_cannotSetPastExpiry() external {
+    function test_reserve_cannotSetPastExpiryAtGenesis() external {
         testExpiry = 0; // genesis
         vm.expectRevert(
             abi.encodeWithSelector(IStandardRegistry.CannotSetPastExpiry.selector, testExpiry)

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -1043,6 +1043,16 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         assertEq(registry.findTokenId(testLabel), tokenId, "again");
     }
 
+    function test_findOwner() external {
+        assertEq(registry.findOwner(testLabel), address(0));
+        uint256 tokenId = this._register();
+        assertEq(registry.findOwner(testLabel), testOwner);
+        registry.unregister(tokenId);
+        assertEq(registry.findOwner(testLabel), address(0), "burn");
+        tokenId = this._register();
+        assertEq(registry.findOwner(testLabel), testOwner, "again");
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // Token Regeneration
     ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- added `ITokenizedRegistry` &mdash; `findTokenId(label): token`
- added `ITemporalRegistry` &mdash; `findExpiry(label): expiry`
- added `IOwnedRegistry` &mdash; `findOwner(label): owner`
- changed `IStandardRegistry` to inherit them
     * by construction: 
         - `findExpiry(label) == getExpiry(findTokenId(label))`
         - `findOwner(label) == ownerOf(findTokenId(label))`
---
```mermaid
graph TD
    ERC1155Singleton --> ITokenizedRegistry
    IRegistry --> ITemporalRegistry
    IRegistry --> IOwnedRegistry
    IOwnedRegistry --> ITokenizedRegistry
    ITokenizedRegistry --> IStandardRegistry
    ITemporalRegistry --> IStandardRegistry
    IStandardRegistry --> IPermissionedRegistry
```