### PR TITLE
Add `PublicResolverV2`

### DIFF
--- a/contracts/deploy/01_PublicResolverSet.ts
+++ b/contracts/deploy/01_PublicResolverSet.ts
@@ -1,0 +1,27 @@
+import { artifacts, execute } from "@rocketh";
+
+export default execute(
+  async ({ deploy, execute: write, get, namedAccounts: { deployer } }) => {
+    const hcaFactory =
+      get<(typeof artifacts.MockHCAFactoryBasic)["abi"]>("HCAFactory");
+
+    const publicResolverSet = await deploy("PublicResolverSet", {
+      account: deployer,
+      artifact: artifacts.PermissionedAddresses,
+      args: [hcaFactory.address, deployer], // TODO: ownership
+    });
+
+    const publicResolverV1 =
+      get<(typeof artifacts.PublicResolver)["abi"]>("PublicResolver");
+
+    await write(publicResolverSet, {
+      account: deployer,
+      functionName: "approve",
+      args: [publicResolverV1.address, true],
+    });
+  },
+  {
+    tags: ["PublicResolverSet", "v2"],
+    dependencies: ["HCAFactory", "PublicResolver"],
+  },
+);

--- a/contracts/deploy/01_PublicResolverSet.ts
+++ b/contracts/deploy/01_PublicResolverSet.ts
@@ -1,4 +1,5 @@
 import { artifacts, execute } from "@rocketh";
+import type { Address } from "viem";
 
 export default execute(
   async ({ deploy, execute: write, get, namedAccounts: { deployer } }) => {
@@ -7,18 +8,31 @@ export default execute(
 
     const publicResolverSet = await deploy("PublicResolverSet", {
       account: deployer,
-      artifact: artifacts.PermissionedAddresses,
+      artifact: artifacts.PermissionedAddressSet,
       args: [hcaFactory.address, deployer], // TODO: ownership
     });
 
     const publicResolverV1 =
       get<(typeof artifacts.PublicResolver)["abi"]>("PublicResolver");
 
-    await write(publicResolverSet, {
-      account: deployer,
-      functionName: "approve",
-      args: [publicResolverV1.address, true],
-    });
+    // TODO: update these addresses
+    const wrapperAwarePublicResolvers: Address[] = [
+      // devnet
+      publicResolverV1.address,
+      // mainnet
+      // "0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63", // PublicResolverV3: https://etherscan.io/address/0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63
+      // "0xF29100983E058B709F3D539b0c765937B804AC15", // PublicResolverV4: https://etherscan.io/address/0xF29100983E058B709F3D539b0c765937B804AC15
+    ];
+    for (const addr of wrapperAwarePublicResolvers) {
+      await write(publicResolverSet, {
+        account: deployer,
+        functionName: "approve",
+        args: [addr, true],
+      });
+    }
+
+    console.log("Wrapper-aware PublicResolvers:");
+    console.table(wrapperAwarePublicResolvers);
   },
   {
     tags: ["PublicResolverSet", "v2"],

--- a/contracts/deploy/01_PublicResolverV2.ts
+++ b/contracts/deploy/01_PublicResolverV2.ts
@@ -1,0 +1,24 @@
+import { artifacts, execute } from "@rocketh";
+
+export default execute(
+  async ({ deploy, get, namedAccounts: { deployer } }) => {
+    const nameWrapper =
+      get<(typeof artifacts.NameWrapper)["abi"]>("NameWrapper");
+
+    const hcaFactory =
+      get<(typeof artifacts.MockHCAFactoryBasic)["abi"]>("HCAFactory");
+
+    const rootRegistry =
+      get<(typeof artifacts.PermissionedRegistry)["abi"]>("RootRegistry");
+
+    await deploy("PublicResolverV2", {
+      account: deployer,
+      artifact: artifacts.PublicResolverV2,
+      args: [hcaFactory.address, nameWrapper.address, rootRegistry.address],
+    });
+  },
+  {
+    tags: ["PublicResolverV2", "v2"],
+    dependencies: ["NameWrapper", "HCAFactory", "RootRegistry"],
+  },
+);

--- a/contracts/deploy/03_WrapperRegistryImpl.ts
+++ b/contracts/deploy/03_WrapperRegistryImpl.ts
@@ -26,6 +26,12 @@ export default execute(
       (typeof artifacts.ApprovedUpgradeGate)["abi"]
     >("ApprovedUpgradeGate");
 
+    const publicResolverSet =
+      get<(typeof artifacts.IAddressSet)["abi"]>("PublicResolverSet");
+
+    const publicResolverV2 =
+      get<(typeof artifacts.PublicResolverV2)["abi"]>("PublicResolverV2");
+
     await deploy("WrapperRegistryImpl", {
       account: deployer,
       artifact: artifacts.WrapperRegistry,
@@ -38,6 +44,8 @@ export default execute(
         registryMetadata.address,
         approvedUpgradeGate.address,
         labelStore.address,
+        publicResolverSet.address,
+        publicResolverV2.address,
       ],
     });
   },
@@ -52,6 +60,8 @@ export default execute(
       "RegistryMetadata",
       "ApprovedUpgradeGate",
       "LabelStore",
+      "PublicResolverSet",
+      "PublicResolverV2",
     ],
   },
 );

--- a/contracts/deploy/04_LockedMigrationController.ts
+++ b/contracts/deploy/04_LockedMigrationController.ts
@@ -18,6 +18,12 @@ export default execute(
       "WrapperRegistryImpl",
     );
 
+    const publicResolverSet =
+      get<(typeof artifacts.IAddressSet)["abi"]>("PublicResolverSet");
+
+    const publicResolverV2 =
+      get<(typeof artifacts.PublicResolverV2)["abi"]>("PublicResolverV2");
+
     const migrationController = await deploy("LockedMigrationController", {
       account: deployer,
       artifact: artifacts.LockedMigrationController,
@@ -27,6 +33,8 @@ export default execute(
         ethRegistry.address,
         verifiableFactory.address,
         wrapperRegistryImpl.address,
+        publicResolverSet.address,
+        publicResolverV2.address,
       ],
     });
 
@@ -48,6 +56,8 @@ export default execute(
       "ETHRegistry",
       "VerifiableFactory",
       "WrapperRegistryImpl",
+      "PublicResolverSet",
+      "PublicResolverV2",
     ],
   },
 );

--- a/contracts/script/setup.ts
+++ b/contracts/script/setup.ts
@@ -389,6 +389,11 @@ export async function setupDevnet({
         address: rocketh.get("Graveyard").address,
         client,
       }),
