### PR TITLE
Fix `LockedMigrationReceiver` to support Unlocked Emancipated 3LD+

### DIFF
--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -8,11 +8,14 @@ import {
     CANNOT_BURN_FUSES,
     CANNOT_TRANSFER,
     CANNOT_SET_RESOLVER,
-    CANNOT_CREATE_SUBDOMAIN
+    CANNOT_CREATE_SUBDOMAIN,
+    IS_DOT_ETH,
+    PARENT_CANNOT_CONTROL
 } from "@ens/contracts/wrapper/INameWrapper.sol";
 import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 
 import {InvalidOwner} from "../CommonErrors.sol";
+import {REGISTRATION_ROLE_BITMAP} from "../registrar/ETHRegistrar.sol";
 import {IRegistry} from "../registry/interfaces/IRegistry.sol";
 import {IWrapperRegistry} from "../registry/interfaces/IWrapperRegistry.sol";
 import {RegistryRolesLib} from "../registry/libraries/RegistryRolesLib.sol";
@@ -105,50 +108,64 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
             // see: V1Fixture.t.sol: `test_nameWrapper_labelTooShort()` and `test_nameWrapper_labelTooLong()`.
 
             (, uint32 fuses, uint64 expiry) = NAME_WRAPPER.getData(uint256(node));
-            if (!_isLocked(fuses)) {
-                revert LibMigration.NameNotLocked(uint256(node));
-            }
+            if (_isLocked(fuses)) {
+                if (NAME_WRAPPER.getApproved(uint256(node)) != address(0)) {
+                    revert LibMigration.FrozenTokenApproval(uint256(node));
+                }
 
-            if (NAME_WRAPPER.getApproved(uint256(node)) != address(0)) {
-                revert LibMigration.FrozenTokenApproval(uint256(node));
-            }
+                if ((fuses & CANNOT_SET_RESOLVER) == 0) {
+                    NAME_WRAPPER.setResolver(node, address(0)); // clear ENSv1 resolver
+                } else {
+                    md.resolver = _REGISTRY_V1.resolver(node); // replace with ENSv1 resolver
+                }
 
-            if ((fuses & CANNOT_SET_RESOLVER) == 0) {
-                NAME_WRAPPER.setResolver(node, address(0)); // clear ENSv1 resolver
-            } else {
-                md.resolver = _REGISTRY_V1.resolver(node); // replace with ENSv1 resolver
-            }
-
-            // create subregistry
-            IRegistry subregistry = IRegistry(
-                VERIFIABLE_FACTORY.deployProxy(
-                    WRAPPER_REGISTRY_IMPL,
-                    uint256(node),
-                    abi.encodeCall(
-                        IWrapperRegistry.initialize,
-                        (
-                            node,
-                            parentRegistry,
-                            md.label,
-                            md.owner,
-                            _subregistryRoleBitmapFromFuses(fuses)
+                // create subregistry
+                IRegistry subregistry = IRegistry(
+                    VERIFIABLE_FACTORY.deployProxy(
+                        WRAPPER_REGISTRY_IMPL,
+                        uint256(node),
+                        abi.encodeCall(
+                            IWrapperRegistry.initialize,
+                            (
+                                node,
+                                parentRegistry,
+                                md.label,
+                                md.owner,
+                                _subregistryRoleBitmapFromFuses(fuses)
+                            )
                         )
                     )
-                )
-            );
+                );
 
-            // add name to ENSv2
-            // PermissionedRegistry._register() => CannotSetPastExpiry :: see expiry check
-            // PermissionedRegistry._register() => LabelAlreadyRegistered :: only have ROLE_REGISTER_RESERVED
-            // ERC1155._safeTransferFrom() => ERC1155InvalidReceiver :: see owner check
-            _inject(
-                md.label,
-                md.owner,
-                subregistry,
-                md.resolver,
-                _tokenRoleBitmapFromFuses(fuses),
-                expiry
-            );
+                // add name to ENSv2
+                // PermissionedRegistry._register() => CannotSetPastExpiry :: see expiry check
+                // PermissionedRegistry._register() => LabelAlreadyRegistered :: only have ROLE_REGISTER_RESERVED
+                // ERC1155._safeTransferFrom() => ERC1155InvalidReceiver :: see owner check
+                _inject(
+                    md.label,
+                    md.owner,
+                    subregistry,
+                    md.resolver,
+                    _tokenRoleBitmapFromFuses(fuses),
+                    expiry
+                );
+            } else if (_isEmancipatedChild(fuses)) {
+                NAME_WRAPPER.unwrap(parentNode, labelHash, address(this));
+
+                _REGISTRY_V1.setResolver(node, address(0)); // clear ENSv1 resolver
+
+                // same as UnlockedMigrationController
+                _inject(
+                    md.label,
+                    md.owner,
+                    md.subregistry,
+                    md.resolver,
+                    REGISTRATION_ROLE_BITMAP,
+                    expiry
+                );
+            } else {
+                revert LibMigration.NameNotLocked(uint256(node));
+            }
         }
     }
 
