### PR TITLE
Add `setters[]` to `PermissionedResolver.initialize()`

### DIFF
--- a/contracts/script/setup.ts
+++ b/contracts/script/setup.ts
@@ -564,11 +564,13 @@ export async function setupDevnet({
       account, // deployer
       admin = account.address,
       roles = ROLES.ALL,
+      setters = [],
       salt,
     }: {
       account: Account;
       admin?: Address;
       roles?: bigint;
+      setters?: Hex[];
       salt?: bigint | { ownedVersion: bigint };
     }) {
       if (typeof salt === "object") {
@@ -581,7 +583,7 @@ export async function setupDevnet({
           implAddress: v2.PermissionedResolverImpl.address,
           abi: v2.PermissionedResolverImpl.abi,
           functionName: "initialize",
-          args: [admin, roles],
+          args: [admin, roles, setters],
           salt,
         }),
       );

--- a/contracts/src/resolver/PermissionedResolver.sol
+++ b/contracts/src/resolver/PermissionedResolver.sol
@@ -22,7 +22,6 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import {EnhancedAccessControl} from "../access-control/EnhancedAccessControl.sol";
 import {IEnhancedAccessControl} from "../access-control/interfaces/IEnhancedAccessControl.sol";
-import {InvalidOwner} from "../CommonErrors.sol";
 import {HCAContext} from "../hca/HCAContext.sol";
 import {HCAContextUpgradeable} from "../hca/HCAContextUpgradeable.sol";
 import {HCAEquivalence} from "../hca/HCAEquivalence.sol";
@@ -197,12 +196,15 @@ contract PermissionedResolver is
     /// @notice Initialize the resolver.
     /// @param initialAccount The account granted roles.
     /// @param roleBitmap The roles granted to `initialAccount` on root.
-    function initialize(address initialAccount, uint256 roleBitmap) external initializer {
-        if (initialAccount == address(0)) {
-            revert InvalidOwner();
-        }
+    /// @param setters The setter calldata that avoids permission checks.
+    function initialize(
+        address initialAccount,
+        uint256 roleBitmap,
+        bytes[] calldata setters
+    ) external initializer {
         __UUPSUpgradeable_init();
         _grantRoles(ROOT_RESOURCE, roleBitmap, initialAccount, false);
+        multicall(setters);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -597,6 +599,17 @@ contract PermissionedResolver is
                 !hasRoles(PermissionedResolverLib.resource(0, part), roleBitmap, sender))
         ) {
             _checkRoles(PermissionedResolverLib.resource(recordId), roleBitmap, sender); // reverts with "widest" resource
+        }
+    }
+
+    /// @dev Avoid permission checks during initialization.
+    function _checkRoles(
+        uint256 resource,
+        uint256 roleBitmap,
+        address account
+    ) internal view override {
+        if (!_isInitializing()) {
+            super._checkRoles(resource, roleBitmap, account);
         }
     }
 

--- a/contracts/test/integration/fixtures/deployV2Fixture.ts
+++ b/contracts/test/integration/fixtures/deployV2Fixture.ts
@@ -1,5 +1,5 @@
 import type { NetworkConnection } from "hardhat/types/network";
-import { type Address, zeroAddress } from "viem";
+import { type Address, type Hex, zeroAddress } from "viem";
 import {
   DEPLOYMENT_ROLES,
   LOCAL_BATCH_GATEWAY_URL,
@@ -82,10 +82,12 @@ export async function deployV2Fixture(
     owner = walletClient.account.address,
     roles = ROLES.ALL,
     salt = idFromLabel(new Date().toISOString()),
+    setters = [],
   }: {
     owner?: Address;
     roles?: bigint;
     salt?: bigint;
+    setters?: Hex[];
   } = {}) {
     return deployVerifiableProxy({
       walletClient: await network.viem.getWalletClient(owner),
@@ -93,7 +95,7 @@ export async function deployV2Fixture(
       implAddress: PermissionedResolverImpl.address,
       abi: PermissionedResolverImpl.abi,
       functionName: "initialize",
-      args: [walletClient.account.address, roles],
+      args: [walletClient.account.address, roles, setters],
       salt,
     });
   }

--- a/contracts/test/unit/resolver/PermissionedResolver.t.sol
+++ b/contracts/test/unit/resolver/PermissionedResolver.t.sol
@@ -45,7 +45,9 @@ string constant TEST_STRING = "abc";
 contract PermissionedResolverTest is Test {
     uint256 constant DEFAULT_ROLES = EACBaseRolesLib.ALL_ROLES;
 
+    VerifiableFactory factory;
     MockHCAFactoryBasic hcaFactory;
+    PermissionedResolver implementation;
     PermissionedResolver resolver;
 
     address owner = makeAddr("owner");
@@ -59,9 +61,9 @@ contract PermissionedResolverTest is Test {
     bytes testAddress = abi.encodePacked(testAddr);
 
     function setUp() external {
-        VerifiableFactory factory = new VerifiableFactory();
+        factory = new VerifiableFactory();
         hcaFactory = new MockHCAFactoryBasic();
-        PermissionedResolver resolverImpl = new PermissionedResolver(hcaFactory);
+        implementation = new PermissionedResolver(hcaFactory);
 
         name1 = NameCoder.encode("test.eth");
         node1 = NameCoder.namehash(name1, 0);
@@ -71,10 +73,10 @@ contract PermissionedResolverTest is Test {
 
         bytes memory initData = abi.encodeCall(
             PermissionedResolver.initialize,
-            (owner, DEFAULT_ROLES)
+            (owner, DEFAULT_ROLES, new bytes[](0))
         );
         resolver = PermissionedResolver(
-            factory.deployProxy(address(resolverImpl), uint256(keccak256(initData)), initData)
+            factory.deployProxy(address(implementation), uint256(keccak256(initData)), initData)
         );
     }
 
@@ -88,6 +90,31 @@ contract PermissionedResolverTest is Test {
 
     function test_initialize() external view {
         assertTrue(resolver.hasRootRoles(DEFAULT_ROLES, owner), "roles");
+    }
+
+    function test_initialize_unowned() external {
+        bytes memory initData = abi.encodeCall(
+            PermissionedResolver.initialize,
+            (address(0), 0, new bytes[](0))
+        );
+        PermissionedResolver r = PermissionedResolver(
+            factory.deployProxy(address(implementation), uint256(keccak256(initData)), initData)
+        );
+        assertEq(r.roleCount(r.ROOT_RESOURCE()), 0);
+    }
+
+    function test_initalize_with_setters() external {
+        bytes[] memory m = new bytes[](2);
+        m[0] = abi.encodeCall(IResolverSetters.setName, (name1, TEST_STRING));
+        m[1] = abi.encodeCall(IResolverSetters.setContentHash, (name2, testAddress));
+
+        bytes memory initData = abi.encodeCall(PermissionedResolver.initialize, (address(0), 0, m));
+        PermissionedResolver r = PermissionedResolver(
+            factory.deployProxy(address(implementation), uint256(keccak256(initData)), initData)
+        );
+
+        assertEq(r.name(node1), TEST_STRING, "name()");
+        assertEq(r.contenthash(node2), testAddress, "contenthash()");
     }
 
     function test_upgrade() external {


### PR DESCRIPTION
**Idea**: pre-populate resolver on init ignoring granted permissions.

---

- added `bytes[] calldata setters` to `initialize()`
- removed `InvalidOwner` revert
- added tests
- updated devnet and fixtures