+      PublicResolverSet: getContract({
+        abi: artifacts.PermissionedAddresses.abi,
+        address: rocketh.get("PublicResolverSet").address,
+        client,
+      }),
       // resolvers
       UniversalResolver: getContract({
         abi: artifacts.UniversalResolverV2.abi,
@@ -418,6 +423,11 @@ export async function setupDevnet({
       ENSV2Resolver: getContract({
         abi: artifacts.ENSV2Resolver.abi,
         address: rocketh.get("ENSV2Resolver").address,
+        client,
+      }),
+      PublicResolver: getContract({
+        abi: artifacts.PublicResolverV2.abi,
+        address: rocketh.get("PublicResolverV2").address,
         client,
       }),
     };
@@ -546,7 +556,10 @@ export async function setupDevnet({
     async function sync({
       blocks = 1,
       warpSec = "local",
-    }: { blocks?: number; warpSec?: number | "local" } = {}) {
+    }: {
+      blocks?: number;
+      warpSec?: number | "local";
+    } = {}) {
       const block = await client.getBlock();
       let timestamp = Number(block.timestamp);
       if (warpSec === "local") {

--- a/contracts/script/setup.ts
+++ b/contracts/script/setup.ts
@@ -390,7 +390,7 @@ export async function setupDevnet({
         client,
       }),
       PublicResolverSet: getContract({
-        abi: artifacts.PermissionedAddresses.abi,
+        abi: artifacts.PermissionedAddressSet.abi,
         address: rocketh.get("PublicResolverSet").address,
         client,
       }),

--- a/contracts/src/migration/LockedMigrationController.sol
+++ b/contracts/src/migration/LockedMigrationController.sol
@@ -33,7 +33,7 @@ contract LockedMigrationController is LockedWrapperReceiver {
     /// @param ethRegistry The ENSv2 .eth `PermissionedRegistry` where migrated names are registered.
     /// @param verifiableFactory The shared factory for verifiable deployments.
     /// @param wrapperRegistryImpl The `WrapperRegistry` implementation contract.
-    /// @param publicResolverSet The approved list of `PublicResolver` contracts.
+    /// @param publicResolverSet The list of `PublicResolver` contracts that require replacement.
     /// @param publicResolver The replacement `PublicResolver`.
     constructor(
         INameWrapper nameWrapper,

--- a/contracts/src/migration/LockedMigrationController.sol
+++ b/contracts/src/migration/LockedMigrationController.sol
@@ -46,6 +46,7 @@ contract LockedMigrationController is LockedWrapperReceiver {
     )
         LockedWrapperReceiver(
             nameWrapper,
+            graveyard,
             verifiableFactory,
             wrapperRegistryImpl,
             publicResolverSet,

--- a/contracts/src/migration/LockedMigrationController.sol
+++ b/contracts/src/migration/LockedMigrationController.sol
@@ -7,6 +7,7 @@ import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactor
 
 import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
 import {IRegistry} from "../registry/interfaces/IRegistry.sol";
+import {IAddressSet} from "../utils/interfaces/IAddressSet.sol";
 
 import {LockedWrapperReceiver} from "./LockedWrapperReceiver.sol";
 
@@ -32,14 +33,24 @@ contract LockedMigrationController is LockedWrapperReceiver {
     /// @param ethRegistry The ENSv2 .eth `PermissionedRegistry` where migrated names are registered.
     /// @param verifiableFactory The shared factory for verifiable deployments.
     /// @param wrapperRegistryImpl The `WrapperRegistry` implementation contract.
+    /// @param publicResolverSet The approved list of `PublicResolver` contracts.
+    /// @param publicResolver The replacement `PublicResolver`.
     constructor(
         INameWrapper nameWrapper,
         address graveyard,
         IPermissionedRegistry ethRegistry,
         VerifiableFactory verifiableFactory,
-        address wrapperRegistryImpl
+        address wrapperRegistryImpl,
+        IAddressSet publicResolverSet,
+        address publicResolver
     )
-        LockedWrapperReceiver(nameWrapper, graveyard, verifiableFactory, wrapperRegistryImpl)
+        LockedWrapperReceiver(
+            nameWrapper,
+            verifiableFactory,
+            wrapperRegistryImpl,
+            publicResolverSet,
+            publicResolver
+        )
     {
         ETH_REGISTRY = ethRegistry;
     }

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -17,6 +17,7 @@ import {REGISTRATION_ROLE_BITMAP} from "../registrar/ETHRegistrar.sol";
 import {IRegistry} from "../registry/interfaces/IRegistry.sol";
 import {IWrapperRegistry} from "../registry/interfaces/IWrapperRegistry.sol";
 import {RegistryRolesLib} from "../registry/libraries/RegistryRolesLib.sol";
+import {IAddressSet} from "../utils/interfaces/IAddressSet.sol";
 
 import {AbstractWrapperReceiver} from "./AbstractWrapperReceiver.sol";
 import {LibMigration} from "./libraries/LibMigration.sol";
@@ -51,6 +52,12 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
     /// @notice The `WrapperRegistry` implementation contract.
     address public immutable WRAPPER_REGISTRY_IMPL;
 
+    /// @notice The approved list of `PublicResolver` contracts.
+    IAddressSet public immutable PUBLIC_RESOLVER_SET;
+
+    /// @notice The replacement `PublicResolver`.
+    address public immutable PUBLIC_RESOLVER;
+
     ////////////////////////////////////////////////////////////////////////
     // Initialization
     ////////////////////////////////////////////////////////////////////////
@@ -59,16 +66,20 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
     /// @param graveyard The ENSv1 `BaseRegistrar` token graveyard.
     /// @param verifiableFactory The shared factory for verifiable deployments.
     /// @param wrapperRegistryImpl The `WrapperRegistry` implementation contract.
+    /// @param publicResolverSet The approved list of `PublicResolver` contracts.
+    /// @param publicResolver The replacement `PublicResolver`.
     constructor(
         INameWrapper nameWrapper,
         address graveyard,
-        IVerifiableFactory verifiableFactory,
-        address wrapperRegistryImpl
-    )
-        AbstractWrapperReceiver(nameWrapper, graveyard)
-    {
+        VerifiableFactory verifiableFactory,
+        address wrapperRegistryImpl,
+        IAddressSet publicResolverSet,
+        address publicResolver
+    ) AbstractWrapperReceiver(nameWrapper, graveyard) {
         VERIFIABLE_FACTORY = verifiableFactory;
         WRAPPER_REGISTRY_IMPL = wrapperRegistryImpl;
+        PUBLIC_RESOLVER_SET = publicResolverSet;
+        PUBLIC_RESOLVER = publicResolver;
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -174,6 +185,54 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
             } else {
                 revert LibMigration.NameNotLocked(uint256(node));
             }
+<<<<<<< HEAD
+=======
+
+            if (NAME_WRAPPER.getApproved(uint256(node)) != address(0)) {
+                revert LibMigration.FrozenTokenApproval(uint256(node));
+            }
+
+            address resolver = md.resolver;
+            if ((fuses & CANNOT_SET_RESOLVER) == 0) {
+                NAME_WRAPPER.setResolver(node, address(0)); // clear ENSv1 resolver
+            } else {
+                resolver = _REGISTRY_V1.resolver(node); // replace with ENSv1 resolver
+                if (PUBLIC_RESOLVER_SET.includes(resolver)) {
+                    resolver = PUBLIC_RESOLVER; // replace with new PublicResolver
+                }
+            }
+
+            // create subregistry
+            IRegistry subregistry = IRegistry(
+                VERIFIABLE_FACTORY.deployProxy(
+                    WRAPPER_REGISTRY_IMPL,
+                    uint256(node),
+                    abi.encodeCall(
+                        IWrapperRegistry.initialize,
+                        (
+                            node,
+                            parentRegistry,
+                            md.label,
+                            md.owner,
+                            _subregistryRoleBitmapFromFuses(fuses)
+                        )
+                    )
+                )
+            );
+
+            // add name to ENSv2
+            // PermissionedRegistry._register() => CannotSetPastExpiry :: see expiry check
+            // PermissionedRegistry._register() => LabelAlreadyRegistered :: only have ROLE_REGISTER_RESERVED
+            // ERC1155._safeTransferFrom() => ERC1155InvalidReceiver :: see owner check
+            _inject(
+                md.label,
+                md.owner,
+                subregistry,
+                resolver,
+                _tokenRoleBitmapFromFuses(fuses),
+                expiry
+            );
+>>>>>>> 33a2ff1c (wip)
         }
     }
 

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -52,7 +52,7 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
     /// @notice The `WrapperRegistry` implementation contract.
     address public immutable WRAPPER_REGISTRY_IMPL;
 
-    /// @notice The approved list of `PublicResolver` contracts.
+    /// @notice The list of `PublicResolver` contracts that require replacement.
     IAddressSet public immutable PUBLIC_RESOLVER_SET;
 
     /// @notice The replacement `PublicResolver`.

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -71,11 +71,13 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
     constructor(
         INameWrapper nameWrapper,
         address graveyard,
-        VerifiableFactory verifiableFactory,
+        IVerifiableFactory verifiableFactory,
         address wrapperRegistryImpl,
         IAddressSet publicResolverSet,
         address publicResolver
-    ) AbstractWrapperReceiver(nameWrapper, graveyard) {
+    )
+        AbstractWrapperReceiver(nameWrapper, graveyard)
+    {
         VERIFIABLE_FACTORY = verifiableFactory;
         WRAPPER_REGISTRY_IMPL = wrapperRegistryImpl;
         PUBLIC_RESOLVER_SET = publicResolverSet;
@@ -134,6 +136,9 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
                     NAME_WRAPPER.setResolver(node, address(0)); // clear ENSv1 resolver
                 } else {
                     resolver = _REGISTRY_V1.resolver(node); // replace with ENSv1 resolver
+                    if (PUBLIC_RESOLVER_SET.includes(resolver)) {
+                        resolver = PUBLIC_RESOLVER; // replace with new PublicResolver
+                    }
                 }
 
                 NAME_WRAPPER.safeTransferFrom(address(this), GRAVEYARD, uint256(node), 1, ""); // transfer to graveyard
@@ -185,54 +190,6 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
             } else {
                 revert LibMigration.NameNotLocked(uint256(node));
             }
-<<<<<<< HEAD
-=======
-
-            if (NAME_WRAPPER.getApproved(uint256(node)) != address(0)) {
-                revert LibMigration.FrozenTokenApproval(uint256(node));
-            }
-
-            address resolver = md.resolver;
-            if ((fuses & CANNOT_SET_RESOLVER) == 0) {
-                NAME_WRAPPER.setResolver(node, address(0)); // clear ENSv1 resolver
-            } else {
-                resolver = _REGISTRY_V1.resolver(node); // replace with ENSv1 resolver
-                if (PUBLIC_RESOLVER_SET.includes(resolver)) {
-                    resolver = PUBLIC_RESOLVER; // replace with new PublicResolver
-                }
-            }
-
-            // create subregistry
-            IRegistry subregistry = IRegistry(
-                VERIFIABLE_FACTORY.deployProxy(
-                    WRAPPER_REGISTRY_IMPL,
-                    uint256(node),
-                    abi.encodeCall(
-                        IWrapperRegistry.initialize,
-                        (
-                            node,
-                            parentRegistry,
-                            md.label,
-                            md.owner,
-                            _subregistryRoleBitmapFromFuses(fuses)
-                        )
-                    )
-                )
-            );
-
-            // add name to ENSv2
-            // PermissionedRegistry._register() => CannotSetPastExpiry :: see expiry check
-            // PermissionedRegistry._register() => LabelAlreadyRegistered :: only have ROLE_REGISTER_RESERVED
-            // ERC1155._safeTransferFrom() => ERC1155InvalidReceiver :: see owner check
-            _inject(
-                md.label,
-                md.owner,
-                subregistry,
-                resolver,
-                _tokenRoleBitmapFromFuses(fuses),
-                expiry
-            );
->>>>>>> 33a2ff1c (wip)
         }
     }
 

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -66,7 +66,7 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
     /// @param graveyard The ENSv1 `BaseRegistrar` token graveyard.
     /// @param verifiableFactory The shared factory for verifiable deployments.
     /// @param wrapperRegistryImpl The `WrapperRegistry` implementation contract.
-    /// @param publicResolverSet The approved list of `PublicResolver` contracts.
+    /// @param publicResolverSet The list of `PublicResolver` contracts that require replacement.
     /// @param publicResolver The replacement `PublicResolver`.
     constructor(
         INameWrapper nameWrapper,

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -13,8 +13,8 @@ import {AbstractWrapperReceiver} from "../migration/AbstractWrapperReceiver.sol"
 import {LibMigration} from "../migration/libraries/LibMigration.sol";
 import {LockedWrapperReceiver} from "../migration/LockedWrapperReceiver.sol";
 import {IWrapperRegistry} from "../registry/interfaces/IWrapperRegistry.sol";
-import {ILabelStore} from "../utils/interfaces/ILabelStore.sol";
 import {IAddressSet} from "../utils/interfaces/IAddressSet.sol";
+import {ILabelStore} from "../utils/interfaces/ILabelStore.sol";
 
 import {ApprovedUpgradeGate} from "./ApprovedUpgradeGate.sol";
 import {IRegistry} from "./interfaces/IRegistry.sol";
@@ -80,12 +80,15 @@ contract WrapperRegistry is
         address ensV1Resolver,
         IHCAFactoryBasic hcaFactory,
         IRegistryMetadata metadataProvider,
+        ApprovedUpgradeGate upgradeGate,
+        ILabelStore labelStore,
         IAddressSet publicResolverSet,
         address publicResolver
     )
         PermissionedRegistry(hcaFactory, metadataProvider, labelStore, address(0), 0) // no roles are granted
         LockedWrapperReceiver(
             nameWrapper,
+            graveyard,
             verifiableFactory,
             address(this),
             publicResolverSet,

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -14,6 +14,7 @@ import {LibMigration} from "../migration/libraries/LibMigration.sol";
 import {LockedWrapperReceiver} from "../migration/LockedWrapperReceiver.sol";
 import {IWrapperRegistry} from "../registry/interfaces/IWrapperRegistry.sol";
 import {ILabelStore} from "../utils/interfaces/ILabelStore.sol";
+import {IAddressSet} from "../utils/interfaces/IAddressSet.sol";
 
 import {ApprovedUpgradeGate} from "./ApprovedUpgradeGate.sol";
 import {IRegistry} from "./interfaces/IRegistry.sol";
@@ -70,6 +71,8 @@ contract WrapperRegistry is
     /// @param metadataProvider The metadata provider.
     /// @param upgradeGate The upgrade target allowlist.
     /// @param labelStore The shared label database.
+    /// @param publicResolverSet The approved list of `PublicResolver` contracts.
+    /// @param publicResolver The replacement `PublicResolver`.
     constructor(
         INameWrapper nameWrapper,
         address graveyard,
@@ -77,11 +80,17 @@ contract WrapperRegistry is
         address ensV1Resolver,
         IHCAFactoryBasic hcaFactory,
         IRegistryMetadata metadataProvider,
-        ApprovedUpgradeGate upgradeGate,
-        ILabelStore labelStore
+        IAddressSet publicResolverSet,
+        address publicResolver
     )
         PermissionedRegistry(hcaFactory, metadataProvider, labelStore, address(0), 0) // no roles are granted
-        LockedWrapperReceiver(nameWrapper, graveyard, verifiableFactory, address(this))
+        LockedWrapperReceiver(
+            nameWrapper,
+            verifiableFactory,
+            address(this),
+            publicResolverSet,
+            publicResolver
+        )
     {
         V1_RESOLVER = ensV1Resolver;
         UPGRADE_GATE = upgradeGate;

--- a/contracts/src/resolver/PublicResolverV2.sol
+++ b/contracts/src/resolver/PublicResolverV2.sol
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Multicallable} from "@ens/contracts/resolvers/Multicallable.sol";
+import {ABIResolver} from "@ens/contracts/resolvers/profiles/ABIResolver.sol";
+import {AddrResolver} from "@ens/contracts/resolvers/profiles/AddrResolver.sol";
+import {ContentHashResolver} from "@ens/contracts/resolvers/profiles/ContentHashResolver.sol";
+import {DataResolver} from "@ens/contracts/resolvers/profiles/DataResolver.sol";
+import {DNSResolver} from "@ens/contracts/resolvers/profiles/DNSResolver.sol";
+import {InterfaceResolver} from "@ens/contracts/resolvers/profiles/InterfaceResolver.sol";
+import {NameResolver} from "@ens/contracts/resolvers/profiles/NameResolver.sol";
+import {PubkeyResolver} from "@ens/contracts/resolvers/profiles/PubkeyResolver.sol";
+import {TextResolver} from "@ens/contracts/resolvers/profiles/TextResolver.sol";
+import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
+import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
+
+import {HCAContext} from "../hca/HCAContext.sol";
+import {HCAEquivalence} from "../hca/HCAEquivalence.sol";
+import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
+import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
+import {LibRegistry} from "../universalResolver/libraries/LibRegistry.sol";
+
+/// @notice PublicResolver that respects the ENSv2 registry.
+contract PublicResolverV2 is
+    Multicallable,
+    ABIResolver,
+    AddrResolver,
+    ContentHashResolver,
+    DataResolver,
+    DNSResolver,
+    InterfaceResolver,
+    NameResolver,
+    PubkeyResolver,
+    TextResolver,
+    HCAContext
+{
+    ////////////////////////////////////////////////////////////////////////
+    // Constants
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice The ENSv1 `NameWrapper` contract.
+    INameWrapper public immutable NAME_WRAPPER;
+
+    /// @notice The ENSv2  Root Registry contract.
+    IPermissionedRegistry public immutable ROOT_REGISTRY;
+
+    ////////////////////////////////////////////////////////////////////////
+    // Storage
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev A mapping of operators. An address that is authorised for an address
+    ///      may make any changes to the name that the owner could, but may not update
+    ///      the set of authorisations.
+    mapping(address owner => mapping(address operator => bool approved))
+        internal _operatorApprovals;
+
+    /// @dev A mapping of delegates. A delegate that is authorised by an owner
+    ///      for a name may make changes to the name's resolver, but may not update
+    ///      the set of token approvals.
+    mapping(address owner => mapping(bytes32 node => mapping(address delegate => bool approved)))
+        internal _tokenApprovals;
+
+    ////////////////////////////////////////////////////////////////////////
+    // Events
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice An operator is added or removed.
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    /// @notice A delegate is approved or an approval is revoked.
+    event Approved(
+        address owner,
+        bytes32 indexed node,
+        address indexed delegate,
+        bool indexed approved
+    );
+
+    ////////////////////////////////////////////////////////////////////////
+    // Initialization
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Create a WrappedPublicResolver.
+    /// @param hcaFactory The HCA factory.
+    /// @param nameWrapper The ENSv1 `NameWrapper` contract.
+    /// @param rootRegistry The ENSv2 Root Registry contract.
+    constructor(
+        IHCAFactoryBasic hcaFactory,
+        INameWrapper nameWrapper,
+        IPermissionedRegistry rootRegistry
+    ) HCAEquivalence(hcaFactory) {
+        NAME_WRAPPER = nameWrapper;
+        ROOT_REGISTRY = rootRegistry;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    )
+        public
+        view
+        override(
+            Multicallable,
+            ABIResolver,
+            AddrResolver,
+            ContentHashResolver,
+            DataResolver,
+            DNSResolver,
+            InterfaceResolver,
+            NameResolver,
+            PubkeyResolver,
+            TextResolver
+        )
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Implementation
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Grant or revoke `operator` approval.
+    /// @param operator The account to approve.
+    /// @param approved If `true`, approved, otherwise revoked.
+    function setApprovalForAll(address operator, bool approved) external {
+        address sender = _msgSender();
+        require(sender != operator, "ERC1155: setting approval status for self");
+        _operatorApprovals[sender][operator] = approved;
+        emit ApprovalForAll(sender, operator, approved);
+    }
+
+    /// @notice Grant or revoke `delegate` approval on a specific node.
+    /// @param node The namehash to approve.
+    /// @param delegate The account to approve.
+    /// @param approved If `true`, approved, otherwise revoked.
+    function approve(bytes32 node, address delegate, bool approved) external {
+        address sender = _msgSender();
+        require(sender != delegate, "Setting delegate status for self");
+        _tokenApprovals[sender][node][delegate] = approved;
+        emit Approved(sender, node, delegate, approved);
+    }
+
+    /// @notice Check if `operator` is approved for all nodes owned by `account`.
+    /// @param owner The owner account.
+    /// @param operator The operator account.
+    /// @return `true` if `operator` is approved.
+    function isApprovedForAll(address owner, address operator) public view returns (bool) {
+        return _operatorApprovals[owner][operator];
+    }
+
+    /// @notice Check to see if the delegate has been approved by the owner for the node.
+    /// @param owner The owner account.
+    /// @param node The namehash to check.
+    /// @param delegate The delegated account.
+    /// @return `true` if `operator` is approved.
+    function isApprovedFor(
+        address owner,
+        bytes32 node,
+        address delegate
+    ) public view returns (bool) {
+        return _tokenApprovals[owner][node][delegate];
+    }
+
+    /// @notice Determine if `operator` is authorized for `node`.
+    /// @param node The namehash to check.
+    /// @param operator The account requesting authorization.
+    /// @return `true` if `node` is authorized.
+    function canModifyName(bytes32 node, address operator) public view returns (bool) {
+        bytes memory name = NAME_WRAPPER.names(node);
+        if (name.length == 0) {
+            return false;
+        }
+        (bytes32 labelHash, uint256 offset) = NameCoder.readLabel(name, 0);
+        if (labelHash == bytes32(0)) {
+            return false;
+        }
+        address parent = address(LibRegistry.findExactRegistry(ROOT_REGISTRY, name, offset));
+        if (parent == address(0)) {
+            return false;
+        }
+        IPermissionedRegistry.State memory state = IPermissionedRegistry(parent).getState(
+            uint256(labelHash)
+        );
+        if (state.status != IPermissionedRegistry.Status.REGISTERED) {
+            return false;
+        }
+        address owner = state.latestOwner;
+        return
+            owner == operator ||
+            isApprovedForAll(owner, operator) ||
+            isApprovedFor(owner, node, operator);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Internal Functions
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Determine if the caller is authorized for `node`.
+    function isAuthorised(bytes32 node) internal view override returns (bool) {
+        return canModifyName(node, _msgSender());
+    }
+}

--- a/contracts/src/resolver/PublicResolverV2.sol
+++ b/contracts/src/resolver/PublicResolverV2.sol
@@ -65,9 +65,16 @@ contract PublicResolverV2 is
     ////////////////////////////////////////////////////////////////////////
 
     /// @notice An operator is added or removed.
+    /// @param owner The node owner.
+    /// @param operator The approved account.
+    /// @param approved If `true`, approved, otherwise revoked.
     event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
 
     /// @notice A delegate is approved or an approval is revoked.
+    /// @param owner The node owner.
+    /// @param node The namehash.
+    /// @param delegate The approved account.
+    /// @param approved If `true`, approved, otherwise revoked.
     event Approved(
         address owner,
         bytes32 indexed node,
@@ -92,6 +99,7 @@ contract PublicResolverV2 is
         ROOT_REGISTRY = rootRegistry;
     }
 
+    /// @inheritdoc AddrResolver
     function supportsInterface(
         bytes4 interfaceId
     )
@@ -194,6 +202,7 @@ contract PublicResolverV2 is
     // Internal Functions
     ////////////////////////////////////////////////////////////////////////
 
+    // solhint-disable private-vars-leading-underscore
     /// @dev Determine if the caller is authorized for `node`.
     function isAuthorised(bytes32 node) internal view override returns (bool) {
         return canModifyName(node, _msgSender());

--- a/contracts/src/resolver/PublicResolverV2.sol
+++ b/contracts/src/resolver/PublicResolverV2.sol
@@ -35,7 +35,7 @@ contract PublicResolverV2 is
     HCAContext
 {
     ////////////////////////////////////////////////////////////////////////
-    // Constants
+    // Immutables
     ////////////////////////////////////////////////////////////////////////
 
     /// @notice The ENSv1 `NameWrapper` contract.
@@ -51,14 +51,12 @@ contract PublicResolverV2 is
     /// @dev A mapping of operators. An address that is authorised for an address
     ///      may make any changes to the name that the owner could, but may not update
     ///      the set of authorisations.
-    mapping(address owner => mapping(address operator => bool approved))
-        internal _operatorApprovals;
+    mapping(address owner => mapping(address operator => bool approved)) internal _operatorApprovals;
 
     /// @dev A mapping of delegates. A delegate that is authorised by an owner
     ///      for a name may make changes to the name's resolver, but may not update
     ///      the set of token approvals.
-    mapping(address owner => mapping(bytes32 node => mapping(address delegate => bool approved)))
-        internal _tokenApprovals;
+    mapping(address owner => mapping(bytes32 node => mapping(address delegate => bool approved))) internal _tokenApprovals;
 
     ////////////////////////////////////////////////////////////////////////
     // Events
@@ -94,15 +92,15 @@ contract PublicResolverV2 is
         IHCAFactoryBasic hcaFactory,
         INameWrapper nameWrapper,
         IPermissionedRegistry rootRegistry
-    ) HCAEquivalence(hcaFactory) {
+    )
+        HCAEquivalence(hcaFactory)
+    {
         NAME_WRAPPER = nameWrapper;
         ROOT_REGISTRY = rootRegistry;
     }
 
     /// @inheritdoc AddrResolver
-    function supportsInterface(
-        bytes4 interfaceId
-    )
+    function supportsInterface(bytes4 interfaceId)
         public
         view
         override(
@@ -160,11 +158,11 @@ contract PublicResolverV2 is
     /// @param node The namehash to check.
     /// @param delegate The delegated account.
     /// @return `true` if `operator` is approved.
-    function isApprovedFor(
-        address owner,
-        bytes32 node,
-        address delegate
-    ) public view returns (bool) {
+    function isApprovedFor(address owner, bytes32 node, address delegate)
+        public
+        view
+        returns (bool)
+    {
         return _tokenApprovals[owner][node][delegate];
     }
 
@@ -185,9 +183,8 @@ contract PublicResolverV2 is
         if (parent == address(0)) {
             return false;
         }
-        IPermissionedRegistry.State memory state = IPermissionedRegistry(parent).getState(
-            uint256(labelHash)
-        );
+        IPermissionedRegistry.State memory state =
+            IPermissionedRegistry(parent).getState(uint256(labelHash));
         if (state.status != IPermissionedRegistry.Status.REGISTERED) {
             return false;
         }

--- a/contracts/src/utils/PermissionedAddressSet.sol
+++ b/contracts/src/utils/PermissionedAddressSet.sol
@@ -8,6 +8,7 @@ import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
 import {IAddressSet} from "./interfaces/IAddressSet.sol";
 
 uint256 constant ROLE_APPROVE = 1 << 0;
+
 uint256 constant ROLE_APPROVE_ADMIN = ROLE_APPROVE << 128;
 
 /// @notice An arbitrary set of addresses managed by EAC.
@@ -41,9 +42,13 @@ contract PermissionedAddressSet is EnhancedAccessControl, IAddressSet {
     }
 
     /// @inheritdoc EnhancedAccessControl
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(EnhancedAccessControl) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(EnhancedAccessControl)
+        returns (bool)
+    {
         return type(IAddressSet).interfaceId == interfaceId || super.supportsInterface(interfaceId);
     }
 

--- a/contracts/src/utils/PermissionedAddressSet.sol
+++ b/contracts/src/utils/PermissionedAddressSet.sol
@@ -7,17 +7,27 @@ import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
 
 import {IAddressSet} from "./interfaces/IAddressSet.sol";
 
-uint256 constant ROLE_APPROVE = 0;
+uint256 constant ROLE_APPROVE = 1 << 0;
 uint256 constant ROLE_APPROVE_ADMIN = ROLE_APPROVE << 128;
 
 /// @notice An arbitrary set of addresses managed by EAC.
-contract PermissionedAddresses is EnhancedAccessControl, IAddressSet {
+contract PermissionedAddressSet is EnhancedAccessControl, IAddressSet {
     ////////////////////////////////////////////////////////////////////////
     // Storage
     ////////////////////////////////////////////////////////////////////////
 
-    /// @dev TODO
+    /// @dev Mapping that determines members of the set.
     mapping(address addr => bool approved) internal _approved;
+
+    ////////////////////////////////////////////////////////////////////////
+    // Events
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Inclusion of a member of the set has changed.
+    /// @param addr The address.
+    /// @param approved If `true`, added, otherwise removed.
+    /// @param sender The sender of the change.
+    event ApprovalChanged(address indexed addr, bool approved, address indexed sender);
 
     ////////////////////////////////////////////////////////////////////////
     // Initialization
@@ -41,11 +51,13 @@ contract PermissionedAddresses is EnhancedAccessControl, IAddressSet {
     // Implementation
     ////////////////////////////////////////////////////////////////////////
 
-    /// @notice Add or remove `addr` from the set.
+    /// @notice Add or remove a member from the set.
     /// @param addr The address to approve.
     /// @param approved If `true`, added, otherwise removed.
     function approve(address addr, bool approved) external onlyRootRoles(ROLE_APPROVE) {
+        require(_approved[addr] != approved);
         _approved[addr] = approved;
+        emit ApprovalChanged(addr, approved, _msgSender());
     }
 
     /// @inheritdoc IAddressSet

--- a/contracts/src/utils/PermissionedAddresses.sol
+++ b/contracts/src/utils/PermissionedAddresses.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {EnhancedAccessControl} from "../access-control/EnhancedAccessControl.sol";
+import {HCAEquivalence} from "../hca/HCAEquivalence.sol";
+import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
+
+import {IAddressSet} from "./interfaces/IAddressSet.sol";
+
+uint256 constant ROLE_APPROVE = 0;
+uint256 constant ROLE_APPROVE_ADMIN = ROLE_APPROVE << 128;
+
+/// @notice An arbitrary set of addresses managed by EAC.
+contract PermissionedAddresses is EnhancedAccessControl, IAddressSet {
+    ////////////////////////////////////////////////////////////////////////
+    // Storage
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev TODO
+    mapping(address addr => bool approved) internal _approved;
+
+    ////////////////////////////////////////////////////////////////////////
+    // Initialization
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Initialize the contract.
+    /// @param hcaFactory The HCA factory.
+    /// @param admin The initial admin.
+    constructor(IHCAFactoryBasic hcaFactory, address admin) HCAEquivalence(hcaFactory) {
+        _grantRoles(ROOT_RESOURCE, ROLE_APPROVE | ROLE_APPROVE_ADMIN, admin, false);
+    }
+
+    /// @inheritdoc EnhancedAccessControl
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(EnhancedAccessControl) returns (bool) {
+        return type(IAddressSet).interfaceId == interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Implementation
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Add or remove `addr` from the set.
+    /// @param addr The address to approve.
+    /// @param approved If `true`, added, otherwise removed.
+    function approve(address addr, bool approved) external onlyRootRoles(ROLE_APPROVE) {
+        _approved[addr] = approved;
+    }
+
+    /// @inheritdoc IAddressSet
+    function includes(address addr) external view returns (bool) {
+        return _approved[addr];
+    }
+}

--- a/contracts/src/utils/interfaces/IAddressSet.sol
+++ b/contracts/src/utils/interfaces/IAddressSet.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @dev Interface selector: `0x1aedefda`
+interface IAddressSet {
+    /// @notice Check if `addr` is included in the set.
+    /// @param addr The address to check.
+    /// @return `true` if included.
+    function includes(address addr) external view returns (bool);
+}

--- a/contracts/test/e2e/migration.test.ts
+++ b/contracts/test/e2e/migration.test.ts
@@ -611,7 +611,7 @@ describe("Migration", () => {
       await locked.checkResolution();
     });
 
-    it("locked resolver", async () => {
+    async function testLockedResolver(whitelisted: boolean) {
       const locked = await registerWrapped({ fuses: FUSES.CANNOT_UNWRAP });
       await locked.setupPublicResolver();
       await locked.burnFuses(FUSES.CANNOT_SET_RESOLVER);
@@ -623,7 +623,23 @@ describe("Migration", () => {
       const resolver = await env.v2.ETHRegistry.read.getResolver([
         locked.label,
       ]);
-      expectVar({ resolver }).toEqualAddress(env.v1.PublicResolver.address);
+      expectVar({ resolver }).toEqualAddress(
+        whitelisted
+          ? env.v2.PublicResolver.address
+          : env.v1.PublicResolver.address,
+      );
+    }
+
+    it("locked resolver", async () => {
+      await env.v2.PublicResolverSet.write.approve([
+        env.v1.PublicResolver.address,
+        false,
+      ]); // remove from set
+      await testLockedResolver(false);
+    });
+
+    it("locked resolver (wrapper-aware)", async () => {
+      await testLockedResolver(true);
     });
 
     it("locked transfer", async () => {

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -42,6 +42,7 @@ import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
 import {IRegistryMetadata} from "~src/registry/interfaces/IRegistryMetadata.sol";
 import {ApprovedUpgradeGate} from "~src/registry/ApprovedUpgradeGate.sol";
 import {PublicResolverV2} from "~src/resolver/PublicResolverV2.sol";
+import {IAddressSet} from "~src/utils/interfaces/IAddressSet.sol";
 import {PermissionedAddressSet} from "~src/utils/PermissionedAddressSet.sol";
 import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixture.sol";
 
@@ -57,7 +58,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
 
         approvedUpgradeGate = new ApprovedUpgradeGate(address(this));
 
-        publicResolverSet = new PermissionedAddresses(hcaFactory, address(this));
+        publicResolverSet = new PermissionedAddressSet(hcaFactory, address(this));
         publicResolver = new PublicResolverV2(hcaFactory, nameWrapper, rootRegistry);
 
         vm.expectEmit();
@@ -593,27 +594,27 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         LibMigration.Data memory md = _makeData(name);
 
         address oldPublicResolver = makeAddr("oldPublicResolver");
-        vm.prank(user);
+        vm.prank(testOwner);
         nameWrapper.setResolver(node, oldPublicResolver);
-        vm.prank(user);
+        vm.prank(testOwner);
         nameWrapper.setFuses(node, uint16(CANNOT_UNWRAP | CANNOT_SET_RESOLVER));
         assertNotEq(md.resolver, oldPublicResolver, "diff");
 
         // add as approved PublicResolver
         publicResolverSet.approve(oldPublicResolver, true);
 
-        assertFalse(publicResolver.canModifyName(node, user), "before");
+        assertFalse(publicResolver.canModifyName(node, testOwner), "before");
 
-        vm.prank(user);
+        vm.prank(testOwner);
         nameWrapper.safeTransferFrom(
-            user,
+            testOwner,
             address(migrationController),
             uint256(node),
             1,
             abi.encode(md)
         );
 
-        assertTrue(publicResolver.canModifyName(node, user), "after");
+        assertTrue(publicResolver.canModifyName(node, testOwner), "after");
 
         assertEq(ethRegistry.getResolver(md.label), address(publicResolver), "prV2");
         checkResolution(name, address(oldPublicResolver), address(publicResolver));
@@ -954,7 +955,9 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
                 hcaFactory,
                 metadata,
                 approvedUpgradeGate,
-                labelStore
+                labelStore,
+                publicResolverSet,
+                address(publicResolver)
             );
     }
 }
@@ -969,7 +972,9 @@ contract WrapperRegistryV2Mock is WrapperRegistry {
         IHCAFactoryBasic hcaFactory,
         IRegistryMetadata metadataProvider,
         ApprovedUpgradeGate upgradeGate,
-        ILabelStore labelStore
+        ILabelStore labelStore,
+        IAddressSet publicResolverSet,
+        address publicResolver
     )
         WrapperRegistry(
             nameWrapper,
@@ -979,7 +984,9 @@ contract WrapperRegistryV2Mock is WrapperRegistry {
             hcaFactory,
             metadataProvider,
             upgradeGate,
-            labelStore
+            labelStore,
+            publicResolverSet,
+            publicResolver
         )
     {}
 

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -41,13 +41,15 @@ import {WrapperRegistry, IWrapperRegistry} from "~src/registry/WrapperRegistry.s
 import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
 import {IRegistryMetadata} from "~src/registry/interfaces/IRegistryMetadata.sol";
 import {ApprovedUpgradeGate} from "~src/registry/ApprovedUpgradeGate.sol";
+import {PublicResolverV2} from "~src/resolver/PublicResolverV2.sol";
+import {PermissionedAddressSet} from "~src/utils/PermissionedAddressSet.sol";
 import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixture.sol";
 
 contract LockedMigrationControllerTest is MigrationControllerFixture {
     LockedMigrationController migrationController;
     ApprovedUpgradeGate approvedUpgradeGate;
     WrapperRegistry wrapperRegistryImpl;
-    PermissionedAddresses publicResolverSet;
+    PermissionedAddressSet publicResolverSet;
     PublicResolverV2 publicResolver;
 
     function setUp() external {

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -47,11 +47,16 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
     LockedMigrationController migrationController;
     ApprovedUpgradeGate approvedUpgradeGate;
     WrapperRegistry wrapperRegistryImpl;
+    PermissionedAddresses publicResolverSet;
+    PublicResolverV2 publicResolver;
 
     function setUp() external {
         deployMigrationControllerFixture();
 
         approvedUpgradeGate = new ApprovedUpgradeGate(address(this));
+
+        publicResolverSet = new PermissionedAddresses(hcaFactory, address(this));
+        publicResolver = new PublicResolverV2(hcaFactory, nameWrapper, rootRegistry);
 
         vm.expectEmit();
         emit IRegistryEvents.RegistryCreated();
@@ -63,7 +68,9 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             hcaFactory,
             metadata,
             approvedUpgradeGate,
-            labelStore
+            labelStore,
+            publicResolverSet,
+            address(publicResolver)
         );
 
         migrationController = new LockedMigrationController(
@@ -71,7 +78,9 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             address(graveyard),
             ethRegistry,
             verifiableFactory,
-            address(wrapperRegistryImpl)
+            address(wrapperRegistryImpl),
+            publicResolverSet,
+            address(publicResolver)
         );
 
         ethRegistry.grantRootRoles(
@@ -574,6 +583,38 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
         vm.prank(testOwner);
         ethRegistry.setResolver(tokenId, testResolver);
+    }
+
+    function test_migrate_lockedResolver_publicResolver() external {
+        bytes memory name = registerWrappedETH2LD(testLabel, CAN_DO_EVERYTHING);
+        bytes32 node = NameCoder.namehash(name, 0);
+        LibMigration.Data memory md = _makeData(name);
+
+        address oldPublicResolver = makeAddr("oldPublicResolver");
+        vm.prank(user);
+        nameWrapper.setResolver(node, oldPublicResolver);
+        vm.prank(user);
+        nameWrapper.setFuses(node, uint16(CANNOT_UNWRAP | CANNOT_SET_RESOLVER));
+        assertNotEq(md.resolver, oldPublicResolver, "diff");
+
+        // add as approved PublicResolver
+        publicResolverSet.approve(oldPublicResolver, true);
+
+        assertFalse(publicResolver.canModifyName(node, user), "before");
+
+        vm.prank(user);
+        nameWrapper.safeTransferFrom(
+            user,
+            address(migrationController),
+            uint256(node),
+            1,
+            abi.encode(md)
+        );
+
+        assertTrue(publicResolver.canModifyName(node, user), "after");
+
+        assertEq(ethRegistry.getResolver(md.label), address(publicResolver), "prV2");
+        checkResolution(name, address(oldPublicResolver), address(publicResolver));
     }
 
     function test_migrate_lockedTransfer() external {

--- a/contracts/test/unit/registrar/AbstractETHRegistrar.t.sol
+++ b/contracts/test/unit/registrar/AbstractETHRegistrar.t.sol
@@ -2,15 +2,13 @@
 pragma solidity >=0.8.13;
 
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
-import {
-    AbstractETHRegistrar,
-    IHCAFactoryBasic,
-    IETHRenewer,
-    IRentPriceOracle,
-    IPermissionedRegistry,
-    Ownable
-} from "~src/registrar/AbstractETHRegistrar.sol";
+import {AbstractETHRegistrar} from "~src/registrar/AbstractETHRegistrar.sol";
+import {IHCAFactoryBasic} from "~src/hca/interfaces/IHCAFactoryBasic.sol";
+import {IETHRenewer} from "~src/registrar/interfaces/IETHRenewer.sol";
+import {IRentPriceOracle} from "~src/registrar/interfaces/IRentPriceOracle.sol";
+import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
 import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixture.sol";
 import {StandardRentPriceOracleFixture} from "~test/fixtures/StandardRentPriceOracleFixture.sol";
 

--- a/contracts/test/unit/registrar/ETHRegistrar.t.sol
+++ b/contracts/test/unit/registrar/ETHRegistrar.t.sol
@@ -8,17 +8,14 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
+import {InvalidOwner} from "~src/CommonErrors.sol";
+import {LibLabel} from "~src/utils/LibLabel.sol";
 import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
+import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
-import {
-    ETHRegistrar,
-    IETHRegistrar,
-    IETHRenewer,
-    IPermissionedRegistry,
-    LibLabel,
-    InvalidOwner,
-    REGISTRATION_ROLE_BITMAP
-} from "~src/registrar/ETHRegistrar.sol";
+import {IETHRegistrar} from "~src/registrar/interfaces/IETHRegistrar.sol";
+import {IETHRenewer} from "~src/registrar/interfaces/IETHRenewer.sol";
+import {ETHRegistrar, REGISTRATION_ROLE_BITMAP} from "~src/registrar/ETHRegistrar.sol";
 import {MockERC20, MockERC20Blacklist} from "~test/mocks/MockERC20.sol";
 import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixture.sol";
 import {StandardRentPriceOracleFixture} from "~test/fixtures/StandardRentPriceOracleFixture.sol";

--- a/contracts/test/unit/registrar/ETHRenewerV1.t.sol
+++ b/contracts/test/unit/registrar/ETHRenewerV1.t.sol
@@ -7,9 +7,11 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {IBaseRegistrar} from "@ens/contracts/ethregistrar/IBaseRegistrar.sol";
 
+import {LibLabel} from "~src/utils/LibLabel.sol";
 import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
-import {ETHRenewerV1, IETHRenewer, LibLabel} from "~src/registrar/ETHRenewerV1.sol";
+import {IETHRenewer} from "~src/registrar/interfaces/IETHRenewer.sol";
+import {ETHRenewerV1} from "~src/registrar/ETHRenewerV1.sol";
 import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixture.sol";
 import {StandardRentPriceOracleFixture} from "~test/fixtures/StandardRentPriceOracleFixture.sol";
 import {MockERC20} from "~test/mocks/MockERC20.sol";

--- a/contracts/test/unit/registrar/StandardRentPriceOracle.t.sol
+++ b/contracts/test/unit/registrar/StandardRentPriceOracle.t.sol
@@ -4,23 +4,21 @@ pragma solidity >=0.8.13;
 // solhint-disable no-console, private-vars-leading-underscore, state-visibility, func-name-mixedcase, contracts-v2/ordering, one-contract-per-file
 
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import {IEnhancedAccessControl} from "~src/access-control/interfaces/IEnhancedAccessControl.sol";
+import {IRentPriceOracle} from "~src/registrar/interfaces/IRentPriceOracle.sol";
 import {
     StandardRentPriceOracle,
-    IRentPriceOracle,
-    IERC20,
-    Math,
     PaymentRatio,
     DiscountPoint,
     DEFAULT_ROLE_BITMAP,
     ROLE_UPDATE_TOKEN,
     ROLE_DISABLE_TOKEN
 } from "~src/registrar/StandardRentPriceOracle.sol";
-import {
-    StandardRentPriceOracleFixture,
-    StandardRegistrar
-} from "~test/fixtures/StandardRentPriceOracleFixture.sol";
+import {StandardRentPriceOracleFixture} from "~test/fixtures/StandardRentPriceOracleFixture.sol";
+import {StandardRegistrar} from "~test/StandardRegistrar.sol";
 
 /// @dev The expiry parameter of `getRenewPrice()` is currently unused.
 uint64 constant UNUSED_EXPIRY = 0;

--- a/contracts/test/unit/resolver/PublicResolverV2.t.sol
+++ b/contracts/test/unit/resolver/PublicResolverV2.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {PublicResolverV2, NameCoder} from "~src/resolver/PublicResolverV2.sol";
+import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
+import {V1Fixture} from "~test/fixtures/V1Fixture.sol";
+import {V2Fixture} from "~test/fixtures/V2Fixture.sol";
+
+contract PublicResolverV2V2Test is V1Fixture, V2Fixture {
+    PublicResolverV2 publicResolver;
+
+    address friend = makeAddr("friend");
+
+    function setUp() external {
+        deployV1Fixture();
+        deployV2Fixture();
+        publicResolver = new PublicResolverV2(hcaFactory, nameWrapper, rootRegistry);
+    }
+
+    function test_canModifyName() external {
+        bytes32 node = _register("test");
+
+        // call a setter
+        vm.prank(user);
+        publicResolver.setAddr(node, user);
+    }
+
+    function test_canModifyName_setApprovalForAll() external {
+        bytes32 node = _register("test");
+
+        vm.prank(user);
+        publicResolver.setApprovalForAll(friend, true);
+
+        assertTrue(publicResolver.canModifyName(node, friend));
+
+        // call a setter
+        vm.prank(friend);
+        publicResolver.setAddr(node, user);
+    }
+
+    function test_canModifyName_approve() external {
+        bytes32 node = _register("test");
+
+        vm.prank(user);
+        publicResolver.approve(node, friend, true);
+
+        assertTrue(publicResolver.canModifyName(node, friend));
+        assertFalse(publicResolver.canModifyName(~node, friend));
+
+        // call a setter
+        vm.prank(friend);
+        publicResolver.setAddr(node, user);
+    }
+
+    function test_canModifyName_notAuthorized(bytes32 node) external {
+        assertFalse(publicResolver.canModifyName(node, user));
+
+        // call a setter
+        vm.expectRevert();
+        publicResolver.setAddr(node, user);
+    }
+
+    function _register(string memory label) internal returns (bytes32 node) {
+        // register wrapped name in v1
+        bytes memory name = this.registerWrappedETH2LD(label, 0);
+        node = NameCoder.namehash(name, 0);
+
+        assertFalse(publicResolver.canModifyName(node, user), "before");
+
+        // register same name in v2
+        ethRegistry.register(
+            label,
+            user,
+            IRegistry(address(0)),
+            address(publicResolver),
+            0,
+            uint64(block.timestamp + 1 days)
+        );
+
+        assertTrue(publicResolver.canModifyName(node, user), "after");
+    }
+}

--- a/contracts/test/unit/resolver/PublicResolverV2.t.sol
+++ b/contracts/test/unit/resolver/PublicResolverV2.t.sol
@@ -8,7 +8,7 @@ import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
 import {V1Fixture} from "~test/fixtures/V1Fixture.sol";
 import {V2Fixture} from "~test/fixtures/V2Fixture.sol";
 
-contract PublicResolverV2V2Test is V1Fixture, V2Fixture {
+contract PublicResolverV2Test is V1Fixture, V2Fixture {
     PublicResolverV2 publicResolver;
 
     address friend = makeAddr("friend");

--- a/contracts/test/unit/resolver/PublicResolverV2.t.sol
+++ b/contracts/test/unit/resolver/PublicResolverV2.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {Test} from "forge-std/Test.sol";
-
 import {PublicResolverV2, NameCoder} from "~src/resolver/PublicResolverV2.sol";
 import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
 import {V1Fixture} from "~test/fixtures/V1Fixture.sol";
@@ -11,6 +9,7 @@ import {V2Fixture} from "~test/fixtures/V2Fixture.sol";
 contract PublicResolverV2Test is V1Fixture, V2Fixture {
     PublicResolverV2 publicResolver;
 
+    address actor = makeAddr("actor");
     address friend = makeAddr("friend");
 
     function setUp() external {
@@ -23,27 +22,27 @@ contract PublicResolverV2Test is V1Fixture, V2Fixture {
         bytes32 node = _register("test");
 
         // call a setter
-        vm.prank(user);
-        publicResolver.setAddr(node, user);
+        vm.prank(testOwner);
+        publicResolver.setAddr(node, testOwner);
     }
 
     function test_canModifyName_setApprovalForAll() external {
         bytes32 node = _register("test");
 
-        vm.prank(user);
+        vm.prank(testOwner);
         publicResolver.setApprovalForAll(friend, true);
 
         assertTrue(publicResolver.canModifyName(node, friend));
 
         // call a setter
         vm.prank(friend);
-        publicResolver.setAddr(node, user);
+        publicResolver.setAddr(node, testOwner);
     }
 
     function test_canModifyName_approve() external {
         bytes32 node = _register("test");
 
-        vm.prank(user);
+        vm.prank(testOwner);
         publicResolver.approve(node, friend, true);
 
         assertTrue(publicResolver.canModifyName(node, friend));
@@ -51,15 +50,16 @@ contract PublicResolverV2Test is V1Fixture, V2Fixture {
 
         // call a setter
         vm.prank(friend);
-        publicResolver.setAddr(node, user);
+        publicResolver.setAddr(node, testOwner);
     }
 
     function test_canModifyName_notAuthorized(bytes32 node) external {
-        assertFalse(publicResolver.canModifyName(node, user));
+        assertFalse(publicResolver.canModifyName(node, testOwner));
 
         // call a setter
         vm.expectRevert();
-        publicResolver.setAddr(node, user);
+        vm.prank(actor);
+        publicResolver.setAddr(node, testOwner);
     }
 
     function _register(string memory label) internal returns (bytes32 node) {
@@ -67,18 +67,18 @@ contract PublicResolverV2Test is V1Fixture, V2Fixture {
         bytes memory name = this.registerWrappedETH2LD(label, 0);
         node = NameCoder.namehash(name, 0);
 
-        assertFalse(publicResolver.canModifyName(node, user), "before");
+        assertFalse(publicResolver.canModifyName(node, testOwner), "before");
 
         // register same name in v2
         ethRegistry.register(
             label,
-            user,
+            testOwner,
             IRegistry(address(0)),
             address(publicResolver),
             0,
             uint64(block.timestamp + 1 days)
         );
 
-        assertTrue(publicResolver.canModifyName(node, user), "after");
+        assertTrue(publicResolver.canModifyName(node, testOwner), "after");
     }
 }

--- a/contracts/test/unit/utils/PermissionedAddressSet.t.sol
+++ b/contracts/test/unit/utils/PermissionedAddressSet.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IEnhancedAccessControl} from "~src/access-control/interfaces/IEnhancedAccessControl.sol";
+import {
+    PermissionedAddressSet,
+    ROLE_APPROVE,
+    ROLE_APPROVE_ADMIN
+} from "~src/utils/PermissionedAddressSet.sol";
+import {MockHCAFactoryBasic} from "~test/mocks/MockHCAFactoryBasic.sol";
+
+contract PermissionedAddressSetTest is Test {
+    MockHCAFactoryBasic hcaFactory;
+    PermissionedAddressSet set;
+
+    address testAddr = makeAddr("something");
+    address friend = makeAddr("anotherAdmin");
+
+    function setUp() external {
+        hcaFactory = new MockHCAFactoryBasic();
+        set = new PermissionedAddressSet(hcaFactory, address(this));
+    }
+
+    function test_approve_notAuthorized() external {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                set.ROOT_RESOURCE(),
+                ROLE_APPROVE,
+                friend
+            )
+        );
+        vm.prank(friend);
+        set.approve(testAddr, true);
+    }
+
+    function test_approve_unchanged() external {
+        vm.expectRevert();
+        set.approve(testAddr, false);
+    }
+
+    function test_approve() external {
+        assertFalse(set.includes(testAddr));
+
+        vm.expectEmit();
+        emit PermissionedAddressSet.ApprovalChanged(testAddr, true, address(this));
+        set.approve(testAddr, true);
+
+        assertTrue(set.includes(testAddr));
+
+        vm.expectEmit();
+        emit PermissionedAddressSet.ApprovalChanged(testAddr, false, address(this));
+        set.approve(testAddr, false);
+
+        assertFalse(set.includes(testAddr));
+    }
+
+    function test_approve_multiple(bool[] calldata approved) external {
+        for (uint160 i; i < approved.length; ++i) {
+            if (approved[i]) {
+                set.approve(address(i), true);
+            }
+        }
+        for (uint160 i; i < approved.length; ++i) {
+            assertEq(set.includes(address(i)), approved[i]);
+        }
+    }
+
+    function test_approve_granted() external {
+        vm.expectRevert();
+        vm.prank(friend);
+        set.approve(testAddr, true);
+
+        set.grantRootRoles(ROLE_APPROVE, friend);
+
+        vm.prank(friend);
+        set.approve(testAddr, true);
+    }
+}

--- a/contracts/test/unit/utils/PermissionedAddressSet.t.sol
+++ b/contracts/test/unit/utils/PermissionedAddressSet.t.sol
@@ -4,11 +4,7 @@ pragma solidity ^0.8.13;
 import {Test} from "forge-std/Test.sol";
 
 import {IEnhancedAccessControl} from "~src/access-control/interfaces/IEnhancedAccessControl.sol";
-import {
-    PermissionedAddressSet,
-    ROLE_APPROVE,
-    ROLE_APPROVE_ADMIN
-} from "~src/utils/PermissionedAddressSet.sol";
+import {PermissionedAddressSet, ROLE_APPROVE} from "~src/utils/PermissionedAddressSet.sol";
 import {MockHCAFactoryBasic} from "~test/mocks/MockHCAFactoryBasic.sol";
 
 contract PermissionedAddressSetTest is Test {


### PR DESCRIPTION
- added `IAddressSet`
- added `PermissionedAddressSet` and tests &mdash; manages a set of addresses with EAC

---

- added `PublicResolverV2` which is like `PublicResolver` except `isAuthorized()` uses ENSv2
- added `PublicResolverV2.t.sol`
- added tests to `LockedMigrationController.t.sol`
- added deploy scripts
    * include `PublicResolverV1`  in set on devnet
- fixed e2e test for whitelisted PublicResolver