@@ -169,12 +186,19 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
     function _isMigratableChild(string memory label) internal view returns (bool) {
         bytes32 node = NameCoder.namehash(getWrappedNode(), keccak256(bytes(label)));
         (address ownerV1, uint32 fuses, ) = NAME_WRAPPER.getData(uint256(node));
-        return ownerV1 != address(this) && _isLocked(fuses);
+        return ownerV1 != address(0) && ownerV1 != address(this) && _isEmancipatedChild(fuses);
     }
 
     /// @dev Returns `true` if the NameWrapper token fuses are not frozen.
     function _notFrozen(uint32 fuses) internal pure returns (bool) {
         return (fuses & CANNOT_BURN_FUSES) == 0;
+    }
+
+    /// @dev Returns `true` if the NameWrapper token is emancipated and not 2LD .eth.
+    function _isEmancipatedChild(uint32 fuses) internal pure returns (bool) {
+        // PARENT_CANNOT_CONTROL must be set for the entire ancestory.
+        // see: V1Fixture.t.sol: `test_nameWrapper_PARENT_CANNOT_CONTROL_withoutParent()`
+        return (fuses & (IS_DOT_ETH | PARENT_CANNOT_CONTROL)) == PARENT_CANNOT_CONTROL;
     }
 
     /// @dev Convert fuses to equivalent subregistry root roles.

--- a/contracts/test/e2e/migration.test.ts
+++ b/contracts/test/e2e/migration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "bun:test";
-import type { AbiParameter, AbiParameterToPrimitiveType } from "abitype";
 import {
+  type AbiParameter,
+  type AbiParameterToPrimitiveType,
   type Account,
   type Address,
   encodeAbiParameters,
@@ -76,7 +77,8 @@ describe("Migration", () => {
   type MigrateArgs = {
     target: Address;
     sender?: Account;
-    data?: Hex | Partial<MigrationData>;
+    rawData?: Hex;
+    data?: Partial<MigrationData>;
   };
 
   abstract class TokenV1 {
@@ -113,7 +115,9 @@ describe("Migration", () => {
     }
     async checkMigrated({
       owner = this.account.address,
-    }: { owner?: Address } = {}) {
+    }: {
+      owner?: Address;
+    } = {}) {
       const parentRegistry = await env.findPermissionedRegistry(
         getParentName(this.name),
       );
@@ -156,9 +160,7 @@ describe("Migration", () => {
             this.account.address,
             args.target ?? env.v2.UnlockedMigrationController.address,
             this.tokenId,
-            typeof args.data === "string"
-              ? args.data
-              : encodeMigrationData(await this.makeData(args.data)),
+            args.rawData ?? encodeMigrationData(await this.makeData(args.data)),
           ],
           { account: args.sender ?? this.account },
         ),
@@ -228,9 +230,7 @@ describe("Migration", () => {
             args.target,
             this.tokenId,
             1n,
-            typeof args.data === "string"
-              ? args.data
-              : encodeMigrationData(await this.makeData(args.data)),
+            args.rawData ?? encodeMigrationData(await this.makeData(args.data)),
           ],
           { account: args.sender ?? this.account },
         ),
@@ -447,7 +447,7 @@ describe("Migration", () => {
     it("invalid data", async () => {
       const unwrapped = await registerUnwrapped();
       expect(
-        unwrapped.migrate({ data: "0x1234" }), // wrong
+        unwrapped.migrate({ rawData: "0x1234" }), // wrong
       ).rejects.toThrow("InvalidData");
     });
 
@@ -503,7 +503,7 @@ describe("Migration", () => {
       expect(
         unlocked.migrate({
           target: env.v2.UnlockedMigrationController.address,
-          data: "0x1234", // wrong
+          rawData: "0x1234", // wrong
         }),
       ).rejects.toThrow("InvalidData");
     });
@@ -585,6 +585,24 @@ describe("Migration", () => {
       await lockedChild.checkResolution();
     });
 
+    it("migrate detached child", async () => {
+      const locked = await registerWrapped({ fuses: FUSES.CANNOT_UNWRAP });
+      const detachedChild = await locked.createChild({
+        fuses: FUSES.PARENT_CANNOT_CONTROL,
+      });
+      await detachedChild.setupPublicResolver();
+      await detachedChild.checkResolution();
+      await locked.migrate({
+        target: env.v2.LockedMigrationController.address,
+      });
+      const lockedRegistry = locked.wrapperRegistry();
+      await detachedChild.migrate({
+        target: lockedRegistry.address,
+      });
+      await detachedChild.checkMigrated();
+      await detachedChild.checkResolution();
+    });
+
     it("unmigrated locked child", async () => {
       const locked = await registerWrapped({ fuses: FUSES.CANNOT_UNWRAP });
       const lockedChild = await locked.createChild({
@@ -606,6 +624,35 @@ describe("Migration", () => {
         lockedRegistry.write.register([
           lockedChild.label,
           lockedChild.account.address,
+          zeroAddress,
+          zeroAddress,
+          0n,
+          MAX_EXPIRY,
+        ]),
+      ).rejects.toThrow("NameRequiresMigration");
+    });
+
+    it("unmigrated detached child", async () => {
+      const locked = await registerWrapped({ fuses: FUSES.CANNOT_UNWRAP });
+      const detachedChild = await locked.createChild({
+        fuses: FUSES.PARENT_CANNOT_CONTROL,
+      });
+      await locked.migrate({
+        target: env.v2.LockedMigrationController.address,
+      });
+      const lockedRegistry = locked.wrapperRegistry();
+
+      // name has fallback resolver
+      const resolver = await lockedRegistry.read.getResolver([
+        detachedChild.label,
+      ]);
+      expectVar({ resolver }).toEqualAddress(env.v2.ENSV1Resolver.address);
+
+      // name cannot be registered
+      expect(
+        lockedRegistry.write.register([
+          detachedChild.label,
+          detachedChild.account.address,
           zeroAddress,
           zeroAddress,
           0n,
@@ -733,7 +780,7 @@ describe("Migration", () => {
       expect(
         locked.migrate({
           target: env.v2.LockedMigrationController.address,
-          data: "0x1234", // wrong
+          rawData: "0x1234", // wrong
         }),
       ).rejects.toThrow("InvalidData");
     });

--- a/contracts/test/fixtures/V1Fixture.t.sol
+++ b/contracts/test/fixtures/V1Fixture.t.sol
@@ -124,10 +124,10 @@ contract V1FixtureTest is V1Fixture {
     function test_nameWrapper_PARENT_CANNOT_CONTROL_via_setFuses() external {
         bytes memory name = registerWrappedETH2LD("test", 0);
         (bytes32 labelhash, ) = NameCoder.readLabel(name, 0);
-        vm.startPrank(user);
+        vm.prank(user);
         nameWrapper.setFuses(NameCoder.namehash(name, 0), uint16(PARENT_CANNOT_CONTROL));
+        vm.prank(user);
         nameWrapper.unwrapETH2LD(labelhash, user, user);
-        vm.stopPrank();
     }
 
     function test_nameWrapper_PARENT_CANNOT_CONTROL_via_wrap() external {
@@ -139,10 +139,14 @@ contract V1FixtureTest is V1Fixture {
             PARENT_CANNOT_CONTROL
         );
         (bytes32 labelhash, ) = NameCoder.readLabel(name, 0);
-        vm.startPrank(user);
-        nameWrapper.setFuses(NameCoder.namehash(name, 0), uint16(PARENT_CANNOT_CONTROL));
+        vm.prank(user);
         nameWrapper.unwrap(NameCoder.namehash(parentName, 0), labelhash, user);
-        vm.stopPrank();
+    }
+
+    function test_nameWrapper_PARENT_CANNOT_CONTROL_withoutParent() external {
+        bytes memory parentName = registerWrappedETH2LD("test", 0);
+        vm.expectRevert();
+        this.createWrappedChild(parentName, "sub", address(0), PARENT_CANNOT_CONTROL);
     }
 
     function test_nameWrapper_CANNOT_BURN_FUSES_via_wrap() external {

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -603,7 +603,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         registry2.renew(tokenId, expiry + 1);
     }
 
-    function test_migrate_emancipatedChildren() external {
+    function test_migrate_emancipatedLockedChildren() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         bytes memory name3 = createWrappedChild(
             name2,
@@ -661,6 +661,87 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         IRegistry registry3 = registry2.getSubregistry(data3.label);
         assertTrue(
             ERC165Checker.supportsInterface(address(registry3), type(IWrapperRegistry).interfaceId),
+            "registry3"
+        );
+
+        // check migrated 3LD child
+        vm.expectRevert(
+            abi.encodeWithSelector(IStandardRegistry.LabelAlreadyRegistered.selector, data3.label)
+        );
+        vm.prank(friend);
+        registry2.register(data3.label, user, IRegistry(address(0)), address(0), 0, _soon());
+
+        // check unmigrated 3LD child
+        vm.expectRevert(abi.encodeWithSelector(LibMigration.NameRequiresMigration.selector));
+        vm.prank(friend);
+        registry2.register(
+            NameCoder.firstLabel(name3unmigrated),
+            friend,
+            IRegistry(address(0)),
+            address(0),
+            0,
+            _soon()
+        );
+
+        vm.prank(friend);
+        nameWrapper.setResolver(NameCoder.namehash(name3unmigrated, 0), testResolver);
+        checkResolution(name3unmigrated, testResolver, address(ensV1Resolver));
+    }
+
+    function test_migrate_emancipatedUnlockedChildren() external {
+        bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        bytes memory name3 = createWrappedChild(name2, "sub", friend, PARENT_CANNOT_CONTROL);
+        bytes memory name3unmigrated = createWrappedChild(
+            name2,
+            "unmigrated",
+            friend,
+            PARENT_CANNOT_CONTROL
+        );
+
+        // migrate 2LD
+        LibMigration.Data memory data2 = _makeData(name2);
+        vm.prank(user);
+        nameWrapper.safeTransferFrom(
+            user,
+            address(migrationController),
+            uint256(NameCoder.namehash(name2, 0)),
+            1,
+            abi.encode(data2)
+        );
+        assertEq(
+            ethRegistry.ownerOf(ethRegistry.getTokenId(LibLabel.id(data2.label))),
+            data2.owner,
+            "owner2"
+        );
+        IWrapperRegistry registry2 = IWrapperRegistry(
+            address(ethRegistry.getSubregistry(data2.label))
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(registry2), type(IWrapperRegistry).interfaceId),
+            "registry2"
+        );
+
+        // migrate 3LD
+        LibMigration.Data memory data3 = _makeData(name3);
+        data3.subregistry = testRegistry; // override
+        vm.prank(friend);
+        nameWrapper.safeTransferFrom(
+            friend,
+            address(registry2),
+            uint256(NameCoder.namehash(name3, 0)),
+            1,
+            abi.encode(data3)
+        );
+        assertEq(registry2.getResolver(data3.label), data3.resolver, "resolver3");
+        checkResolution(name3, address(ensV2Resolver), data3.resolver);
+        assertEq(
+            registry2.ownerOf(registry2.getTokenId(LibLabel.id(data3.label))),
+            data3.owner,
+            "owner3"
+        );
+        assertEq(
+            address(registry2.getSubregistry(data3.label)),
+            address(testRegistry),
             "registry3"
         );
 

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -523,7 +523,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
-    function test_migrate_lockedChildren() external {
+    function test_migrate_cannotCreateChildren() external {
         bytes memory name = registerWrappedETH2LD(
             testLabel,
             CANNOT_UNWRAP | CANNOT_CREATE_SUBDOMAIN
@@ -603,7 +603,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         registry2.renew(tokenId, expiry + 1);
     }
 
-    function test_migrate_emancipatedLockedChildren() external {
+    function test_migrate_lockedChildren() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         bytes memory name3 = createWrappedChild(
             name2,
@@ -688,7 +688,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         checkResolution(name3unmigrated, testResolver, address(ensV1Resolver));
     }
 
-    function test_migrate_emancipatedUnlockedChildren() external {
+    function test_migrate_detachedChildren() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         bytes memory name3 = createWrappedChild(name2, "sub", friend, PARENT_CANNOT_CONTROL);
         bytes memory name3unmigrated = createWrappedChild(


### PR DESCRIPTION
- changed `LockedWrapperReceiver`
    * added `_isEmancipatedChild()`
    * changed `_isMigratableChild()` to check `_isEmancipatedChild()` instead of `_isLocked()`
    * changed `_migrateWrapped()` to support `!_isLocked()` but `_isEmancipatedChild()`
- added solidity test
- added e2e test