### PR TITLE
Add `Graveyard`

### DIFF
--- a/contracts/deploy/00_Graveyard.ts
+++ b/contracts/deploy/00_Graveyard.ts
@@ -2,17 +2,17 @@ import { artifacts, execute } from "@rocketh";
 
 export default execute(
   async ({ get, deploy, namedAccounts: { deployer } }) => {
-    const ensRegistryV1 =
-      get<(typeof artifacts.ENSRegistry)["abi"]>("ENSRegistry");
+    const nameWrapper =
+      get<(typeof artifacts.NameWrapper)["abi"]>("NameWrapper");
 
     await deploy("Graveyard", {
       account: deployer,
       artifact: artifacts.Graveyard,
-      args: [ensRegistryV1.address],
+      args: [nameWrapper.address],
     });
   },
   {
     tags: ["Graveyard", "v2"],
-    dependencies: ["ENSRegistry"],
+    dependencies: ["NameWrapper"],
   },
 );

--- a/contracts/deploy/00_Graveyard.ts
+++ b/contracts/deploy/00_Graveyard.ts
@@ -1,0 +1,18 @@
+import { artifacts, execute } from "@rocketh";
+
+export default execute(
+  async ({ get, deploy, namedAccounts: { deployer } }) => {
+    const ensRegistryV1 =
+      get<(typeof artifacts.ENSRegistry)["abi"]>("ENSRegistry");
+
+    await deploy("Graveyard", {
+      account: deployer,
+      artifact: artifacts.Graveyard,
+      args: [ensRegistryV1.address],
+    });
+  },
+  {
+    tags: ["Graveyard", "v2"],
+    dependencies: ["ENSRegistry"],
+  },
+);

--- a/contracts/deploy/02_UnlockedMigrationController.ts
+++ b/contracts/deploy/02_UnlockedMigrationController.ts
@@ -6,13 +6,15 @@ export default execute(
     const nameWrapper =
       get<(typeof artifacts.NameWrapper)["abi"]>("NameWrapper");
 
+    const graveyard = get<(typeof artifacts.Graveyard)["abi"]>("Graveyard");
+
     const ethRegistry =
       get<(typeof artifacts.PermissionedRegistry)["abi"]>("ETHRegistry");
 
     const migrationController = await deploy("UnlockedMigrationController", {
       account: deployer,
       artifact: artifacts.UnlockedMigrationController,
-      args: [nameWrapper.address, ethRegistry.address],
+      args: [nameWrapper.address, graveyard.address, ethRegistry.address],
     });
 
     // see: UnlockedMigrationController.t.sol
@@ -27,6 +29,6 @@ export default execute(
   },
   {
     tags: ["UnlockedMigrationController", "v2"],
-    dependencies: ["NameWrapper", "ETHRegistry"],
+    dependencies: ["NameWrapper", "Graveyard", "ETHRegistry"],
   },
 );

--- a/contracts/deploy/03_WrapperRegistryImpl.ts
+++ b/contracts/deploy/03_WrapperRegistryImpl.ts
@@ -5,6 +5,8 @@ export default execute(
     const nameWrapper =
       get<(typeof artifacts.NameWrapper)["abi"]>("NameWrapper");
 
+    const graveyard = get<(typeof artifacts.Graveyard)["abi"]>("Graveyard");
+
     const verifiableFactory =
       get<(typeof artifacts.VerifiableFactory)["abi"]>("VerifiableFactory");
 
@@ -29,6 +31,7 @@ export default execute(
       artifact: artifacts.WrapperRegistry,
       args: [
         nameWrapper.address,
+        graveyard.address,
         verifiableFactory.address,
         ensV1Resolver.address,
         hcaFactory.address,
@@ -42,11 +45,12 @@ export default execute(
     tags: ["WrapperRegistryImpl", "v2"],
     dependencies: [
       "NameWrapper",
+      "Graveyard",
       "VerifiableFactory",
       "ENSV1Resolver",
-      "ApprovedUpgradeGate",
       "HCAFactory",
-      "RegistryMetadata",
+      "SimpleRegistryMetadata",
+      "ApprovedUpgradeGate",
       "LabelStore",
     ],
   },

--- a/contracts/deploy/04_LockedMigrationController.ts
+++ b/contracts/deploy/04_LockedMigrationController.ts
@@ -6,6 +6,8 @@ export default execute(
     const nameWrapper =
       get<(typeof artifacts.NameWrapper)["abi"]>("NameWrapper");
 
+    const graveyard = get<(typeof artifacts.Graveyard)["abi"]>("Graveyard");
+
     const ethRegistry =
       get<(typeof artifacts.PermissionedRegistry)["abi"]>("ETHRegistry");
 
@@ -21,6 +23,7 @@ export default execute(
       artifact: artifacts.LockedMigrationController,
       args: [
         nameWrapper.address,
+        graveyard.address,
         ethRegistry.address,
         verifiableFactory.address,
         wrapperRegistryImpl.address,
@@ -41,6 +44,7 @@ export default execute(
     tags: ["LockedMigrationController", "v2"],
     dependencies: [
       "NameWrapper",
+      "Graveyard",
       "ETHRegistry",
       "VerifiableFactory",
       "WrapperRegistryImpl",

--- a/contracts/script/setup.ts
+++ b/contracts/script/setup.ts
@@ -261,6 +261,11 @@ export async function setupDevnet({
         address: rocketh.get("DefaultReverseRegistrarHCAAdapter").address,
         client,
       }),
+      Graveyard: getContract({
+        abi: artifacts.Graveyard.abi,
+        address: rocketh.get("Graveyard").address,
+        client,
+      }),
     };
 
     const v1 = {

--- a/contracts/src/migration/AbstractWrapperReceiver.sol
+++ b/contracts/src/migration/AbstractWrapperReceiver.sol
@@ -2,10 +2,17 @@
 pragma solidity >=0.8.13;
 
 import {ENS} from "@ens/contracts/registry/ENS.sol";
-import {INameWrapper, CANNOT_UNWRAP} from "@ens/contracts/wrapper/INameWrapper.sol";
-import {IERC1155Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
-import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
-import {ERC165, IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
+import {
+    IERC1155Errors
+} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {
+    IERC1155Receiver
+} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {
+    ERC165,
+    IERC165
+} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 import {UnauthorizedCaller} from "../CommonErrors.sol";
 import {WrappedErrorLib} from "../utils/WrappedErrorLib.sol";
@@ -23,7 +30,7 @@ import {LibMigration} from "./libraries/LibMigration.sol";
 /// 1. UnlockedMigrationController accepts unlocked tokens.
 /// 2. LockedWrapperReceiver accepts locked tokens.
 ///
-/// `_isLocked()` determines lock status.
+/// `LibMigration.isLocked()` determines lock status.
 ///
 abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
     ////////////////////////////////////////////////////////////////////////
@@ -58,7 +65,9 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
     ///      Reverts wrapped errors for use inside of legacy IERC1155Receiver handler.
     modifier withData(bytes calldata data, uint256 minimumSize) {
         if (data.length < minimumSize) {
-            WrappedErrorLib.wrapAndRevert(abi.encodeWithSelector(LibMigration.InvalidData.selector));
+            WrappedErrorLib.wrapAndRevert(
+                abi.encodeWithSelector(LibMigration.InvalidData.selector)
+            );
         }
         _;
     }
@@ -76,13 +85,9 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
     }
 
     /// @inheritdoc IERC165
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC165, IERC165)
-        returns (bool)
-    {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC165, IERC165) returns (bool) {
         return
             interfaceId == type(IERC1155Receiver).interfaceId ||
             super.supportsInterface(interfaceId);
@@ -145,7 +150,10 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
         // https://github.com/ensdomains/ens-contracts/blob/staging/contracts/wrapper/ERC1155Fuse.sol#L162
         // if (amounts[i] != 1) { ... } => never happens :: caught by ERC1155Fuse
         // https://github.com/ensdomains/ens-contracts/blob/staging/contracts/wrapper/ERC1155Fuse.sol#L182
-        LibMigration.Data[] memory mds = abi.decode(data, (LibMigration.Data[])); // reverts if invalid
+        LibMigration.Data[] memory mds = abi.decode(
+            data,
+            (LibMigration.Data[])
+        ); // reverts if invalid
         try this.finishERC1155Migration(ids, mds) {
             return this.onERC1155BatchReceived.selector;
         } catch (bytes memory reason) {
@@ -161,14 +169,18 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
     ///
     /// @param ids The NameWrapper token IDs (namehashes) of the names being migrated.
     /// @param mds The migration parameters for each name, indexed in parallel with `ids`.
-    function finishERC1155Migration(uint256[] calldata ids, LibMigration.Data[] calldata mds)
-        external
-    {
+    function finishERC1155Migration(
+        uint256[] calldata ids,
+        LibMigration.Data[] calldata mds
+    ) external {
         if (msg.sender != address(this)) {
             revert UnauthorizedCaller(msg.sender);
         }
         if (ids.length != mds.length) {
-            revert IERC1155Errors.ERC1155InvalidArrayLength(ids.length, mds.length);
+            revert IERC1155Errors.ERC1155InvalidArrayLength(
+                ids.length,
+                mds.length
+            );
         }
         _migrateWrapped(ids, mds);
     }
@@ -180,14 +192,8 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
     /// @dev Migrate received NameWrapper tokens.
     ///      Token owner is this contract.
     ///      Token is not expired.
-    function _migrateWrapped(uint256[] calldata ids, LibMigration.Data[] calldata mds)
-        internal
-        virtual;
-
-    /// @dev Returns `true` if the NameWrapper token is locked.
-    function _isLocked(uint32 fuses) internal pure returns (bool) {
-        // PARENT_CANNOT_CONTROL is required to set CANNOT_UNWRAP, so CANNOT_UNWRAP is sufficient
-        // see: V1Fixture.t.sol: `test_nameWrapper_CANNOT_UNWRAP_requires_PARENT_CANNOT_CONTROL()`
-        return (fuses & CANNOT_UNWRAP) != 0;
-    }
+    function _migrateWrapped(
+        uint256[] calldata ids,
+        LibMigration.Data[] calldata mds
+    ) internal virtual;
 }

--- a/contracts/src/migration/AbstractWrapperReceiver.sol
+++ b/contracts/src/migration/AbstractWrapperReceiver.sol
@@ -3,16 +3,9 @@ pragma solidity >=0.8.13;
 
 import {ENS} from "@ens/contracts/registry/ENS.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
-import {
-    IERC1155Errors
-} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
-import {
-    IERC1155Receiver
-} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
-import {
-    ERC165,
-    IERC165
-} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {IERC1155Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {ERC165, IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 import {UnauthorizedCaller} from "../CommonErrors.sol";
 import {WrappedErrorLib} from "../utils/WrappedErrorLib.sol";
@@ -65,9 +58,7 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
     ///      Reverts wrapped errors for use inside of legacy IERC1155Receiver handler.
     modifier withData(bytes calldata data, uint256 minimumSize) {
         if (data.length < minimumSize) {
-            WrappedErrorLib.wrapAndRevert(
-                abi.encodeWithSelector(LibMigration.InvalidData.selector)
-            );
+            WrappedErrorLib.wrapAndRevert(abi.encodeWithSelector(LibMigration.InvalidData.selector));
         }
         _;
     }
@@ -85,9 +76,13 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
     }
 
     /// @inheritdoc IERC165
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC165, IERC165) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC165, IERC165)
+        returns (bool)
+    {
         return
             interfaceId == type(IERC1155Receiver).interfaceId ||
             super.supportsInterface(interfaceId);
@@ -150,10 +145,7 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
         // https://github.com/ensdomains/ens-contracts/blob/staging/contracts/wrapper/ERC1155Fuse.sol#L162
         // if (amounts[i] != 1) { ... } => never happens :: caught by ERC1155Fuse
         // https://github.com/ensdomains/ens-contracts/blob/staging/contracts/wrapper/ERC1155Fuse.sol#L182
-        LibMigration.Data[] memory mds = abi.decode(
-            data,
-            (LibMigration.Data[])
-        ); // reverts if invalid
+        LibMigration.Data[] memory mds = abi.decode(data, (LibMigration.Data[])); // reverts if invalid
         try this.finishERC1155Migration(ids, mds) {
             return this.onERC1155BatchReceived.selector;
         } catch (bytes memory reason) {
@@ -169,18 +161,14 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
     ///
     /// @param ids The NameWrapper token IDs (namehashes) of the names being migrated.
     /// @param mds The migration parameters for each name, indexed in parallel with `ids`.
-    function finishERC1155Migration(
-        uint256[] calldata ids,
-        LibMigration.Data[] calldata mds
-    ) external {
+    function finishERC1155Migration(uint256[] calldata ids, LibMigration.Data[] calldata mds)
+        external
+    {
         if (msg.sender != address(this)) {
             revert UnauthorizedCaller(msg.sender);
         }
         if (ids.length != mds.length) {
-            revert IERC1155Errors.ERC1155InvalidArrayLength(
-                ids.length,
-                mds.length
-            );
+            revert IERC1155Errors.ERC1155InvalidArrayLength(ids.length, mds.length);
         }
         _migrateWrapped(ids, mds);
     }
@@ -192,8 +180,7 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
     /// @dev Migrate received NameWrapper tokens.
     ///      Token owner is this contract.
     ///      Token is not expired.
-    function _migrateWrapped(
-        uint256[] calldata ids,
-        LibMigration.Data[] calldata mds
-    ) internal virtual;
+    function _migrateWrapped(uint256[] calldata ids, LibMigration.Data[] calldata mds)
+        internal
+        virtual;
 }

--- a/contracts/src/migration/AbstractWrapperReceiver.sol
+++ b/contracts/src/migration/AbstractWrapperReceiver.sol
@@ -33,6 +33,9 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
     /// @notice The ENSv1 `NameWrapper` contract that holds wrapped names as ERC1155 tokens.
     INameWrapper public immutable NAME_WRAPPER;
 
+    /// @notice The ENSv1 `BaseRegistrar` token graveyard.
+    address public immutable GRAVEYARD;
+
     /// @dev The ENSv1 `ENSRegistry` contract.
     ENS internal immutable _REGISTRY_V1;
 
@@ -65,8 +68,10 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
     ////////////////////////////////////////////////////////////////////////
 
     /// @param nameWrapper The ENSv1 `NameWrapper` contract.
-    constructor(INameWrapper nameWrapper) {
+    /// @param graveyard The ENSv1 `BaseRegistrar` token graveyard.
+    constructor(INameWrapper nameWrapper, address graveyard) {
         NAME_WRAPPER = nameWrapper;
+        GRAVEYARD = graveyard;
         _REGISTRY_V1 = nameWrapper.ens();
     }
 

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
+import {
+    BaseRegistrarImplementation
+} from "@ens/contracts/ethregistrar/BaseRegistrarImplementation.sol";
 import {IBaseRegistrar} from "@ens/contracts/ethregistrar/IBaseRegistrar.sol";
 import {ENS} from "@ens/contracts/registry/ENS.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
@@ -8,12 +11,30 @@ import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
 import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
 import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 
+import {LibMigration} from "./libraries/LibMigration.sol";
+
 /// @notice The ENSv1 ETHRegistrarController for ENSv2 launch which becomes the burn address for migrated tokens.
 ///
 /// 1. Claim any expired ENSv1 name and assign ownership to this contract.
 /// 2. Clear the registry for any owned token.
 ///
 contract Graveyard is ERC721Holder, ERC1155Holder {
+    ////////////////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev The internal states of registry ownership.
+    enum State {
+        ROOT,
+        ETH,
+        OWNED,
+        LOCKED
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Constants
+    ////////////////////////////////////////////////////////////////////////
+
     /// @notice The ENSv1 `NameWrapper` contract.
     INameWrapper public immutable NAME_WRAPPER;
 
@@ -22,6 +43,9 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
 
     /// @dev The ENSv1 `BaseRegistrar` contract.
     IBaseRegistrar internal immutable _REGISTRAR_V1;
+
+    /// @dev Same as `BaseRegistrarImplementation.GRACE_PERIOD()`.
+    uint256 internal immutable _GRACE_PERIOD;
 
     ////////////////////////////////////////////////////////////////////////
     // Initialization
@@ -33,57 +57,87 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
         NAME_WRAPPER = nameWrapper;
         _REGISTRY_V1 = nameWrapper.ens();
         _REGISTRAR_V1 = nameWrapper.registrar();
+        _GRACE_PERIOD = BaseRegistrarImplementation(address(_REGISTRAR_V1)).GRACE_PERIOD();
     }
 
     ////////////////////////////////////////////////////////////////////////
     // Implementation
     ////////////////////////////////////////////////////////////////////////
 
-    /// @notice Clear registry for unwrapped names with automatic temporary registration.
-    /// @param parentNodes The array of unwrapped parent nodes.
-    /// @param labelHashes The array of child labelhashes.
-    function clearUnwrapped(
-        bytes32[] calldata parentNodes,
-        bytes32[] calldata labelHashes
-    ) external {
-        for (uint256 i; i < parentNodes.length; ++i) {
-            bytes32 parentNode = parentNodes[i];
-            bytes32 labelHash = labelHashes[i];
-            if (parentNode == NameCoder.ETH_NODE) {
-                bytes32 node = NameCoder.namehash(parentNode, labelHash);
-                if (_REGISTRY_V1.owner(node) != address(this)) {
-                    _REGISTRAR_V1.register(uint256(labelHash), address(this), 1);
-                }
-                _REGISTRY_V1.setResolver(node, address(0));
-            } else {
-                _REGISTRY_V1.setSubnodeRecord(parentNode, labelHash, address(this), address(0), 0);
-            }
+    /// @notice Clear registry for migrated names.
+    /// @param names The array of names to clear.
+    function clear(bytes[] calldata names) external {
+        for (uint256 i; i < names.length; ++i) {
+            _clear(names[i], 0);
         }
     }
 
-    /// @notice Clear registry for wrapped children with automatic unwrap.
-    /// @param parentNodes The array of wrapped parent nodes.
-    /// @param labels The array of child labels.
-    function clearWrappedChildren(
-        bytes32[] calldata parentNodes,
-        string[] calldata labels
-    ) external {
-        for (uint256 i; i < parentNodes.length; ++i) {
-            bytes32 parentNode = parentNodes[i];
-            string calldata label = labels[i];
-            //bytes32 node = NAME_WRAPPER.setSubnodeRecord(
+    ////////////////////////////////////////////////////////////////////////
+    // Internal Functions
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Recursively clear ancestor namespace.
+    function _clear(
+        bytes calldata name,
+        uint256 offset
+    ) internal returns (bytes32 node, State state) {
+        (bytes32 labelHash, uint256 nextOffset) = NameCoder.readLabel(name, offset);
+        if (labelHash == bytes32(0)) {
+            return (bytes32(0), State.ROOT);
+        }
+        bytes32 parentNode;
+        (parentNode, state) = _clear(name, nextOffset);
+        node = NameCoder.namehash(parentNode, labelHash);
+        if (state == State.ROOT) {
+            require(node == NameCoder.ETH_NODE);
+            return (node, State.ETH);
+        } else if (state == State.ETH) {
+            address owner = _REGISTRY_V1.owner(node);
+            if (owner == address(this)) {
+                // resolver is cleared by migration
+                return (node, State.OWNED);
+            }
+            uint32 fuses;
+            (owner, fuses, ) = NAME_WRAPPER.getData(uint256(node));
+            if (LibMigration.isLocked(fuses)) {
+                require(owner == address(this));
+                // resolver is cleared by migration
+                return (node, State.LOCKED);
+            }
+            _REGISTRAR_V1.register(
+                uint256(labelHash),
+                address(this),
+                type(uint64).max - block.timestamp - _GRACE_PERIOD // max duration?
+            );
+            // lock expired? so clear it
+            if (_REGISTRY_V1.resolver(node) != address(0)) {
+                _REGISTRY_V1.setResolver(node, address(0));
+            }
+            return (node, State.OWNED);
+        } else if (state == State.OWNED) {
+            _REGISTRY_V1.setSubnodeRecord(parentNode, labelHash, address(this), address(0), 0);
+            return (node, State.OWNED);
+        } else {
+            (address owner, uint32 fuses, ) = NAME_WRAPPER.getData(uint256(node));
+            if (owner == address(this)) {
+                // resolver is cleared by migration
+                if (LibMigration.isLocked(fuses)) {
+                    return (node, State.LOCKED);
+                } else if (LibMigration.isEmancipatedChild(fuses)) {
+                    return (node, State.OWNED);
+                }
+            }
             NAME_WRAPPER.setSubnodeRecord(
                 parentNode,
-                label,
+                string(name[offset + 1:nextOffset]),
                 address(this), // owner
                 address(0), // resolver
                 0, // ttl
                 0, // fuses
-                0 // expiry
-            );
-            //(, uint32 fuses, ) = NAME_WRAPPER.getData(uint256(node));
-            //if (!LibMigration.isLocked(fuses)) {
-            NAME_WRAPPER.unwrap(parentNode, keccak256(bytes(label)), address(this));
+                0 // expiry (uses min)
+            ); // reverts if not migrated
+            NAME_WRAPPER.unwrap(parentNode, labelHash, address(this));
+            return (node, State.OWNED);
         }
     }
 }

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -4,16 +4,19 @@ pragma solidity >=0.8.13;
 import {IBaseRegistrar} from "@ens/contracts/ethregistrar/IBaseRegistrar.sol";
 import {ENS} from "@ens/contracts/registry/ENS.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
-import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
+import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
+import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 
-import {UnauthorizedCaller} from "../CommonErrors.sol";
-
-/// @notice The ENSv1 ETHRegistrarController for ENSv2 launch which becomes the burn address for migrated ERC-721 tokens.
+/// @notice The ENSv1 ETHRegistrarController for ENSv2 launch which becomes the burn address for migrated tokens.
 ///
 /// 1. Claim any expired ENSv1 name and assign ownership to this contract.
 /// 2. Clear the registry for any owned token.
 ///
-contract Graveyard is IERC721Receiver {
+contract Graveyard is ERC721Holder, ERC1155Holder {
+    /// @notice The ENSv1 `NameWrapper` contract.
+    INameWrapper public immutable NAME_WRAPPER;
+
     /// @dev The ENSv1 `ENSRegistry` contract.
     ENS internal immutable _REGISTRY_V1;
 
@@ -25,20 +28,24 @@ contract Graveyard is IERC721Receiver {
     ////////////////////////////////////////////////////////////////////////
 
     /// @notice Create a graveyard.
-    /// @param ens The ENSv1 `ENSRegistry` contract.
-    constructor(ENS ens) {
-        _REGISTRY_V1 = ens;
-        _REGISTRAR_V1 = IBaseRegistrar(ens.owner(NameCoder.ETH_NODE));
+    /// @param nameWrapper The ENSv1 `NameWrapper` contract.
+    constructor(INameWrapper nameWrapper) {
+        NAME_WRAPPER = nameWrapper;
+        _REGISTRY_V1 = nameWrapper.ens();
+        _REGISTRAR_V1 = nameWrapper.registrar();
     }
 
     ////////////////////////////////////////////////////////////////////////
     // Implementation
     ////////////////////////////////////////////////////////////////////////
 
-    /// @notice Clear registry resolvers with automatic temporary registration.
-    /// @param parentNodes The array of parent nodes.
+    /// @notice Clear registry for unwrapped names with automatic temporary registration.
+    /// @param parentNodes The array of unwrapped parent nodes.
     /// @param labelHashes The array of child labelhashes.
-    function clear(bytes32[] calldata parentNodes, bytes32[] calldata labelHashes) external {
+    function clearUnwrapped(
+        bytes32[] calldata parentNodes,
+        bytes32[] calldata labelHashes
+    ) external {
         for (uint256 i; i < parentNodes.length; ++i) {
             bytes32 parentNode = parentNodes[i];
             bytes32 labelHash = labelHashes[i];
@@ -54,17 +61,29 @@ contract Graveyard is IERC721Receiver {
         }
     }
 
-    /// @inheritdoc IERC721Receiver
-    /// @notice Accept any ENSv1 `BaseRegistrar` token.
-    function onERC721Received(
-        address /*operator*/,
-        address /*from*/,
-        uint256 /*tokenId*/,
-        bytes calldata /*data*/
-    ) external view returns (bytes4) {
-        if (msg.sender != address(_REGISTRAR_V1)) {
-            revert UnauthorizedCaller(msg.sender);
+    /// @notice Clear registry for wrapped children with automatic unwrap.
+    /// @param parentNodes The array of wrapped parent nodes.
+    /// @param labels The array of child labels.
+    function clearWrappedChildren(
+        bytes32[] calldata parentNodes,
+        string[] calldata labels
+    ) external {
+        for (uint256 i; i < parentNodes.length; ++i) {
+            bytes32 parentNode = parentNodes[i];
+            string calldata label = labels[i];
+            //bytes32 node = NAME_WRAPPER.setSubnodeRecord(
+            NAME_WRAPPER.setSubnodeRecord(
+                parentNode,
+                label,
+                address(this), // owner
+                address(0), // resolver
+                0, // ttl
+                0, // fuses
+                0 // expiry
+            );
+            //(, uint32 fuses, ) = NAME_WRAPPER.getData(uint256(node));
+            //if (!LibMigration.isLocked(fuses)) {
+            NAME_WRAPPER.unwrap(parentNode, keccak256(bytes(label)), address(this));
         }
-        return this.onERC721Received.selector;
     }
 }

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import {IBaseRegistrar} from "@ens/contracts/ethregistrar/IBaseRegistrar.sol";
+import {ENS} from "@ens/contracts/registry/ENS.sol";
+import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+
+import {UnauthorizedCaller} from "../CommonErrors.sol";
+
+/// @notice The ENSv1 ETHRegistrarController for ENSv2 launch which becomes the burn address for migrated ERC-721 tokens.
+///
+/// 1. Claim any expired ENSv1 name and assign ownership to this contract.
+/// 2. Clear the registry for any owned token.
+///
+contract Graveyard is IERC721Receiver {
+    /// @dev The ENSv1 `ENSRegistry` contract.
+    ENS internal immutable _REGISTRY_V1;
+
+    /// @dev The ENSv1 `BaseRegistrar` contract.
+    IBaseRegistrar internal immutable _REGISTRAR_V1;
+
+    ////////////////////////////////////////////////////////////////////////
+    // Initialization
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Create a graveyard.
+    /// @param ens The ENSv1 `ENSRegistry` contract.
+    constructor(ENS ens) {
+        _REGISTRY_V1 = ens;
+        _REGISTRAR_V1 = IBaseRegistrar(ens.owner(NameCoder.ETH_NODE));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Implementation
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Clear registry resolvers with automatic temporary registration.
+    /// @param parentNodes The array of parent nodes.
+    /// @param labelHashes The array of child labelhashes.
+    function clear(bytes32[] calldata parentNodes, bytes32[] calldata labelHashes) external {
+        for (uint256 i; i < parentNodes.length; ++i) {
+            bytes32 parentNode = parentNodes[i];
+            bytes32 labelHash = labelHashes[i];
+            if (parentNode == NameCoder.ETH_NODE) {
+                bytes32 node = NameCoder.namehash(parentNode, labelHash);
+                if (_REGISTRY_V1.owner(node) != address(this)) {
+                    _REGISTRAR_V1.register(uint256(labelHash), address(this), 1);
+                }
+                _REGISTRY_V1.setResolver(node, address(0));
+            } else {
+                _REGISTRY_V1.setSubnodeRecord(parentNode, labelHash, address(this), address(0), 0);
+            }
+        }
+    }
+
+    /// @inheritdoc IERC721Receiver
+    /// @notice Accept any ENSv1 `BaseRegistrar` token.
+    function onERC721Received(
+        address /*operator*/,
+        address /*from*/,
+        uint256 /*tokenId*/,
+        bytes calldata /*data*/
+    ) external view returns (bytes4) {
+        if (msg.sender != address(_REGISTRAR_V1)) {
+            revert UnauthorizedCaller(msg.sender);
+        }
+        return this.onERC721Received.selector;
+    }
+}

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -126,17 +126,18 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
                 } else if (LibMigration.isEmancipatedChild(fuses)) {
                     return (node, State.OWNED);
                 }
+            } else if (owner != address(0)) {
+                NAME_WRAPPER.setSubnodeRecord(
+                    parentNode,
+                    string(name[offset + 1:nextOffset]),
+                    address(this), // owner
+                    address(0), // resolver
+                    0, // ttl
+                    0, // fuses
+                    0 // expiry (uses min)
+                ); // reverts if not migrated
+                NAME_WRAPPER.unwrap(parentNode, labelHash, address(this));
             }
-            NAME_WRAPPER.setSubnodeRecord(
-                parentNode,
-                string(name[offset + 1:nextOffset]),
-                address(this), // owner
-                address(0), // resolver
-                0, // ttl
-                0, // fuses
-                0 // expiry (uses min)
-            ); // reverts if not migrated
-            NAME_WRAPPER.unwrap(parentNode, labelHash, address(this));
             return (node, State.OWNED);
         }
     }

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -48,6 +48,13 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
     uint256 internal immutable _GRACE_PERIOD;
 
     ////////////////////////////////////////////////////////////////////////
+    // Errors
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Error selector: `0xacae6b3b`
+    error NameNotClearable();
+
+    ////////////////////////////////////////////////////////////////////////
     // Initialization
     ////////////////////////////////////////////////////////////////////////
 
@@ -89,7 +96,9 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
         (parentNode, state) = _clear(name, nextOffset);
         node = NameCoder.namehash(parentNode, labelHash);
         if (state == State.ROOT) {
-            require(node == NameCoder.ETH_NODE);
+            if (node != NameCoder.ETH_NODE) {
+                revert NameNotClearable();
+            }
             return (node, State.ETH);
         } else if (state == State.ETH) {
             address owner = _REGISTRY_V1.owner(node);
@@ -100,7 +109,9 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
             uint32 fuses;
             (owner, fuses, ) = NAME_WRAPPER.getData(uint256(node));
             if (LibMigration.isLocked(fuses)) {
-                require(owner == address(this));
+                if (owner != address(this)) {
+                    revert NameNotClearable();
+                }
                 // resolver is cleared by migration
                 return (node, State.LOCKED);
             }

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -32,7 +32,7 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
     }
 
     ////////////////////////////////////////////////////////////////////////
-    // Constants
+    // Immutables
     ////////////////////////////////////////////////////////////////////////
 
     /// @notice The ENSv1 `NameWrapper` contract.
@@ -84,10 +84,10 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
     ////////////////////////////////////////////////////////////////////////
 
     /// @dev Recursively clear ancestor namespace.
-    function _clear(
-        bytes calldata name,
-        uint256 offset
-    ) internal returns (bytes32 node, State state) {
+    function _clear(bytes calldata name, uint256 offset)
+        internal
+        returns (bytes32 node, State state)
+    {
         (bytes32 labelHash, uint256 nextOffset) = NameCoder.readLabel(name, offset);
         if (labelHash == bytes32(0)) {
             return (bytes32(0), State.ROOT);

--- a/contracts/src/migration/LockedMigrationController.sol
+++ b/contracts/src/migration/LockedMigrationController.sol
@@ -3,13 +3,9 @@ pragma solidity >=0.8.13;
 
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
-import {
-    VerifiableFactory
-} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
+import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 
-import {
-    IPermissionedRegistry
-} from "../registry/interfaces/IPermissionedRegistry.sol";
+import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
 import {IRegistry} from "../registry/interfaces/IRegistry.sol";
 
 import {LockedWrapperReceiver} from "./LockedWrapperReceiver.sol";
@@ -43,12 +39,7 @@ contract LockedMigrationController is LockedWrapperReceiver {
         VerifiableFactory verifiableFactory,
         address wrapperRegistryImpl
     )
-        LockedWrapperReceiver(
-            nameWrapper,
-            graveyard,
-            verifiableFactory,
-            wrapperRegistryImpl
-        )
+        LockedWrapperReceiver(nameWrapper, graveyard, verifiableFactory, wrapperRegistryImpl)
     {
         ETH_REGISTRY = ethRegistry;
     }
@@ -74,7 +65,11 @@ contract LockedMigrationController is LockedWrapperReceiver {
         address resolver,
         uint256 roleBitmap,
         uint64 /*expiry*/
-    ) internal override returns (uint256 tokenId) {
+    )
+        internal
+        override
+        returns (uint256 tokenId)
+    {
         return
             ETH_REGISTRY.register(
                 label,

--- a/contracts/src/migration/LockedMigrationController.sol
+++ b/contracts/src/migration/LockedMigrationController.sol
@@ -3,9 +3,13 @@ pragma solidity >=0.8.13;
 
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
-import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
+import {
+    VerifiableFactory
+} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 
-import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
+import {
+    IPermissionedRegistry
+} from "../registry/interfaces/IPermissionedRegistry.sol";
 import {IRegistry} from "../registry/interfaces/IRegistry.sol";
 
 import {LockedWrapperReceiver} from "./LockedWrapperReceiver.sol";
@@ -28,16 +32,23 @@ contract LockedMigrationController is LockedWrapperReceiver {
     ////////////////////////////////////////////////////////////////////////
 
     /// @param nameWrapper The ENSv1 `NameWrapper` contract.
+    /// @param graveyard The ENSv1 `BaseRegistrar` token graveyard.
     /// @param ethRegistry The ENSv2 .eth `PermissionedRegistry` where migrated names are registered.
     /// @param verifiableFactory The shared factory for verifiable deployments.
     /// @param wrapperRegistryImpl The `WrapperRegistry` implementation contract.
     constructor(
         INameWrapper nameWrapper,
+        address graveyard,
         IPermissionedRegistry ethRegistry,
         VerifiableFactory verifiableFactory,
         address wrapperRegistryImpl
     )
-        LockedWrapperReceiver(nameWrapper, verifiableFactory, wrapperRegistryImpl)
+        LockedWrapperReceiver(
+            nameWrapper,
+            graveyard,
+            verifiableFactory,
+            wrapperRegistryImpl
+        )
     {
         ETH_REGISTRY = ethRegistry;
     }
@@ -63,11 +74,7 @@ contract LockedMigrationController is LockedWrapperReceiver {
         address resolver,
         uint256 roleBitmap,
         uint64 /*expiry*/
-    )
-        internal
-        override
-        returns (uint256 tokenId)
-    {
+    ) internal override returns (uint256 tokenId) {
         return
             ETH_REGISTRY.register(
                 label,

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -5,9 +5,12 @@ import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {
     INameWrapper,
     CAN_EXTEND_EXPIRY,
-    CANNOT_TRANSFER,
+    CANNOT_APPROVE,
+    CANNOT_CREATE_SUBDOMAIN,
     CANNOT_SET_RESOLVER,
-    CANNOT_CREATE_SUBDOMAIN
+    CANNOT_TRANSFER,
+    IS_DOT_ETH,
+    PARENT_CANNOT_CONTROL
 } from "@ens/contracts/wrapper/INameWrapper.sol";
 import {
     IVerifiableFactory
@@ -113,7 +116,10 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
                 uint256(node)
             );
             if (LibMigration.isLocked(fuses)) {
-                if (NAME_WRAPPER.getApproved(uint256(node)) != address(0)) {
+                if (
+                    (fuses & CANNOT_APPROVE) != 0 &&
+                    NAME_WRAPPER.getApproved(uint256(node)) != address(0)
+                ) {
                     revert LibMigration.FrozenTokenApproval(uint256(node));
                 }
 

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -8,13 +8,9 @@ import {
     CANNOT_APPROVE,
     CANNOT_CREATE_SUBDOMAIN,
     CANNOT_SET_RESOLVER,
-    CANNOT_TRANSFER,
-    IS_DOT_ETH,
-    PARENT_CANNOT_CONTROL
+    CANNOT_TRANSFER
 } from "@ens/contracts/wrapper/INameWrapper.sol";
-import {
-    IVerifiableFactory
-} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
+import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
 
 import {InvalidOwner} from "../CommonErrors.sol";
 import {REGISTRATION_ROLE_BITMAP} from "../registrar/ETHRegistrar.sol";
@@ -66,9 +62,11 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
     constructor(
         INameWrapper nameWrapper,
         address graveyard,
-        VerifiableFactory verifiableFactory,
+        IVerifiableFactory verifiableFactory,
         address wrapperRegistryImpl
-    ) AbstractWrapperReceiver(nameWrapper, graveyard) {
+    )
+        AbstractWrapperReceiver(nameWrapper, graveyard)
+    {
         VERIFIABLE_FACTORY = verifiableFactory;
         WRAPPER_REGISTRY_IMPL = wrapperRegistryImpl;
     }
@@ -90,10 +88,10 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
     ////////////////////////////////////////////////////////////////////////
 
     /// @inheritdoc AbstractWrapperReceiver
-    function _migrateWrapped(
-        uint256[] calldata ids,
-        LibMigration.Data[] calldata mds
-    ) internal override {
+    function _migrateWrapped(uint256[] calldata ids, LibMigration.Data[] calldata mds)
+        internal
+        override
+    {
         IRegistry parentRegistry = _getRegistry();
         bytes32 parentNode = getWrappedNode();
         for (uint256 i; i < ids.length; ++i) {
@@ -112,9 +110,7 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
             // see: V1Fixture.t.sol: `test_nameWrapper_labelTooShort()` and `test_nameWrapper_labelTooLong()`.
 
             address resolver = md.resolver;
-            (, uint32 fuses, uint64 expiry) = NAME_WRAPPER.getData(
-                uint256(node)
-            );
+            (, uint32 fuses, uint64 expiry) = NAME_WRAPPER.getData(uint256(node));
             if (LibMigration.isLocked(fuses)) {
                 if (
                     (fuses & CANNOT_APPROVE) != 0 &&
@@ -129,31 +125,26 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
                     resolver = _REGISTRY_V1.resolver(node); // replace with ENSv1 resolver
                 }
 
-                NAME_WRAPPER.safeTransferFrom(
-                    address(this),
-                    GRAVEYARD,
-                    uint256(node),
-                    1,
-                    ""
-                ); // transfer to graveyard
+                NAME_WRAPPER.safeTransferFrom(address(this), GRAVEYARD, uint256(node), 1, ""); // transfer to graveyard
 
                 // create subregistry
-                IRegistry subregistry = IRegistry(
-                    VERIFIABLE_FACTORY.deployProxy(
-                        WRAPPER_REGISTRY_IMPL,
-                        uint256(node),
-                        abi.encodeCall(
-                            IWrapperRegistry.initialize,
-                            (
-                                node,
-                                parentRegistry,
-                                md.label,
-                                md.owner,
-                                _subregistryRoleBitmapFromFuses(fuses)
+                IRegistry subregistry =
+                    IRegistry(
+                        VERIFIABLE_FACTORY.deployProxy(
+                            WRAPPER_REGISTRY_IMPL,
+                            uint256(node),
+                            abi.encodeCall(
+                                IWrapperRegistry.initialize,
+                                (
+                                    node,
+                                    parentRegistry,
+                                    md.label,
+                                    md.owner,
+                                    _subregistryRoleBitmapFromFuses(fuses)
+                                )
                             )
                         )
-                    )
-                );
+                    );
 
                 // add name to ENSv2
                 // PermissionedRegistry._register() => CannotSetPastExpiry :: see expiry check
@@ -194,19 +185,17 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
         address resolver,
         uint256 roleBitmap,
         uint64 expiry
-    ) internal virtual returns (uint256 tokenId);
+    )
+        internal
+        virtual
+        returns (uint256 tokenId);
 
     /// @dev The ENSv2 registry being migrated to.
     function _getRegistry() internal view virtual returns (IRegistry);
 
     /// @dev Determine if `label` is emancipated but not-yet migrated.
-    function _isMigratableChild(
-        string memory label
-    ) internal view returns (bool) {
-        bytes32 node = NameCoder.namehash(
-            getWrappedNode(),
-            keccak256(bytes(label))
-        );
+    function _isMigratableChild(string memory label) internal view returns (bool) {
+        bytes32 node = NameCoder.namehash(getWrappedNode(), keccak256(bytes(label)));
         (address ownerV1, uint32 fuses, ) = NAME_WRAPPER.getData(uint256(node));
         return
             ownerV1 != address(0) &&
@@ -215,9 +204,11 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
     }
 
     /// @dev Convert fuses to equivalent subregistry root roles.
-    function _subregistryRoleBitmapFromFuses(
-        uint32 fuses
-    ) internal pure returns (uint256 roleBitmap) {
+    function _subregistryRoleBitmapFromFuses(uint32 fuses)
+        internal
+        pure
+        returns (uint256 roleBitmap)
+    {
         if ((fuses & CANNOT_CREATE_SUBDOMAIN) == 0) {
             roleBitmap |= RegistryRolesLib.ROLE_REGISTRAR;
         }
@@ -232,9 +223,7 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
     }
 
     /// @dev Convert fuses to equivalent token roles.
-    function _tokenRoleBitmapFromFuses(
-        uint32 fuses
-    ) internal pure returns (uint256 roleBitmap) {
+    function _tokenRoleBitmapFromFuses(uint32 fuses) internal pure returns (uint256 roleBitmap) {
         if ((fuses & CAN_EXTEND_EXPIRY) != 0) {
             roleBitmap |= RegistryRolesLib.ROLE_RENEW;
         }

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -60,13 +60,15 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
     ////////////////////////////////////////////////////////////////////////
 
     /// @param nameWrapper The ENSv1 `NameWrapper` contract.
+    /// @param graveyard The ENSv1 `BaseRegistrar` token graveyard.
     /// @param verifiableFactory The shared factory for verifiable deployments.
     /// @param wrapperRegistryImpl The `WrapperRegistry` implementation contract.
     constructor(
         INameWrapper nameWrapper,
-        IVerifiableFactory verifiableFactory,
+        address graveyard,
+        VerifiableFactory verifiableFactory,
         address wrapperRegistryImpl
-    ) AbstractWrapperReceiver(nameWrapper) {
+    ) AbstractWrapperReceiver(nameWrapper, graveyard) {
         VERIFIABLE_FACTORY = verifiableFactory;
         WRAPPER_REGISTRY_IMPL = wrapperRegistryImpl;
     }
@@ -154,11 +156,10 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
                     expiry
                 );
             } else if (_isEmancipatedChild(fuses)) {
-                NAME_WRAPPER.unwrap(parentNode, labelHash, address(this));
+                NAME_WRAPPER.setResolver(node, address(0)); // clear ENSv1 resolver
+                NAME_WRAPPER.unwrap(parentNode, labelHash, GRAVEYARD); // unwrap and transfer to graveyard
 
-                _REGISTRY_V1.setResolver(node, address(0)); // clear ENSv1 resolver
-
-                // same as UnlockedMigrationController
+                // add name to ENSv2 (same as UnlockedMigrationController)
                 _inject(
                     md.label,
                     md.owner,

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -5,12 +5,9 @@ import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {
     INameWrapper,
     CAN_EXTEND_EXPIRY,
-    CANNOT_BURN_FUSES,
     CANNOT_TRANSFER,
     CANNOT_SET_RESOLVER,
-    CANNOT_CREATE_SUBDOMAIN,
-    IS_DOT_ETH,
-    PARENT_CANNOT_CONTROL
+    CANNOT_CREATE_SUBDOMAIN
 } from "@ens/contracts/wrapper/INameWrapper.sol";
 import {
     IVerifiableFactory
@@ -111,10 +108,11 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
             // same as NameCoder.assertLabelSize()
             // see: V1Fixture.t.sol: `test_nameWrapper_labelTooShort()` and `test_nameWrapper_labelTooLong()`.
 
+            address resolver = md.resolver;
             (, uint32 fuses, uint64 expiry) = NAME_WRAPPER.getData(
                 uint256(node)
             );
-            if (_isLocked(fuses)) {
+            if (LibMigration.isLocked(fuses)) {
                 if (NAME_WRAPPER.getApproved(uint256(node)) != address(0)) {
                     revert LibMigration.FrozenTokenApproval(uint256(node));
                 }
@@ -122,8 +120,16 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
                 if ((fuses & CANNOT_SET_RESOLVER) == 0) {
                     NAME_WRAPPER.setResolver(node, address(0)); // clear ENSv1 resolver
                 } else {
-                    md.resolver = _REGISTRY_V1.resolver(node); // replace with ENSv1 resolver
+                    resolver = _REGISTRY_V1.resolver(node); // replace with ENSv1 resolver
                 }
+
+                NAME_WRAPPER.safeTransferFrom(
+                    address(this),
+                    GRAVEYARD,
+                    uint256(node),
+                    1,
+                    ""
+                ); // transfer to graveyard
 
                 // create subregistry
                 IRegistry subregistry = IRegistry(
@@ -151,11 +157,11 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
                     md.label,
                     md.owner,
                     subregistry,
-                    md.resolver,
+                    resolver,
                     _tokenRoleBitmapFromFuses(fuses),
                     expiry
                 );
-            } else if (_isEmancipatedChild(fuses)) {
+            } else if (LibMigration.isEmancipatedChild(fuses)) {
                 NAME_WRAPPER.setResolver(node, address(0)); // clear ENSv1 resolver
                 NAME_WRAPPER.unwrap(parentNode, labelHash, GRAVEYARD); // unwrap and transfer to graveyard
 
@@ -164,7 +170,7 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
                     md.label,
                     md.owner,
                     md.subregistry,
-                    md.resolver,
+                    resolver,
                     REGISTRATION_ROLE_BITMAP,
                     expiry
                 );
@@ -198,22 +204,8 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
         (address ownerV1, uint32 fuses, ) = NAME_WRAPPER.getData(uint256(node));
         return
             ownerV1 != address(0) &&
-            ownerV1 != address(this) &&
-            _isEmancipatedChild(fuses);
-    }
-
-    /// @dev Returns `true` if the NameWrapper token fuses are not frozen.
-    function _notFrozen(uint32 fuses) internal pure returns (bool) {
-        return (fuses & CANNOT_BURN_FUSES) == 0;
-    }
-
-    /// @dev Returns `true` if the NameWrapper token is emancipated and not 2LD .eth.
-    function _isEmancipatedChild(uint32 fuses) internal pure returns (bool) {
-        // PARENT_CANNOT_CONTROL must be set for the entire ancestory.
-        // see: V1Fixture.t.sol: `test_nameWrapper_PARENT_CANNOT_CONTROL_withoutParent()`
-        return
-            (fuses & (IS_DOT_ETH | PARENT_CANNOT_CONTROL)) ==
-            PARENT_CANNOT_CONTROL;
+            ownerV1 != address(GRAVEYARD) &&
+            LibMigration.isEmancipatedChild(fuses);
     }
 
     /// @dev Convert fuses to equivalent subregistry root roles.
@@ -223,7 +215,7 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
         if ((fuses & CANNOT_CREATE_SUBDOMAIN) == 0) {
             roleBitmap |= RegistryRolesLib.ROLE_REGISTRAR;
         }
-        if (_notFrozen(fuses)) {
+        if (LibMigration.notFrozen(fuses)) {
             roleBitmap |= roleBitmap << 128; // give admin
         }
         roleBitmap |=
@@ -243,7 +235,7 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
         if ((fuses & CANNOT_SET_RESOLVER) == 0) {
             roleBitmap |= RegistryRolesLib.ROLE_SET_RESOLVER;
         }
-        if (_notFrozen(fuses)) {
+        if (LibMigration.notFrozen(fuses)) {
             roleBitmap |= roleBitmap << 128; // give admin
         }
         if ((fuses & CANNOT_TRANSFER) == 0) {

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -12,7 +12,9 @@ import {
     IS_DOT_ETH,
     PARENT_CANNOT_CONTROL
 } from "@ens/contracts/wrapper/INameWrapper.sol";
-import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
+import {
+    IVerifiableFactory
+} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
 
 import {InvalidOwner} from "../CommonErrors.sol";
 import {REGISTRATION_ROLE_BITMAP} from "../registrar/ETHRegistrar.sol";
@@ -64,9 +66,7 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
         INameWrapper nameWrapper,
         IVerifiableFactory verifiableFactory,
         address wrapperRegistryImpl
-    )
-        AbstractWrapperReceiver(nameWrapper)
-    {
+    ) AbstractWrapperReceiver(nameWrapper) {
         VERIFIABLE_FACTORY = verifiableFactory;
         WRAPPER_REGISTRY_IMPL = wrapperRegistryImpl;
     }
@@ -88,10 +88,10 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
     ////////////////////////////////////////////////////////////////////////
 
     /// @inheritdoc AbstractWrapperReceiver
-    function _migrateWrapped(uint256[] calldata ids, LibMigration.Data[] calldata mds)
-        internal
-        override
-    {
+    function _migrateWrapped(
+        uint256[] calldata ids,
+        LibMigration.Data[] calldata mds
+    ) internal override {
         IRegistry parentRegistry = _getRegistry();
         bytes32 parentNode = getWrappedNode();
         for (uint256 i; i < ids.length; ++i) {
@@ -109,7 +109,9 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
             // same as NameCoder.assertLabelSize()
             // see: V1Fixture.t.sol: `test_nameWrapper_labelTooShort()` and `test_nameWrapper_labelTooLong()`.
 
-            (, uint32 fuses, uint64 expiry) = NAME_WRAPPER.getData(uint256(node));
+            (, uint32 fuses, uint64 expiry) = NAME_WRAPPER.getData(
+                uint256(node)
+            );
             if (_isLocked(fuses)) {
                 if (NAME_WRAPPER.getApproved(uint256(node)) != address(0)) {
                     revert LibMigration.FrozenTokenApproval(uint256(node));
@@ -122,23 +124,22 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
                 }
 
                 // create subregistry
-                IRegistry subregistry =
-                    IRegistry(
-                        VERIFIABLE_FACTORY.deployProxy(
-                            WRAPPER_REGISTRY_IMPL,
-                            uint256(node),
-                            abi.encodeCall(
-                                IWrapperRegistry.initialize,
-                                (
-                                    node,
-                                    parentRegistry,
-                                    md.label,
-                                    md.owner,
-                                    _subregistryRoleBitmapFromFuses(fuses)
-                                )
+                IRegistry subregistry = IRegistry(
+                    VERIFIABLE_FACTORY.deployProxy(
+                        WRAPPER_REGISTRY_IMPL,
+                        uint256(node),
+                        abi.encodeCall(
+                            IWrapperRegistry.initialize,
+                            (
+                                node,
+                                parentRegistry,
+                                md.label,
+                                md.owner,
+                                _subregistryRoleBitmapFromFuses(fuses)
                             )
                         )
-                    );
+                    )
+                );
 
                 // add name to ENSv2
                 // PermissionedRegistry._register() => CannotSetPastExpiry :: see expiry check
@@ -180,19 +181,24 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
         address resolver,
         uint256 roleBitmap,
         uint64 expiry
-    )
-        internal
-        virtual
-        returns (uint256 tokenId);
+    ) internal virtual returns (uint256 tokenId);
 
     /// @dev The ENSv2 registry being migrated to.
     function _getRegistry() internal view virtual returns (IRegistry);
 
     /// @dev Determine if `label` is emancipated but not-yet migrated.
-    function _isMigratableChild(string memory label) internal view returns (bool) {
-        bytes32 node = NameCoder.namehash(getWrappedNode(), keccak256(bytes(label)));
+    function _isMigratableChild(
+        string memory label
+    ) internal view returns (bool) {
+        bytes32 node = NameCoder.namehash(
+            getWrappedNode(),
+            keccak256(bytes(label))
+        );
         (address ownerV1, uint32 fuses, ) = NAME_WRAPPER.getData(uint256(node));
-        return ownerV1 != address(0) && ownerV1 != address(this) && _isEmancipatedChild(fuses);
+        return
+            ownerV1 != address(0) &&
+            ownerV1 != address(this) &&
+            _isEmancipatedChild(fuses);
     }
 
     /// @dev Returns `true` if the NameWrapper token fuses are not frozen.
@@ -204,15 +210,15 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
     function _isEmancipatedChild(uint32 fuses) internal pure returns (bool) {
         // PARENT_CANNOT_CONTROL must be set for the entire ancestory.
         // see: V1Fixture.t.sol: `test_nameWrapper_PARENT_CANNOT_CONTROL_withoutParent()`
-        return (fuses & (IS_DOT_ETH | PARENT_CANNOT_CONTROL)) == PARENT_CANNOT_CONTROL;
+        return
+            (fuses & (IS_DOT_ETH | PARENT_CANNOT_CONTROL)) ==
+            PARENT_CANNOT_CONTROL;
     }
 
     /// @dev Convert fuses to equivalent subregistry root roles.
-    function _subregistryRoleBitmapFromFuses(uint32 fuses)
-        internal
-        pure
-        returns (uint256 roleBitmap)
-    {
+    function _subregistryRoleBitmapFromFuses(
+        uint32 fuses
+    ) internal pure returns (uint256 roleBitmap) {
         if ((fuses & CANNOT_CREATE_SUBDOMAIN) == 0) {
             roleBitmap |= RegistryRolesLib.ROLE_REGISTRAR;
         }
@@ -227,7 +233,9 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
     }
 
     /// @dev Convert fuses to equivalent token roles.
-    function _tokenRoleBitmapFromFuses(uint32 fuses) internal pure returns (uint256 roleBitmap) {
+    function _tokenRoleBitmapFromFuses(
+        uint32 fuses
+    ) internal pure returns (uint256 roleBitmap) {
         if ((fuses & CAN_EXTEND_EXPIRY) != 0) {
             roleBitmap |= RegistryRolesLib.ROLE_RENEW;
         }

--- a/contracts/src/migration/UnlockedMigrationController.sol
+++ b/contracts/src/migration/UnlockedMigrationController.sol
@@ -26,7 +26,7 @@ import {LibMigration} from "./libraries/LibMigration.sol";
 ///
 /// Supports (2) token sources:
 /// 1. NameWrapper (ERC-1155) but unlocked only.
-///    Reverts with `NameIsWrapped` if `_isLocked()` => use LockedMigrationController instead.
+///    Reverts with `NameIsWrapped` if `LibMigration.isLocked()` => use LockedMigrationController instead.
 /// 2. BaseRegistrar (ERC-721)
 ///
 /// Unlike locked migration, no subregistry is deployed and no fuse-to-role translation is
@@ -127,7 +127,7 @@ contract UnlockedMigrationController is
         for (uint256 i; i < ids.length; ++i) {
             uint256 id = ids[i];
             (, uint32 fuses, ) = NAME_WRAPPER.getData(id);
-            if (_isLocked(fuses)) {
+            if (LibMigration.isLocked(fuses)) {
                 revert LibMigration.NameIsLocked(id);
             }
             bytes32 labelHash = keccak256(bytes(mds[i].label));

--- a/contracts/src/migration/UnlockedMigrationController.sol
+++ b/contracts/src/migration/UnlockedMigrationController.sol
@@ -4,12 +4,16 @@ pragma solidity >=0.8.13;
 import {IBaseRegistrar} from "@ens/contracts/ethregistrar/IBaseRegistrar.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
-import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {
+    IERC721Receiver
+} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import {InvalidOwner, UnauthorizedCaller} from "../CommonErrors.sol";
 import {REGISTRATION_ROLE_BITMAP} from "../registrar/ETHRegistrar.sol";
-import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
+import {
+    IPermissionedRegistry
+} from "../registry/interfaces/IPermissionedRegistry.sol";
 
 import {AbstractWrapperReceiver} from "./AbstractWrapperReceiver.sol";
 import {LibMigration} from "./libraries/LibMigration.sol";
@@ -29,7 +33,10 @@ import {LibMigration} from "./libraries/LibMigration.sol";
 /// performed.  The name is registered in the .eth registry with the roles and subregistry
 /// specified in the caller-provided `LibMigration.Data`.
 ///
-contract UnlockedMigrationController is AbstractWrapperReceiver, IERC721Receiver {
+contract UnlockedMigrationController is
+    AbstractWrapperReceiver,
+    IERC721Receiver
+{
     ////////////////////////////////////////////////////////////////////////
     // Immutables
     ////////////////////////////////////////////////////////////////////////
@@ -45,18 +52,24 @@ contract UnlockedMigrationController is AbstractWrapperReceiver, IERC721Receiver
     ////////////////////////////////////////////////////////////////////////
 
     /// @param nameWrapper The ENSv1 `NameWrapper` contract.
+    /// @param graveyard The ENSv1 `BaseRegistrar` token graveyard.
     /// @param ethRegistry The ENSv2 .eth `PermissionedRegistry` where migrated names are registered.
-    constructor(INameWrapper nameWrapper, IPermissionedRegistry ethRegistry)
-        AbstractWrapperReceiver(nameWrapper)
-    {
+    constructor(
+        INameWrapper nameWrapper,
+        address graveyard,
+        IPermissionedRegistry ethRegistry
+    ) AbstractWrapperReceiver(nameWrapper, graveyard) {
         ETH_REGISTRY = ethRegistry;
         _REGISTRAR_V1 = nameWrapper.registrar();
     }
 
     /// @inheritdoc IERC165
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
         return
-            interfaceId == type(IERC721Receiver).interfaceId || super.supportsInterface(interfaceId);
+            interfaceId == type(IERC721Receiver).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -75,10 +88,7 @@ contract UnlockedMigrationController is AbstractWrapperReceiver, IERC721Receiver
         address /*from*/,
         uint256 tokenId,
         bytes calldata data
-    )
-        external
-        returns (bytes4)
-    {
+    ) external returns (bytes4) {
         if (msg.sender != address(_REGISTRAR_V1)) {
             revert UnauthorizedCaller(msg.sender);
         }
@@ -89,12 +99,14 @@ contract UnlockedMigrationController is AbstractWrapperReceiver, IERC721Receiver
         if (tokenId != uint256(keccak256(bytes(md.label)))) {
             revert LibMigration.NameDataMismatch(tokenId);
         }
-        // clear ENSv1 resolver
         _REGISTRAR_V1.reclaim(tokenId, address(this));
-        _REGISTRY_V1.setResolver(
+        _REGISTRY_V1.setRecord(
             NameCoder.namehash(NameCoder.ETH_NODE, bytes32(tokenId)),
-            address(0)
+            GRAVEYARD, // transfer ownership to graveyard
+            address(0), // clear ENSv1 resolver
+            0
         );
+        _REGISTRAR_V1.safeTransferFrom(address(this), GRAVEYARD, tokenId); // transfer token to graveyard
         _inject(md);
         return this.onERC721Received.selector;
     }
@@ -108,10 +120,10 @@ contract UnlockedMigrationController is AbstractWrapperReceiver, IERC721Receiver
     ///      Reverts `NameDataMismatch` if any token is mislabeled.
     /// @param ids The NameWrapper token IDs (namehash) of the names to migrate.
     /// @param mds The migration parameters for each name, indexed in parallel with `ids`.
-    function _migrateWrapped(uint256[] calldata ids, LibMigration.Data[] calldata mds)
-        internal
-        override
-    {
+    function _migrateWrapped(
+        uint256[] calldata ids,
+        LibMigration.Data[] calldata mds
+    ) internal override {
         for (uint256 i; i < ids.length; ++i) {
             uint256 id = ids[i];
             (, uint32 fuses, ) = NAME_WRAPPER.getData(id);
@@ -119,11 +131,13 @@ contract UnlockedMigrationController is AbstractWrapperReceiver, IERC721Receiver
                 revert LibMigration.NameIsLocked(id);
             }
             bytes32 labelHash = keccak256(bytes(mds[i].label));
-            if (bytes32(id) != NameCoder.namehash(NameCoder.ETH_NODE, labelHash)) {
+            if (
+                bytes32(id) != NameCoder.namehash(NameCoder.ETH_NODE, labelHash)
+            ) {
                 revert LibMigration.NameDataMismatch(id);
             }
-            // clear ENSv1 resolver
-            NAME_WRAPPER.setResolver(bytes32(id), address(0));
+            NAME_WRAPPER.setResolver(bytes32(id), address(0)); // clear ENSv1 resolver
+            NAME_WRAPPER.unwrapETH2LD(labelHash, GRAVEYARD, GRAVEYARD); // unwrap and transfer to graveyard
             _inject(mds[i]);
         }
     }

--- a/contracts/src/migration/UnlockedMigrationController.sol
+++ b/contracts/src/migration/UnlockedMigrationController.sol
@@ -4,16 +4,12 @@ pragma solidity >=0.8.13;
 import {IBaseRegistrar} from "@ens/contracts/ethregistrar/IBaseRegistrar.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
-import {
-    IERC721Receiver
-} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import {InvalidOwner, UnauthorizedCaller} from "../CommonErrors.sol";
 import {REGISTRATION_ROLE_BITMAP} from "../registrar/ETHRegistrar.sol";
-import {
-    IPermissionedRegistry
-} from "../registry/interfaces/IPermissionedRegistry.sol";
+import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
 
 import {AbstractWrapperReceiver} from "./AbstractWrapperReceiver.sol";
 import {LibMigration} from "./libraries/LibMigration.sol";
@@ -33,10 +29,7 @@ import {LibMigration} from "./libraries/LibMigration.sol";
 /// performed.  The name is registered in the .eth registry with the roles and subregistry
 /// specified in the caller-provided `LibMigration.Data`.
 ///
-contract UnlockedMigrationController is
-    AbstractWrapperReceiver,
-    IERC721Receiver
-{
+contract UnlockedMigrationController is AbstractWrapperReceiver, IERC721Receiver {
     ////////////////////////////////////////////////////////////////////////
     // Immutables
     ////////////////////////////////////////////////////////////////////////
@@ -54,22 +47,17 @@ contract UnlockedMigrationController is
     /// @param nameWrapper The ENSv1 `NameWrapper` contract.
     /// @param graveyard The ENSv1 `BaseRegistrar` token graveyard.
     /// @param ethRegistry The ENSv2 .eth `PermissionedRegistry` where migrated names are registered.
-    constructor(
-        INameWrapper nameWrapper,
-        address graveyard,
-        IPermissionedRegistry ethRegistry
-    ) AbstractWrapperReceiver(nameWrapper, graveyard) {
+    constructor(INameWrapper nameWrapper, address graveyard, IPermissionedRegistry ethRegistry)
+        AbstractWrapperReceiver(nameWrapper, graveyard)
+    {
         ETH_REGISTRY = ethRegistry;
         _REGISTRAR_V1 = nameWrapper.registrar();
     }
 
     /// @inheritdoc IERC165
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return
-            interfaceId == type(IERC721Receiver).interfaceId ||
-            super.supportsInterface(interfaceId);
+            interfaceId == type(IERC721Receiver).interfaceId || super.supportsInterface(interfaceId);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -88,7 +76,10 @@ contract UnlockedMigrationController is
         address /*from*/,
         uint256 tokenId,
         bytes calldata data
-    ) external returns (bytes4) {
+    )
+        external
+        returns (bytes4)
+    {
         if (msg.sender != address(_REGISTRAR_V1)) {
             revert UnauthorizedCaller(msg.sender);
         }
@@ -120,10 +111,10 @@ contract UnlockedMigrationController is
     ///      Reverts `NameDataMismatch` if any token is mislabeled.
     /// @param ids The NameWrapper token IDs (namehash) of the names to migrate.
     /// @param mds The migration parameters for each name, indexed in parallel with `ids`.
-    function _migrateWrapped(
-        uint256[] calldata ids,
-        LibMigration.Data[] calldata mds
-    ) internal override {
+    function _migrateWrapped(uint256[] calldata ids, LibMigration.Data[] calldata mds)
+        internal
+        override
+    {
         for (uint256 i; i < ids.length; ++i) {
             uint256 id = ids[i];
             (, uint32 fuses, ) = NAME_WRAPPER.getData(id);
@@ -131,9 +122,7 @@ contract UnlockedMigrationController is
                 revert LibMigration.NameIsLocked(id);
             }
             bytes32 labelHash = keccak256(bytes(mds[i].label));
-            if (
-                bytes32(id) != NameCoder.namehash(NameCoder.ETH_NODE, labelHash)
-            ) {
+            if (bytes32(id) != NameCoder.namehash(NameCoder.ETH_NODE, labelHash)) {
                 revert LibMigration.NameDataMismatch(id);
             }
             NAME_WRAPPER.setResolver(bytes32(id), address(0)); // clear ENSv1 resolver

--- a/contracts/src/migration/libraries/LibMigration.sol
+++ b/contracts/src/migration/libraries/LibMigration.sol
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
+import {
+    CANNOT_BURN_FUSES,
+    CANNOT_UNWRAP,
+    IS_DOT_ETH,
+    PARENT_CANNOT_CONTROL
+} from "@ens/contracts/wrapper/INameWrapper.sol";
+
 import {IRegistry} from "../../registry/interfaces/IRegistry.sol";
 
 /// @dev Primitives for migration.
@@ -57,4 +64,27 @@ library LibMigration {
     /// @notice The encoded data is invalid.
     /// @dev Error selector: `0x5cb045db`
     error InvalidData();
+
+    ////////////////////////////////////////////////////////////////////////
+    // Implementation
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Returns `true` if the NameWrapper token is locked.
+    function isLocked(uint32 fuses) internal pure returns (bool) {
+        // PARENT_CANNOT_CONTROL is required to set CANNOT_UNWRAP, so CANNOT_UNWRAP is sufficient
+        // see: V1Fixture.t.sol: `test_nameWrapper_CANNOT_UNWRAP_requires_PARENT_CANNOT_CONTROL()`
+        return (fuses & CANNOT_UNWRAP) != 0;
+    }
+
+    /// @dev Returns `true` if the NameWrapper token fuses are not frozen.
+    function notFrozen(uint32 fuses) internal pure returns (bool) {
+        return (fuses & CANNOT_BURN_FUSES) == 0;
+    }
+
+    /// @dev Returns `true` if the NameWrapper token is emancipated and not 2LD .eth.
+    function isEmancipatedChild(uint32 fuses) internal pure returns (bool) {
+        // PARENT_CANNOT_CONTROL must be set for the entire ancestory.
+        // see: V1Fixture.t.sol: `test_nameWrapper_PARENT_CANNOT_CONTROL_withoutParent()`
+        return (fuses & (IS_DOT_ETH | PARENT_CANNOT_CONTROL)) == PARENT_CANNOT_CONTROL;
+    }
 }

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -2,14 +2,24 @@
 pragma solidity >=0.8.13;
 
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
-import {IProxyAuthorization} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
-import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {
+    IProxyAuthorization
+} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
+import {
+    IVerifiableFactory
+} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
+import {
+    Initializable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {
+    UUPSUpgradeable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
-import {AbstractWrapperReceiver} from "../migration/AbstractWrapperReceiver.sol";
+import {
+    AbstractWrapperReceiver
+} from "../migration/AbstractWrapperReceiver.sol";
 import {LibMigration} from "../migration/libraries/LibMigration.sol";
 import {LockedWrapperReceiver} from "../migration/LockedWrapperReceiver.sol";
 import {IWrapperRegistry} from "../registry/interfaces/IWrapperRegistry.sol";
@@ -63,6 +73,7 @@ contract WrapperRegistry is
     ////////////////////////////////////////////////////////////////////////
 
     /// @param nameWrapper The ENSv1 NameWrapper.
+    /// @param graveyard The ENSv1 `BaseRegistrar` token graveyard.
     /// @param verifiableFactory The VerifiableFactory.
     /// @param ensV1Resolver The ENSv1 resolver.
     /// @param hcaFactory The HCA factory.
@@ -71,6 +82,7 @@ contract WrapperRegistry is
     /// @param labelStore The shared label database.
     constructor(
         INameWrapper nameWrapper,
+        address graveyard,
         IVerifiableFactory verifiableFactory,
         address ensV1Resolver,
         IHCAFactoryBasic hcaFactory,
@@ -78,8 +90,19 @@ contract WrapperRegistry is
         ApprovedUpgradeGate upgradeGate,
         ILabelStore labelStore
     )
-        PermissionedRegistry(hcaFactory, metadataProvider, labelStore, address(0), 0) // no roles are granted
-        LockedWrapperReceiver(nameWrapper, verifiableFactory, address(this))
+        PermissionedRegistry(
+            hcaFactory,
+            metadataProvider,
+            labelStore,
+            address(0),
+            0
+        ) // no roles are granted
+        LockedWrapperReceiver(
+            nameWrapper,
+            graveyard,
+            verifiableFactory,
+            address(this)
+        )
     {
         V1_RESOLVER = ensV1Resolver;
         UPGRADE_GATE = upgradeGate;
@@ -87,7 +110,9 @@ contract WrapperRegistry is
     }
 
     /// @inheritdoc IERC165
-    function supportsInterface(bytes4 interfaceId)
+    function supportsInterface(
+        bytes4 interfaceId
+    )
         public
         view
         virtual
@@ -108,10 +133,7 @@ contract WrapperRegistry is
         string calldata childLabel,
         address rootAccount,
         uint256 roleBitmap
-    )
-        public
-        initializer
-    {
+    ) public initializer {
         _node = node;
         // setup canonical parent (ROLE_SET_PARENT is not granted)
         _parentRegistry = parentRegistry;
@@ -131,13 +153,7 @@ contract WrapperRegistry is
     /// @return allowed Always `true` for implementations in this wrapper registry family.
     function canUpgradeFrom(
         address /* previousImplementation */
-    )
-        external
-        pure
-        virtual
-        override
-        returns (bool allowed)
-    {
+    ) external pure virtual override returns (bool allowed) {
         return true;
     }
 
@@ -158,18 +174,24 @@ contract WrapperRegistry is
         if (_isMigratableChild(label)) {
             revert LibMigration.NameRequiresMigration();
         }
-        return super.register(label, owner, registry, resolver, roleBitmap, expiry);
+        return
+            super.register(
+                label,
+                owner,
+                registry,
+                resolver,
+                roleBitmap,
+                expiry
+            );
     }
 
     /// @inheritdoc PermissionedRegistry
     /// @dev Return `V1_RESOLVER` upon visiting migratable children.
-    function getResolver(string calldata label)
-        public
-        view
-        override(IRegistry, PermissionedRegistry)
-        returns (address)
-    {
-        return _isMigratableChild(label) ? V1_RESOLVER : super.getResolver(label);
+    function getResolver(
+        string calldata label
+    ) public view override(IRegistry, PermissionedRegistry) returns (address) {
+        return
+            _isMigratableChild(label) ? V1_RESOLVER : super.getResolver(label);
     }
 
     /// @inheritdoc IWrapperRegistry
@@ -205,21 +227,23 @@ contract WrapperRegistry is
         address resolver,
         uint256 roleBitmap,
         uint64 expiry
-    )
-        internal
-        override
-        returns (uint256 tokenId)
-    {
-        return _register(label, owner, subregistry, resolver, roleBitmap, expiry, false);
+    ) internal override returns (uint256 tokenId) {
+        return
+            _register(
+                label,
+                owner,
+                subregistry,
+                resolver,
+                roleBitmap,
+                expiry,
+                false
+            );
     }
 
     /// @dev Requires `ROLE_UPGRADE` and approval for the target implementation.
-    function _authorizeUpgrade(address newImplementation)
-        internal
-        view
-        override
-        onlyRootRoles(RegistryRolesLib.ROLE_UPGRADE)
-    {
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal view override onlyRootRoles(RegistryRolesLib.ROLE_UPGRADE) {
         if (!UPGRADE_GATE.approvedImplementations(newImplementation)) {
             revert UpgradeTargetNotApproved(newImplementation);
         }

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -2,24 +2,14 @@
 pragma solidity >=0.8.13;
 
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
-import {
-    IProxyAuthorization
-} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
-import {
-    IVerifiableFactory
-} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
-import {
-    Initializable
-} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {
-    UUPSUpgradeable
-} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {IProxyAuthorization} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
+import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
-import {
-    AbstractWrapperReceiver
-} from "../migration/AbstractWrapperReceiver.sol";
+import {AbstractWrapperReceiver} from "../migration/AbstractWrapperReceiver.sol";
 import {LibMigration} from "../migration/libraries/LibMigration.sol";
 import {LockedWrapperReceiver} from "../migration/LockedWrapperReceiver.sol";
 import {IWrapperRegistry} from "../registry/interfaces/IWrapperRegistry.sol";
@@ -90,19 +80,8 @@ contract WrapperRegistry is
         ApprovedUpgradeGate upgradeGate,
         ILabelStore labelStore
     )
-        PermissionedRegistry(
-            hcaFactory,
-            metadataProvider,
-            labelStore,
-            address(0),
-            0
-        ) // no roles are granted
-        LockedWrapperReceiver(
-            nameWrapper,
-            graveyard,
-            verifiableFactory,
-            address(this)
-        )
+        PermissionedRegistry(hcaFactory, metadataProvider, labelStore, address(0), 0) // no roles are granted
+        LockedWrapperReceiver(nameWrapper, graveyard, verifiableFactory, address(this))
     {
         V1_RESOLVER = ensV1Resolver;
         UPGRADE_GATE = upgradeGate;
@@ -110,9 +89,7 @@ contract WrapperRegistry is
     }
 
     /// @inheritdoc IERC165
-    function supportsInterface(
-        bytes4 interfaceId
-    )
+    function supportsInterface(bytes4 interfaceId)
         public
         view
         virtual
@@ -133,7 +110,10 @@ contract WrapperRegistry is
         string calldata childLabel,
         address rootAccount,
         uint256 roleBitmap
-    ) public initializer {
+    )
+        public
+        initializer
+    {
         _node = node;
         // setup canonical parent (ROLE_SET_PARENT is not granted)
         _parentRegistry = parentRegistry;
@@ -153,7 +133,13 @@ contract WrapperRegistry is
     /// @return allowed Always `true` for implementations in this wrapper registry family.
     function canUpgradeFrom(
         address /* previousImplementation */
-    ) external pure virtual override returns (bool allowed) {
+    )
+        external
+        pure
+        virtual
+        override
+        returns (bool allowed)
+    {
         return true;
     }
 
@@ -174,24 +160,18 @@ contract WrapperRegistry is
         if (_isMigratableChild(label)) {
             revert LibMigration.NameRequiresMigration();
         }
-        return
-            super.register(
-                label,
-                owner,
-                registry,
-                resolver,
-                roleBitmap,
-                expiry
-            );
+        return super.register(label, owner, registry, resolver, roleBitmap, expiry);
     }
 
     /// @inheritdoc PermissionedRegistry
     /// @dev Return `V1_RESOLVER` upon visiting migratable children.
-    function getResolver(
-        string calldata label
-    ) public view override(IRegistry, PermissionedRegistry) returns (address) {
-        return
-            _isMigratableChild(label) ? V1_RESOLVER : super.getResolver(label);
+    function getResolver(string calldata label)
+        public
+        view
+        override(IRegistry, PermissionedRegistry)
+        returns (address)
+    {
+        return _isMigratableChild(label) ? V1_RESOLVER : super.getResolver(label);
     }
 
     /// @inheritdoc IWrapperRegistry
@@ -227,23 +207,21 @@ contract WrapperRegistry is
         address resolver,
         uint256 roleBitmap,
         uint64 expiry
-    ) internal override returns (uint256 tokenId) {
-        return
-            _register(
-                label,
-                owner,
-                subregistry,
-                resolver,
-                roleBitmap,
-                expiry,
-                false
-            );
+    )
+        internal
+        override
+        returns (uint256 tokenId)
+    {
+        return _register(label, owner, subregistry, resolver, roleBitmap, expiry, false);
     }
 
     /// @dev Requires `ROLE_UPGRADE` and approval for the target implementation.
-    function _authorizeUpgrade(
-        address newImplementation
-    ) internal view override onlyRootRoles(RegistryRolesLib.ROLE_UPGRADE) {
+    function _authorizeUpgrade(address newImplementation)
+        internal
+        view
+        override
+        onlyRootRoles(RegistryRolesLib.ROLE_UPGRADE)
+    {
         if (!UPGRADE_GATE.approvedImplementations(newImplementation)) {
             revert UpgradeTargetNotApproved(newImplementation);
         }

--- a/contracts/test/fixtures/V1Fixture.sol
+++ b/contracts/test/fixtures/V1Fixture.sol
@@ -19,6 +19,8 @@ contract V1Fixture is Test, ERC721Holder, ERC1155Holder {
     BaseRegistrarImplementation ethRegistrarV1;
     NameWrapper nameWrapper;
 
+    uint64 gracePeriodV1;
+    uint64 testDuration = 1 days;
     address user = makeAddr("user");
     address ensV1Controller = makeAddr("ensV1Controller");
 
@@ -26,12 +28,13 @@ contract V1Fixture is Test, ERC721Holder, ERC1155Holder {
         registryV1 = new ENSRegistry();
         ethRegistrarV1 = new BaseRegistrarImplementation(registryV1, NameCoder.ETH_NODE);
         ethRegistrarV1.addController(ensV1Controller);
+        gracePeriodV1 = uint64(ethRegistrarV1.GRACE_PERIOD());
         _claimNodes(NameCoder.encode("eth"), 0, address(ethRegistrarV1));
         _claimNodes(NameCoder.encode("addr.reverse"), 0, address(this)); // see: fake ReverseClaimer
         nameWrapper = new NameWrapper(registryV1, ethRegistrarV1, IMetadataService(address(0)));
         nameWrapper.setController(ensV1Controller, true);
         ethRegistrarV1.addController(address(nameWrapper));
-        vm.warp(ethRegistrarV1.GRACE_PERIOD() + 1); // avoid timestamp issues
+        vm.warp(gracePeriodV1 + 1); // avoid timestamp issues
     }
 
     // fake ReverseClaimer
@@ -60,7 +63,7 @@ contract V1Fixture is Test, ERC721Holder, ERC1155Holder {
         name = NameCoder.ethName(label);
         tokenId = uint256(keccak256(bytes(label)));
         vm.prank(ensV1Controller);
-        ethRegistrarV1.register(tokenId, user, 1 days); // test duration
+        ethRegistrarV1.register(tokenId, user, testDuration);
     }
 
     function registerWrappedETH2LD(string memory label, uint32 ownerFuses)

--- a/contracts/test/fixtures/V1Fixture.t.sol
+++ b/contracts/test/fixtures/V1Fixture.t.sol
@@ -109,7 +109,7 @@ contract V1FixtureTest is V1Fixture {
         uint256 unwrappedExpiry =
             ethRegistrarV1.nameExpires(uint256(keccak256(bytes(NameCoder.firstLabel(name)))));
         (, , uint256 wrappedExpiry) = nameWrapper.getData(uint256(NameCoder.namehash(name, 0)));
-        assertEq(unwrappedExpiry + ethRegistrarV1.GRACE_PERIOD(), wrappedExpiry);
+        assertEq(unwrappedExpiry + gracePeriodV1, wrappedExpiry);
     }
 
     function test_nameWrapper_CANNOT_UNWRAP_requires_PARENT_CANNOT_CONTROL() external {

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -339,9 +339,7 @@ contract GraveyardTest is MigrationControllerFixture {
     function _simulateExpiry(bytes memory name) internal {
         (bytes32 labelHash, uint256 offset) = NameCoder.readLabel(name, 0);
         if (NameCoder.namehash(name, offset) == NameCoder.ETH_NODE) {
-            vm.warp(
-                ethRegistrarV1.nameExpires(uint256(labelHash)) + ethRegistrarV1.GRACE_PERIOD() + 1
-            );
+            vm.warp(ethRegistrarV1.nameExpires(uint256(labelHash)) + gracePeriodV1 + 1);
         } else {
             (address owner, , uint64 expiry) = nameWrapper.getData(
                 uint256(NameCoder.namehash(name, 0))

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.13;
 import {console} from "forge-std/console.sol";
 import {
     CAN_DO_EVERYTHING,
+    CANNOT_SET_RESOLVER,
     CANNOT_UNWRAP,
     PARENT_CANNOT_CONTROL
 } from "@ens/contracts/wrapper/INameWrapper.sol";
@@ -18,9 +19,34 @@ contract GraveyardTest is MigrationControllerFixture {
         ethRegistrarV1.addController(address(graveyard));
     }
 
-    function test_clear_deep() external {
-        (bytes memory name, uint256 tokenId) = registerUnwrapped(testLabel);
+    function test_clear_alreadyRegistered() external {
+        (bytes memory name, ) = registerUnwrapped(testLabel);
 
+        vm.expectRevert();
+        graveyard.clear(_oneName(name));
+    }
+
+    function test_clear_unregistered() external {
+        graveyard.clear(_oneName(NameCoder.encode("dne.eth")));
+    }
+
+    function test_clear_notDotEth() external {
+        vm.expectRevert();
+        graveyard.clear(_oneName(NameCoder.encode("test.xyz")));
+    }
+
+    function test_clear_root() external {
+        graveyard.clear(_oneName(NameCoder.encode(""))); // noop
+    }
+
+    function test_clear_eth() external {
+        graveyard.clear(_oneName(NameCoder.encode("eth"))); // noop
+    }
+
+    function test_clear_deep() external {
+        (bytes memory name0, ) = registerUnwrapped(testLabel);
+
+        bytes memory name = name0;
         for (uint256 i; i < N; ++i) {
             vm.prank(user);
             registryV1.setSubnodeRecord(
@@ -33,16 +59,22 @@ contract GraveyardTest is MigrationControllerFixture {
             name = NameCoder.addLabel(name, testLabel);
         }
 
-        _simulateUnwrappedMigration(tokenId);
+        _simulateMigration(name);
 
         graveyard.clear(_oneName(name));
+
+        name = name0;
+        for (uint256 i; i < N; ++i) {
+            name = NameCoder.addLabel(name, testLabel);
+            assertEq(registryV1.resolver(NameCoder.namehash(name, 0)), address(0), vm.toString(i));
+        }
     }
 
     function test_clear_wide() external {
-        bytes[] memory names = new bytes[](10);
+        bytes[] memory names = new bytes[](N);
 
         for (uint256 i; i < names.length; ++i) {
-            (bytes memory name, uint256 tokenId) = registerUnwrapped(_label(i));
+            (bytes memory name, ) = registerUnwrapped(_label(i));
             vm.prank(user);
             registryV1.setSubnodeRecord(
                 NameCoder.namehash(name, 0),
@@ -51,14 +83,18 @@ contract GraveyardTest is MigrationControllerFixture {
                 address(1),
                 0
             );
-            _simulateUnwrappedMigration(tokenId);
+            _simulateMigration(name);
             names[i] = NameCoder.addLabel(name, testLabel);
         }
 
         graveyard.clear(names);
 
         for (uint256 i; i < names.length; ++i) {
-            assertEq(registryV1.resolver(NameCoder.namehash(names[i], 0)), address(0));
+            assertEq(
+                registryV1.resolver(NameCoder.namehash(names[i], 0)),
+                address(0),
+                vm.toString(i)
+            );
         }
     }
 
@@ -71,22 +107,23 @@ contract GraveyardTest is MigrationControllerFixture {
             PARENT_CANNOT_CONTROL | CANNOT_UNWRAP
         );
 
-        vm.prank(user);
-        nameWrapper.setResolver(NameCoder.namehash(name2, 0), address(1));
-        vm.prank(user);
+        // set resolvers
+        vm.startPrank(user);
         nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
+        nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
+        vm.stopPrank();
 
-        _simulateLockedMigration(name2);
+        _simulateMigration(name2);
 
         vm.expectRevert();
         graveyard.clear(_oneName(name3));
 
-        _simulateLockedMigration(name3);
+        _simulateMigration(name3);
 
         graveyard.clear(_oneName(name3));
 
-        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0));
-        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0));
+        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0), "2");
+        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
     }
 
     function test_clear_nestedLocked_migrateParent_expiredChild() external {
@@ -98,12 +135,13 @@ contract GraveyardTest is MigrationControllerFixture {
             PARENT_CANNOT_CONTROL | CANNOT_UNWRAP
         );
 
-        vm.prank(user);
-        nameWrapper.setResolver(NameCoder.namehash(name2, 0), address(1));
-        vm.prank(user);
+        // set resolvers
+        vm.startPrank(user);
         nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
+        nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
+        vm.stopPrank();
 
-        _simulateLockedMigration(name2);
+        _simulateMigration(name2);
 
         vm.expectRevert();
         graveyard.clear(_oneName(name3));
@@ -112,8 +150,8 @@ contract GraveyardTest is MigrationControllerFixture {
 
         graveyard.clear(_oneName(name3));
 
-        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0));
-        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0));
+        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0), "2");
+        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
     }
 
     function test_clear_nestedLocked_bothExpired() external {
@@ -125,10 +163,11 @@ contract GraveyardTest is MigrationControllerFixture {
             PARENT_CANNOT_CONTROL | CANNOT_UNWRAP
         );
 
-        vm.prank(user);
+        // set resolvers
+        vm.startPrank(user);
         nameWrapper.setResolver(NameCoder.namehash(name2, 0), address(1));
-        vm.prank(user);
         nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
+        vm.stopPrank();
 
         // expiry(name2) > expiry(name3)
         vm.prank(ensV1Controller);
@@ -146,8 +185,8 @@ contract GraveyardTest is MigrationControllerFixture {
 
         graveyard.clear(_oneName(name3));
 
-        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0));
-        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0));
+        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0), "2");
+        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
     }
 
     function test_clear_locked_expired() external {
@@ -169,22 +208,21 @@ contract GraveyardTest is MigrationControllerFixture {
         name = name0;
         for (uint256 i; i < N; ++i) {
             name = NameCoder.addLabel(name, testLabel);
-            assertEq(registryV1.resolver(NameCoder.namehash(name, 0)), address(0));
+            assertEq(registryV1.resolver(NameCoder.namehash(name, 0)), address(0), vm.toString(i));
         }
     }
 
     function test_clear_complex() external {
         bytes memory name2 = registerWrappedETH2LD("2", CANNOT_UNWRAP);
-        bytes memory name3 = createWrappedChild(name2, "3", user, CAN_DO_EVERYTHING);
+        bytes memory name3 = createWrappedChild(name2, "3", user, PARENT_CANNOT_CONTROL);
         bytes memory name4 = createWrappedChild(name3, "4", user, CAN_DO_EVERYTHING);
 
-        // name2 resolver would be cleared by migration
-
         // set resolvers
-        vm.prank(user);
-        nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(3));
-        vm.prank(user);
-        nameWrapper.setResolver(NameCoder.namehash(name4, 0), address(4));
+        vm.startPrank(user);
+        nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
+        nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
+        nameWrapper.setResolver(NameCoder.namehash(name4, 0), address(1));
+        vm.stopPrank();
 
         // unwrap name4
         vm.prank(user);
@@ -194,37 +232,57 @@ contract GraveyardTest is MigrationControllerFixture {
             address(graveyard)
         );
 
-        // name2 = wrapped locked
-        // name3 = wrapped unlocked emancipated
+        // name2 = locked
+        // name3 = detached (wrapped unlocked emancipated)
         // name4 = unwrapped
 
-        _simulateLockedMigration(name2);
-        _simulateLockedMigration(name3);
+        _simulateMigration(name2);
+        _simulateMigration(name3);
 
         graveyard.clear(_oneName(name4));
 
+        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "2");
         assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
         assertEq(registryV1.resolver(NameCoder.namehash(name4, 0)), address(0), "4");
     }
 
-    function _simulateUnwrappedMigration(uint256 tokenId) internal {
-        vm.prank(user);
-        registryV1.setRecord(
-            NameCoder.namehash(NameCoder.ETH_NODE, bytes32(tokenId)),
-            address(graveyard), // owner
-            address(0), // resolver
-            0 // ttl
-        );
-        vm.prank(user);
-        ethRegistrarV1.safeTransferFrom(user, address(graveyard), tokenId);
-    }
-
-    function _simulateLockedMigration(bytes memory name) internal {
-        bytes32 node = NameCoder.namehash(name, 0);
-        vm.prank(user);
-        nameWrapper.setResolver(node, address(0));
-        vm.prank(user);
-        nameWrapper.safeTransferFrom(user, address(graveyard), uint256(node), 1, "");
+    /// @dev Clear resolver if possible and transfer to graveyard.
+    function _simulateMigration(bytes memory name) internal {
+        uint256 offset;
+        bytes32 labelHash;
+        while (true) {
+            bytes32 node = NameCoder.namehash(name, offset);
+            (labelHash, offset) = NameCoder.readLabel(name, offset);
+            bytes32 parentNode = NameCoder.namehash(name, offset);
+            address owner = registryV1.owner(node);
+            if (owner == address(nameWrapper)) {
+                uint32 fuses;
+                (owner, fuses, ) = nameWrapper.getData(uint256(node));
+                if ((fuses & CANNOT_SET_RESOLVER) == 0) {
+                    vm.prank(owner);
+                    nameWrapper.setResolver(node, address(0));
+                }
+                if ((fuses & CANNOT_UNWRAP) == 0) {
+                    vm.prank(owner);
+                    nameWrapper.unwrap(parentNode, labelHash, address(graveyard));
+                } else {
+                    vm.prank(owner);
+                    nameWrapper.safeTransferFrom(owner, address(graveyard), uint256(node), 1, "");
+                }
+                return;
+            } else if (parentNode == NameCoder.ETH_NODE) {
+                vm.prank(owner);
+                registryV1.setRecord(
+                    node,
+                    address(graveyard), // owner
+                    address(0), // resolver
+                    0 // ttl
+                );
+                vm.prank(owner);
+                ethRegistrarV1.safeTransferFrom(owner, address(graveyard), uint256(labelHash));
+                return;
+            }
+        }
     }
 
     function _simulateExpiry(bytes memory name) internal {

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-import {console} from "forge-std/console.sol";
 import {
     CAN_DO_EVERYTHING,
     CANNOT_SET_RESOLVER,
@@ -19,28 +18,58 @@ contract GraveyardTest is MigrationControllerFixture {
         ethRegistrarV1.addController(address(graveyard));
     }
 
-    function test_clear_alreadyRegistered() external {
-        (bytes memory name, ) = registerUnwrapped(testLabel);
-
-        vm.expectRevert();
-        graveyard.clear(_oneName(name));
-    }
-
-    function test_clear_unregistered() external {
-        graveyard.clear(_oneName(NameCoder.encode("dne.eth")));
-    }
-
-    function test_clear_notDotEth() external {
-        vm.expectRevert();
-        graveyard.clear(_oneName(NameCoder.encode("test.xyz")));
-    }
-
     function test_clear_root() external {
         graveyard.clear(_oneName(NameCoder.encode(""))); // noop
     }
 
     function test_clear_eth() external {
         graveyard.clear(_oneName(NameCoder.encode("eth"))); // noop
+    }
+
+    function test_clear_xyz() external {
+        vm.expectRevert();
+        graveyard.clear(_oneName(NameCoder.encode("xyz")));
+        vm.expectRevert();
+        graveyard.clear(_oneName(NameCoder.encode("test.xyz")));
+    }
+
+    function test_clear_registered_unwrapped() external {
+        (bytes memory name, ) = registerUnwrapped(testLabel);
+
+        vm.expectRevert();
+        graveyard.clear(_oneName(name));
+    }
+
+    function test_clear_registered_unlocked() external {
+        bytes memory name = registerWrappedETH2LD(testLabel, CAN_DO_EVERYTHING);
+
+        vm.expectRevert();
+        graveyard.clear(_oneName(name));
+    }
+
+    function test_clear_registered_locked() external {
+        bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+
+        vm.expectRevert();
+        graveyard.clear(_oneName(name));
+    }
+
+    function test_clear_unregistered(uint256) external {
+        graveyard.clear(_oneName(_randomName()));
+    }
+
+    function test_clear_junk_deep(uint256) external {
+        bytes memory name = _randomName();
+        bytes32 node = NameCoder.namehash(name, 0);
+
+        _claimNodes(name, 0, address(user));
+        vm.prank(user);
+        registryV1.setResolver(node, address(1));
+        assertEq(registryV1.resolver(node), address(1));
+
+        graveyard.clear(_oneName(name));
+
+        assertEq(registryV1.resolver(node), address(0));
     }
 
     function test_clear_deep() external {
@@ -189,6 +218,33 @@ contract GraveyardTest is MigrationControllerFixture {
         assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
     }
 
+    function test_clear_detached(bool unwrapped) external {
+        bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        bytes memory name3 = createWrappedChild(name2, testLabel, user, PARENT_CANNOT_CONTROL);
+
+        // set resolvers
+        vm.startPrank(user);
+        nameWrapper.setResolver(NameCoder.namehash(name2, 0), address(1));
+        nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
+        vm.stopPrank();
+
+        if (unwrapped) {
+            vm.prank(user);
+            nameWrapper.unwrap(
+                NameCoder.namehash(name2, 0),
+                keccak256(bytes(NameCoder.firstLabel(name3))),
+                address(graveyard)
+            );
+        }
+
+        _simulateExpiry(name2);
+
+        graveyard.clear(_oneName(name3));
+
+        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0), "2");
+        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
+    }
+
     function test_clear_locked_expired() external {
         bytes memory name0 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         bytes memory name = name0;
@@ -279,6 +335,7 @@ contract GraveyardTest is MigrationControllerFixture {
         }
     }
 
+    /// @dev Warp past expiry + grace.
     function _simulateExpiry(bytes memory name) internal {
         (bytes32 labelHash, uint256 offset) = NameCoder.readLabel(name, 0);
         if (NameCoder.namehash(name, offset) == NameCoder.ETH_NODE) {
@@ -292,6 +349,14 @@ contract GraveyardTest is MigrationControllerFixture {
             if (owner != address(0)) {
                 vm.warp(expiry + 1);
             }
+        }
+    }
+
+    /// @dev Create random .eth name.
+    function _randomName() internal returns (bytes memory name) {
+        name = NameCoder.encode("eth");
+        for (uint256 n = vm.randomUint(1, 10); n > 0; --n) {
+            name = NameCoder.addLabel(name, new string(vm.randomUint(1, 255)));
         }
     }
 

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -59,7 +59,7 @@ contract GraveyardTest is MigrationControllerFixture {
             name = NameCoder.addLabel(name, testLabel);
         }
 
-        _simulateMigration(name);
+        _simulateMigration(name0);
 
         graveyard.clear(_oneName(name));
 
@@ -248,40 +248,34 @@ contract GraveyardTest is MigrationControllerFixture {
 
     /// @dev Clear resolver if possible and transfer to graveyard.
     function _simulateMigration(bytes memory name) internal {
-        uint256 offset;
-        bytes32 labelHash;
-        while (true) {
-            bytes32 node = NameCoder.namehash(name, offset);
-            (labelHash, offset) = NameCoder.readLabel(name, offset);
-            bytes32 parentNode = NameCoder.namehash(name, offset);
-            address owner = registryV1.owner(node);
-            if (owner == address(nameWrapper)) {
-                uint32 fuses;
-                (owner, fuses, ) = nameWrapper.getData(uint256(node));
-                if ((fuses & CANNOT_SET_RESOLVER) == 0) {
-                    vm.prank(owner);
-                    nameWrapper.setResolver(node, address(0));
-                }
-                if ((fuses & CANNOT_UNWRAP) == 0) {
-                    vm.prank(owner);
-                    nameWrapper.unwrap(parentNode, labelHash, address(graveyard));
-                } else {
-                    vm.prank(owner);
-                    nameWrapper.safeTransferFrom(owner, address(graveyard), uint256(node), 1, "");
-                }
-                return;
-            } else if (parentNode == NameCoder.ETH_NODE) {
+        bytes32 node = NameCoder.namehash(name, 0);
+        (bytes32 labelHash, uint256 offset) = NameCoder.readLabel(name, 0);
+        bytes32 parentNode = NameCoder.namehash(name, offset);
+        address owner = registryV1.owner(node);
+        if (owner == address(nameWrapper)) {
+            uint32 fuses;
+            (owner, fuses, ) = nameWrapper.getData(uint256(node));
+            if ((fuses & CANNOT_SET_RESOLVER) == 0) {
                 vm.prank(owner);
-                registryV1.setRecord(
-                    node,
-                    address(graveyard), // owner
-                    address(0), // resolver
-                    0 // ttl
-                );
-                vm.prank(owner);
-                ethRegistrarV1.safeTransferFrom(owner, address(graveyard), uint256(labelHash));
-                return;
+                nameWrapper.setResolver(node, address(0));
             }
+            if ((fuses & CANNOT_UNWRAP) == 0) {
+                vm.prank(owner);
+                nameWrapper.unwrap(parentNode, labelHash, address(graveyard));
+            } else {
+                vm.prank(owner);
+                nameWrapper.safeTransferFrom(owner, address(graveyard), uint256(node), 1, "");
+            }
+        } else if (parentNode == NameCoder.ETH_NODE) {
+            vm.prank(owner);
+            registryV1.setRecord(
+                node,
+                address(graveyard), // owner
+                address(0), // resolver
+                0 // ttl
+            );
+            vm.prank(owner);
+            ethRegistrarV1.safeTransferFrom(owner, address(graveyard), uint256(labelHash));
         }
     }
 

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import {MigrationControllerFixture, NameCoder} from "./MigrationControllerFixture.sol";
+
+contract GraveyardTest is MigrationControllerFixture {
+    function setUp() public override {
+        super.setUp();
+        ethRegistrarV1.addController(address(graveyard));
+    }
+
+    function test_clear_wide(uint8 count) external {
+        bytes32[] memory ls = new bytes32[](count);
+        bytes32[] memory ps = new bytes32[](count);
+        for (uint256 i; i < count; ++i) {
+            ls[i] = bytes32(i);
+            ps[i] = NameCoder.ETH_NODE;
+        }
+
+        graveyard.clear(ps, ls);
+    }
+
+    function test_clear_deep(uint8 depth) external {
+        bytes32[] memory ls = new bytes32[](depth);
+        bytes32[] memory ps = new bytes32[](depth);
+        bytes32 parent = NameCoder.ETH_NODE;
+        for (uint256 i; i < depth; ++i) {
+            bytes32 labelHash = bytes32(i);
+            ls[i] = labelHash;
+            ps[i] = parent;
+            parent = NameCoder.namehash(parent, labelHash);
+        }
+
+        graveyard.clear(ps, ls);
+    }
+}

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -1,123 +1,186 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-import {CAN_DO_EVERYTHING, CANNOT_UNWRAP} from "@ens/contracts/wrapper/INameWrapper.sol";
+import {console} from "forge-std/console.sol";
+import {
+    CAN_DO_EVERYTHING,
+    CANNOT_UNWRAP,
+    PARENT_CANNOT_CONTROL
+} from "@ens/contracts/wrapper/INameWrapper.sol";
 
 import {MigrationControllerFixture, NameCoder} from "./MigrationControllerFixture.sol";
 
 contract GraveyardTest is MigrationControllerFixture {
+    uint256 constant N = 10;
+
     function setUp() public override {
         super.setUp();
         ethRegistrarV1.addController(address(graveyard));
     }
 
-    function test_clearUnwrapped_example_registered() external {
-        (bytes memory name, uint256 tokenId) = registerUnwrapped("test");
-        bytes32 node = NameCoder.namehash(name, 0);
+    function test_clear_deep() external {
+        (bytes memory name, uint256 tokenId) = registerUnwrapped(testLabel);
 
-        vm.prank(user);
-        registryV1.setResolver(node, address(1));
-
-        bytes32[] memory ls = new bytes32[](1);
-        bytes32[] memory ps = new bytes32[](1);
-
-        ls[0] = bytes32(tokenId);
-        ps[0] = NameCoder.ETH_NODE;
-
-        vm.expectRevert();
-        graveyard.clearUnwrapped(ps, ls);
-
-        vm.warp(ethRegistrarV1.nameExpires(tokenId) + ethRegistrarV1.GRACE_PERIOD() + 1);
-
-        graveyard.clearUnwrapped(ps, ls);
-
-        assertEq(registryV1.resolver(node), address(0));
-    }
-
-    function test_clearUnwrapped_example_transferred() external {
-        (bytes memory name, uint256 tokenId) = registerUnwrapped("test");
-        bytes32 node = NameCoder.namehash(name, 0);
-
-        vm.prank(user);
-        registryV1.setResolver(node, address(1));
-
-        bytes32[] memory ls = new bytes32[](1);
-        bytes32[] memory ps = new bytes32[](1);
-
-        ls[0] = bytes32(tokenId);
-        ps[0] = NameCoder.ETH_NODE;
-
-        vm.expectRevert();
-        graveyard.clearUnwrapped(ps, ls);
-
-        // do migration logic
-        vm.prank(user);
-        registryV1.setOwner(node, address(graveyard));
-        vm.prank(user);
-        ethRegistrarV1.safeTransferFrom(user, address(graveyard), tokenId);
-
-        graveyard.clearUnwrapped(ps, ls);
-
-        assertEq(registryV1.resolver(node), address(0));
-    }
-
-    function test_clearUnwrapped_example_deep() external {
-        bytes memory name = NameCoder.encode("a.bb.ccc.dddd.eeeee.eth");
-        _claimNodes(name, 0, user);
-
-        uint256 count = NameCoder.countLabels(name, 0) - 1; // drop eth
-        bytes32[] memory ls = new bytes32[](count);
-        bytes32[] memory ps = new bytes32[](count);
-
-        uint256 offset;
-        bytes32 node = NameCoder.namehash(name, offset);
-
-        while (node != NameCoder.ETH_NODE) {
+        for (uint256 i; i < N; ++i) {
             vm.prank(user);
-            registryV1.setResolver(node, address(1));
-            (ls[--count], offset) = NameCoder.readLabel(name, offset);
-            ps[count] = node = NameCoder.namehash(name, offset);
+            registryV1.setSubnodeRecord(
+                NameCoder.namehash(name, 0),
+                keccak256(bytes(testLabel)),
+                user,
+                address(1),
+                0
+            );
+            name = NameCoder.addLabel(name, testLabel);
         }
 
-        graveyard.clearUnwrapped(ps, ls);
+        _simulateUnwrappedMigration(tokenId);
 
-        for (uint256 i; i < ls.length; ++i) {
-            assertEq(registryV1.resolver(NameCoder.namehash(ps[i], ls[i])), address(0));
+        graveyard.clear(_oneName(name));
+    }
+
+    function test_clear_wide() external {
+        bytes[] memory names = new bytes[](10);
+
+        for (uint256 i; i < names.length; ++i) {
+            (bytes memory name, uint256 tokenId) = registerUnwrapped(_label(i));
+            vm.prank(user);
+            registryV1.setSubnodeRecord(
+                NameCoder.namehash(name, 0),
+                keccak256(bytes(testLabel)),
+                friend,
+                address(1),
+                0
+            );
+            _simulateUnwrappedMigration(tokenId);
+            names[i] = NameCoder.addLabel(name, testLabel);
+        }
+
+        graveyard.clear(names);
+
+        for (uint256 i; i < names.length; ++i) {
+            assertEq(registryV1.resolver(NameCoder.namehash(names[i], 0)), address(0));
         }
     }
 
-    function test_clearUnwrapped_wide(uint8 count) external {
-        bytes32[] memory ls = new bytes32[](count);
-        bytes32[] memory ps = new bytes32[](count);
-        for (uint256 i; i < count; ++i) {
-            ls[i] = bytes32(i);
-            ps[i] = NameCoder.ETH_NODE;
-        }
+    function test_clear_nestedLocked_migrateBoth() external {
+        bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        bytes memory name3 = createWrappedChild(
+            name2,
+            testLabel,
+            user,
+            PARENT_CANNOT_CONTROL | CANNOT_UNWRAP
+        );
 
-        graveyard.clearUnwrapped(ps, ls);
+        vm.prank(user);
+        nameWrapper.setResolver(NameCoder.namehash(name2, 0), address(1));
+        vm.prank(user);
+        nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
+
+        _simulateLockedMigration(name2);
+
+        vm.expectRevert();
+        graveyard.clear(_oneName(name3));
+
+        _simulateLockedMigration(name3);
+
+        graveyard.clear(_oneName(name3));
+
+        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0));
+        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0));
     }
 
-    function test_clearUnwrapped_deep(uint8 depth) external {
-        bytes32[] memory ls = new bytes32[](depth);
-        bytes32[] memory ps = new bytes32[](depth);
-        bytes32 parent = NameCoder.ETH_NODE;
-        for (uint256 i; i < depth; ++i) {
-            bytes32 labelHash = bytes32(i);
-            ls[i] = labelHash;
-            ps[i] = parent;
-            parent = NameCoder.namehash(parent, labelHash);
-        }
+    function test_clear_nestedLocked_migrateParent_expiredChild() external {
+        bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        bytes memory name3 = createWrappedChild(
+            name2,
+            testLabel,
+            user,
+            PARENT_CANNOT_CONTROL | CANNOT_UNWRAP
+        );
 
-        graveyard.clearUnwrapped(ps, ls);
+        vm.prank(user);
+        nameWrapper.setResolver(NameCoder.namehash(name2, 0), address(1));
+        vm.prank(user);
+        nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
+
+        _simulateLockedMigration(name2);
+
+        vm.expectRevert();
+        graveyard.clear(_oneName(name3));
+
+        _simulateExpiry(name3);
+
+        graveyard.clear(_oneName(name3));
+
+        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0));
+        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0));
     }
 
-    function test_clearWrappedChildren_example() external {
-        bytes memory name2 = registerWrappedETH2LD("test", CANNOT_UNWRAP);
-        bytes memory name3 = createWrappedChild(name2, "sub", user, CAN_DO_EVERYTHING);
-        bytes memory name4 = createWrappedChild(name3, "abc", user, CAN_DO_EVERYTHING);
+    function test_clear_nestedLocked_bothExpired() external {
+        bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        bytes memory name3 = createWrappedChild(
+            name2,
+            testLabel,
+            user,
+            PARENT_CANNOT_CONTROL | CANNOT_UNWRAP
+        );
+
+        vm.prank(user);
+        nameWrapper.setResolver(NameCoder.namehash(name2, 0), address(1));
+        vm.prank(user);
+        nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
+
+        // expiry(name2) > expiry(name3)
+        vm.prank(ensV1Controller);
+        nameWrapper.renew(uint256(keccak256(bytes(testLabel))), 10 days);
+
+        vm.expectRevert();
+        graveyard.clear(_oneName(name3));
+
+        _simulateExpiry(name3);
+
+        vm.expectRevert();
+        graveyard.clear(_oneName(name3));
+
+        _simulateExpiry(name2);
+
+        graveyard.clear(_oneName(name3));
+
+        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0));
+        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0));
+    }
+
+    function test_clear_locked_expired() external {
+        bytes memory name0 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        bytes memory name = name0;
+        for (uint256 i; i < N; ++i) {
+            name = createWrappedChild(name, testLabel, user, PARENT_CANNOT_CONTROL | CANNOT_UNWRAP);
+            vm.prank(user);
+            nameWrapper.setResolver(NameCoder.namehash(name, 0), address(1));
+        }
+
+        vm.expectRevert();
+        graveyard.clear(_oneName(name));
+
+        _simulateExpiry(name0);
+
+        graveyard.clear(_oneName(name));
+
+        name = name0;
+        for (uint256 i; i < N; ++i) {
+            name = NameCoder.addLabel(name, testLabel);
+            assertEq(registryV1.resolver(NameCoder.namehash(name, 0)), address(0));
+        }
+    }
+
+    function test_clear_complex() external {
+        bytes memory name2 = registerWrappedETH2LD("2", CANNOT_UNWRAP);
+        bytes memory name3 = createWrappedChild(name2, "3", user, CAN_DO_EVERYTHING);
+        bytes memory name4 = createWrappedChild(name3, "4", user, CAN_DO_EVERYTHING);
 
         // name2 resolver would be cleared by migration
 
+        // set resolvers
         vm.prank(user);
         nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(3));
         vm.prank(user);
@@ -131,37 +194,57 @@ contract GraveyardTest is MigrationControllerFixture {
             address(graveyard)
         );
 
-        vm.prank(user);
-        nameWrapper.safeTransferFrom(
-            user,
-            address(graveyard),
-            uint256(NameCoder.namehash(name2, 0)),
-            1,
-            ""
-        );
-        vm.prank(user);
-        nameWrapper.safeTransferFrom(
-            user,
-            address(graveyard),
-            uint256(NameCoder.namehash(name3, 0)),
-            1,
-            ""
-        );
+        // name2 = wrapped locked
+        // name3 = wrapped unlocked emancipated
+        // name4 = unwrapped
 
-        // clear name3
-        string[] memory ss = new string[](1);
-        bytes32[] memory ps = new bytes32[](1);
-        ss[0] = NameCoder.firstLabel(name3);
-        ps[0] = NameCoder.namehash(name2, 0);
-        graveyard.clearWrappedChildren(ps, ss);
+        _simulateLockedMigration(name2);
+        _simulateLockedMigration(name3);
 
-        // clear name4
-        bytes32[] memory ls = new bytes32[](1);
-        ls[0] = keccak256(bytes(NameCoder.firstLabel(name4)));
-        ps[0] = NameCoder.namehash(name3, 0);
-        graveyard.clearUnwrapped(ps, ls);
+        graveyard.clear(_oneName(name4));
 
         assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
         assertEq(registryV1.resolver(NameCoder.namehash(name4, 0)), address(0), "4");
+    }
+
+    function _simulateUnwrappedMigration(uint256 tokenId) internal {
+        vm.prank(user);
+        registryV1.setRecord(
+            NameCoder.namehash(NameCoder.ETH_NODE, bytes32(tokenId)),
+            address(graveyard), // owner
+            address(0), // resolver
+            0 // ttl
+        );
+        vm.prank(user);
+        ethRegistrarV1.safeTransferFrom(user, address(graveyard), tokenId);
+    }
+
+    function _simulateLockedMigration(bytes memory name) internal {
+        bytes32 node = NameCoder.namehash(name, 0);
+        vm.prank(user);
+        nameWrapper.setResolver(node, address(0));
+        vm.prank(user);
+        nameWrapper.safeTransferFrom(user, address(graveyard), uint256(node), 1, "");
+    }
+
+    function _simulateExpiry(bytes memory name) internal {
+        (bytes32 labelHash, uint256 offset) = NameCoder.readLabel(name, 0);
+        if (NameCoder.namehash(name, offset) == NameCoder.ETH_NODE) {
+            vm.warp(
+                ethRegistrarV1.nameExpires(uint256(labelHash)) + ethRegistrarV1.GRACE_PERIOD() + 1
+            );
+        } else {
+            (address owner, , uint64 expiry) = nameWrapper.getData(
+                uint256(NameCoder.namehash(name, 0))
+            );
+            if (owner != address(0)) {
+                vm.warp(expiry + 1);
+            }
+        }
+    }
+
+    function _oneName(bytes memory name) internal pure returns (bytes[] memory names) {
+        names = new bytes[](1);
+        names[0] = name;
     }
 }

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-import {console} from "forge-std/console.sol";
+import {CAN_DO_EVERYTHING, CANNOT_UNWRAP} from "@ens/contracts/wrapper/INameWrapper.sol";
 
 import {MigrationControllerFixture, NameCoder} from "./MigrationControllerFixture.sol";
 
@@ -11,7 +11,7 @@ contract GraveyardTest is MigrationControllerFixture {
         ethRegistrarV1.addController(address(graveyard));
     }
 
-    function test_clear_example_registered() external {
+    function test_clearUnwrapped_example_registered() external {
         (bytes memory name, uint256 tokenId) = registerUnwrapped("test");
         bytes32 node = NameCoder.namehash(name, 0);
 
@@ -25,16 +25,43 @@ contract GraveyardTest is MigrationControllerFixture {
         ps[0] = NameCoder.ETH_NODE;
 
         vm.expectRevert();
-        graveyard.clear(ps, ls);
+        graveyard.clearUnwrapped(ps, ls);
 
         vm.warp(ethRegistrarV1.nameExpires(tokenId) + ethRegistrarV1.GRACE_PERIOD() + 1);
 
-        graveyard.clear(ps, ls);
+        graveyard.clearUnwrapped(ps, ls);
 
         assertEq(registryV1.resolver(node), address(0));
     }
 
-    function test_clear_example_deep() external {
+    function test_clearUnwrapped_example_transferred() external {
+        (bytes memory name, uint256 tokenId) = registerUnwrapped("test");
+        bytes32 node = NameCoder.namehash(name, 0);
+
+        vm.prank(user);
+        registryV1.setResolver(node, address(1));
+
+        bytes32[] memory ls = new bytes32[](1);
+        bytes32[] memory ps = new bytes32[](1);
+
+        ls[0] = bytes32(tokenId);
+        ps[0] = NameCoder.ETH_NODE;
+
+        vm.expectRevert();
+        graveyard.clearUnwrapped(ps, ls);
+
+        // do migration logic
+        vm.prank(user);
+        registryV1.setOwner(node, address(graveyard));
+        vm.prank(user);
+        ethRegistrarV1.safeTransferFrom(user, address(graveyard), tokenId);
+
+        graveyard.clearUnwrapped(ps, ls);
+
+        assertEq(registryV1.resolver(node), address(0));
+    }
+
+    function test_clearUnwrapped_example_deep() external {
         bytes memory name = NameCoder.encode("a.bb.ccc.dddd.eeeee.eth");
         _claimNodes(name, 0, user);
 
@@ -52,14 +79,14 @@ contract GraveyardTest is MigrationControllerFixture {
             ps[count] = node = NameCoder.namehash(name, offset);
         }
 
-        graveyard.clear(ps, ls);
+        graveyard.clearUnwrapped(ps, ls);
 
         for (uint256 i; i < ls.length; ++i) {
             assertEq(registryV1.resolver(NameCoder.namehash(ps[i], ls[i])), address(0));
         }
     }
 
-    function test_clear_wide(uint8 count) external {
+    function test_clearUnwrapped_wide(uint8 count) external {
         bytes32[] memory ls = new bytes32[](count);
         bytes32[] memory ps = new bytes32[](count);
         for (uint256 i; i < count; ++i) {
@@ -67,10 +94,10 @@ contract GraveyardTest is MigrationControllerFixture {
             ps[i] = NameCoder.ETH_NODE;
         }
 
-        graveyard.clear(ps, ls);
+        graveyard.clearUnwrapped(ps, ls);
     }
 
-    function test_clear_deep(uint8 depth) external {
+    function test_clearUnwrapped_deep(uint8 depth) external {
         bytes32[] memory ls = new bytes32[](depth);
         bytes32[] memory ps = new bytes32[](depth);
         bytes32 parent = NameCoder.ETH_NODE;
@@ -81,6 +108,60 @@ contract GraveyardTest is MigrationControllerFixture {
             parent = NameCoder.namehash(parent, labelHash);
         }
 
-        graveyard.clear(ps, ls);
+        graveyard.clearUnwrapped(ps, ls);
+    }
+
+    function test_clearWrappedChildren_example() external {
+        bytes memory name2 = registerWrappedETH2LD("test", CANNOT_UNWRAP);
+        bytes memory name3 = createWrappedChild(name2, "sub", user, CAN_DO_EVERYTHING);
+        bytes memory name4 = createWrappedChild(name3, "abc", user, CAN_DO_EVERYTHING);
+
+        // name2 resolver would be cleared by migration
+
+        vm.prank(user);
+        nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(3));
+        vm.prank(user);
+        nameWrapper.setResolver(NameCoder.namehash(name4, 0), address(4));
+
+        // unwrap name4
+        vm.prank(user);
+        nameWrapper.unwrap(
+            NameCoder.namehash(name3, 0),
+            keccak256(bytes(NameCoder.firstLabel(name4))),
+            address(graveyard)
+        );
+
+        vm.prank(user);
+        nameWrapper.safeTransferFrom(
+            user,
+            address(graveyard),
+            uint256(NameCoder.namehash(name2, 0)),
+            1,
+            ""
+        );
+        vm.prank(user);
+        nameWrapper.safeTransferFrom(
+            user,
+            address(graveyard),
+            uint256(NameCoder.namehash(name3, 0)),
+            1,
+            ""
+        );
+
+        // clear name3
+        string[] memory ss = new string[](1);
+        bytes32[] memory ps = new bytes32[](1);
+        ss[0] = NameCoder.firstLabel(name3);
+        ps[0] = NameCoder.namehash(name2, 0);
+        graveyard.clearWrappedChildren(ps, ss);
+
+        // clear name4
+        bytes32[] memory ls = new bytes32[](1);
+        ls[0] = keccak256(bytes(NameCoder.firstLabel(name4)));
+        ps[0] = NameCoder.namehash(name3, 0);
+        graveyard.clearUnwrapped(ps, ls);
+
+        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
+        assertEq(registryV1.resolver(NameCoder.namehash(name4, 0)), address(0), "4");
     }
 }

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -1,12 +1,62 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
+import {console} from "forge-std/console.sol";
+
 import {MigrationControllerFixture, NameCoder} from "./MigrationControllerFixture.sol";
 
 contract GraveyardTest is MigrationControllerFixture {
     function setUp() public override {
         super.setUp();
         ethRegistrarV1.addController(address(graveyard));
+    }
+
+    function test_clear_example_registered() external {
+        (bytes memory name, uint256 tokenId) = registerUnwrapped("test");
+        bytes32 node = NameCoder.namehash(name, 0);
+
+        vm.prank(user);
+        registryV1.setResolver(node, address(1));
+
+        bytes32[] memory ls = new bytes32[](1);
+        bytes32[] memory ps = new bytes32[](1);
+
+        ls[0] = bytes32(tokenId);
+        ps[0] = NameCoder.ETH_NODE;
+
+        vm.expectRevert();
+        graveyard.clear(ps, ls);
+
+        vm.warp(ethRegistrarV1.nameExpires(tokenId) + ethRegistrarV1.GRACE_PERIOD() + 1);
+
+        graveyard.clear(ps, ls);
+
+        assertEq(registryV1.resolver(node), address(0));
+    }
+
+    function test_clear_example_deep() external {
+        bytes memory name = NameCoder.encode("a.bb.ccc.dddd.eeeee.eth");
+        _claimNodes(name, 0, user);
+
+        uint256 count = NameCoder.countLabels(name, 0) - 1; // drop eth
+        bytes32[] memory ls = new bytes32[](count);
+        bytes32[] memory ps = new bytes32[](count);
+
+        uint256 offset;
+        bytes32 node = NameCoder.namehash(name, offset);
+
+        while (node != NameCoder.ETH_NODE) {
+            vm.prank(user);
+            registryV1.setResolver(node, address(1));
+            (ls[--count], offset) = NameCoder.readLabel(name, offset);
+            ps[count] = node = NameCoder.namehash(name, offset);
+        }
+
+        graveyard.clear(ps, ls);
+
+        for (uint256 i; i < ls.length; ++i) {
+            assertEq(registryV1.resolver(NameCoder.namehash(ps[i], ls[i])), address(0));
+        }
     }
 
     function test_clear_wide(uint8 count) external {

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -129,12 +129,8 @@ contract GraveyardTest is MigrationControllerFixture {
 
     function test_clear_nestedLocked_migrateBoth() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
-        bytes memory name3 = createWrappedChild(
-            name2,
-            testLabel,
-            user,
-            PARENT_CANNOT_CONTROL | CANNOT_UNWRAP
-        );
+        bytes memory name3 =
+            createWrappedChild(name2, testLabel, user, PARENT_CANNOT_CONTROL | CANNOT_UNWRAP);
 
         // set resolvers
         vm.startPrank(user);
@@ -157,12 +153,8 @@ contract GraveyardTest is MigrationControllerFixture {
 
     function test_clear_nestedLocked_migrateParent_expiredChild() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
-        bytes memory name3 = createWrappedChild(
-            name2,
-            testLabel,
-            user,
-            PARENT_CANNOT_CONTROL | CANNOT_UNWRAP
-        );
+        bytes memory name3 =
+            createWrappedChild(name2, testLabel, user, PARENT_CANNOT_CONTROL | CANNOT_UNWRAP);
 
         // set resolvers
         vm.startPrank(user);
@@ -185,12 +177,8 @@ contract GraveyardTest is MigrationControllerFixture {
 
     function test_clear_nestedLocked_bothExpired() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
-        bytes memory name3 = createWrappedChild(
-            name2,
-            testLabel,
-            user,
-            PARENT_CANNOT_CONTROL | CANNOT_UNWRAP
-        );
+        bytes memory name3 =
+            createWrappedChild(name2, testLabel, user, PARENT_CANNOT_CONTROL | CANNOT_UNWRAP);
 
         // set resolvers
         vm.startPrank(user);
@@ -341,9 +329,8 @@ contract GraveyardTest is MigrationControllerFixture {
         if (NameCoder.namehash(name, offset) == NameCoder.ETH_NODE) {
             vm.warp(ethRegistrarV1.nameExpires(uint256(labelHash)) + gracePeriodV1 + 1);
         } else {
-            (address owner, , uint64 expiry) = nameWrapper.getData(
-                uint256(NameCoder.namehash(name, 0))
-            );
+            (address owner, , uint64 expiry) =
+                nameWrapper.getData(uint256(NameCoder.namehash(name, 0)));
             if (owner != address(0)) {
                 vm.warp(expiry + 1);
             }

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -80,6 +80,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         emit IRegistryEvents.RegistryCreated();
         wrapperRegistryImpl = new WrapperRegistry(
             nameWrapper,
+            address(graveyard),
             verifiableFactory,
             address(ensV1Resolver),
             hcaFactory,
@@ -89,6 +90,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
         migrationController = new LockedMigrationController(
             nameWrapper,
+            address(graveyard),
             ethRegistry,
             verifiableFactory,
             address(wrapperRegistryImpl)
@@ -104,16 +106,21 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         ethRegistrarV1.setResolver(address(ensV2Resolver));
     }
 
-    function test_constructor() external view {
+    function test_constructor_controller() external view {
         assertEq(
-            address(migrationController.ETH_REGISTRY()),
-            address(ethRegistry),
-            "ETH_REGISTRY"
+            address(migrationController.GRAVEYARD()),
+            address(graveyard),
+            "GRAVEYARD"
         );
         assertEq(
             address(migrationController.NAME_WRAPPER()),
             address(nameWrapper),
             "NAME_WRAPPER"
+        );
+        assertEq(
+            address(migrationController.ETH_REGISTRY()),
+            address(ethRegistry),
+            "ETH_REGISTRY"
         );
         assertEq(
             address(migrationController.VERIFIABLE_FACTORY()),
@@ -125,6 +132,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             address(wrapperRegistryImpl),
             "WRAPPER_REGISTRY_IMPL"
         );
+
         assertEq(
             migrationController.getWrappedName(),
             NameCoder.encode("eth"),
@@ -137,13 +145,53 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
-    function test_supportsInterface() external view {
+    function test_constructor_registry() external view {
+        assertEq(
+            address(wrapperRegistryImpl.GRAVEYARD()),
+            address(graveyard),
+            "GRAVEYARD"
+        );
+        assertEq(
+            address(wrapperRegistryImpl.NAME_WRAPPER()),
+            address(nameWrapper),
+            "NAME_WRAPPER"
+        );
+        assertEq(
+            address(wrapperRegistryImpl.VERIFIABLE_FACTORY()),
+            address(verifiableFactory),
+            "VERIFIABLE_FACTORY"
+        );
+        assertEq(
+            wrapperRegistryImpl.V1_RESOLVER(),
+            address(ensV1Resolver),
+            "V1_RESOLVER"
+        );
+    }
+
+    function test_supportsInterface_controller() external view {
         assertTrue(
             ERC165Checker.supportsInterface(
                 address(migrationController),
                 type(IERC1155Receiver).interfaceId
             ),
             "IERC1155Receiver"
+        );
+    }
+
+    function test_supportsInterface_registry() external view {
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(migrationController),
+                type(IERC1155Receiver).interfaceId
+            ),
+            "IERC1155Receiver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(wrapperRegistryImpl),
+                type(IWrapperRegistry).interfaceId
+            ),
+            "IWrapperRegistry"
         );
     }
 
@@ -193,6 +241,12 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
                 RegistryRolesLib.ROLE_UPGRADE,
                 user
             )
+        );
+    }
+
+    function test_finishERC1155Migration_unauthorizedCaller() external {
+        vm.expectRevert(
+            abi.encodeWithSelector(UnauthorizedCaller.selector, user)
         );
         vm.prank(user);
         registry.upgradeToAndCall(address(newImplementation), "");
@@ -994,6 +1048,11 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             address(registry2.getSubregistry(data3.label)),
             address(testRegistry),
             "registry3"
+        );
+        assertEq(
+            registryV1.owner(NameCoder.namehash(name3, 0)),
+            address(graveyard),
+            "graveyard3"
         );
 
         // check migrated 3LD child

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -19,29 +19,54 @@ import {
 import {ENS} from "@ens/contracts/registry/ENS.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
-import {IERC1155Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
-import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
-import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
-import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
+import {
+    IERC1155Errors
+} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {
+    IERC1155Receiver
+} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {
+    ERC165Checker
+} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import {
+    IVerifiableFactory
+} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
 
 import {InvalidOwner, UnauthorizedCaller} from "~src/CommonErrors.sol";
 import {LibLabel} from "~src/utils/LibLabel.sol";
 import {ILabelStore} from "~src/utils/interfaces/ILabelStore.sol";
 import {LibMigration} from "~src/migration/libraries/LibMigration.sol";
 import {WrappedErrorLib} from "~src/utils/WrappedErrorLib.sol";
-import {LockedMigrationController} from "~src/migration/LockedMigrationController.sol";
+import {
+    LockedMigrationController
+} from "~src/migration/LockedMigrationController.sol";
 import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
-import {IStandardRegistry} from "~src/registry/interfaces/IStandardRegistry.sol";
-import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
+import {
+    IStandardRegistry
+} from "~src/registry/interfaces/IStandardRegistry.sol";
+import {
+    IPermissionedRegistry
+} from "~src/registry/interfaces/IPermissionedRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
-import {IEnhancedAccessControl} from "~src/access-control/interfaces/IEnhancedAccessControl.sol";
-import {EACBaseRolesLib} from "~src/access-control/libraries/EACBaseRolesLib.sol";
+import {
+    IEnhancedAccessControl
+} from "~src/access-control/interfaces/IEnhancedAccessControl.sol";
+import {
+    EACBaseRolesLib
+} from "~src/access-control/libraries/EACBaseRolesLib.sol";
 import {IHCAFactoryBasic} from "~src/hca/interfaces/IHCAFactoryBasic.sol";
-import {WrapperRegistry, IWrapperRegistry} from "~src/registry/WrapperRegistry.sol";
+import {
+    WrapperRegistry,
+    IWrapperRegistry
+} from "~src/registry/WrapperRegistry.sol";
 import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
-import {IRegistryMetadata} from "~src/registry/interfaces/IRegistryMetadata.sol";
+import {
+    IRegistryMetadata
+} from "~src/registry/interfaces/IRegistryMetadata.sol";
 import {ApprovedUpgradeGate} from "~src/registry/ApprovedUpgradeGate.sol";
-import {MigrationControllerFixture} from "~test/unit/migration/MigrationControllerFixture.sol";
+import {
+    MigrationControllerFixture
+} from "~test/unit/migration/MigrationControllerFixture.sol";
 
 contract LockedMigrationControllerTest is MigrationControllerFixture {
     LockedMigrationController migrationController;
@@ -68,7 +93,10 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             verifiableFactory,
             address(wrapperRegistryImpl)
         );
-        ethRegistry.grantRootRoles(RegistryRolesLib.ROLE_REGISTRAR, premigrationController);
+        ethRegistry.grantRootRoles(
+            RegistryRolesLib.ROLE_REGISTRAR,
+            premigrationController
+        );
         ethRegistry.grantRootRoles(
             RegistryRolesLib.ROLE_REGISTER_RESERVED,
             address(migrationController)
@@ -77,8 +105,16 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
     }
 
     function test_constructor() external view {
-        assertEq(address(migrationController.ETH_REGISTRY()), address(ethRegistry), "ETH_REGISTRY");
-        assertEq(address(migrationController.NAME_WRAPPER()), address(nameWrapper), "NAME_WRAPPER");
+        assertEq(
+            address(migrationController.ETH_REGISTRY()),
+            address(ethRegistry),
+            "ETH_REGISTRY"
+        );
+        assertEq(
+            address(migrationController.NAME_WRAPPER()),
+            address(nameWrapper),
+            "NAME_WRAPPER"
+        );
         assertEq(
             address(migrationController.VERIFIABLE_FACTORY()),
             address(verifiableFactory),
@@ -89,8 +125,16 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             address(wrapperRegistryImpl),
             "WRAPPER_REGISTRY_IMPL"
         );
-        assertEq(migrationController.getWrappedName(), NameCoder.encode("eth"), "getWrappedName");
-        assertEq(migrationController.getWrappedNode(), NameCoder.ETH_NODE, "getWrappedNode");
+        assertEq(
+            migrationController.getWrappedName(),
+            NameCoder.encode("eth"),
+            "getWrappedName"
+        );
+        assertEq(
+            migrationController.getWrappedNode(),
+            NameCoder.ETH_NODE,
+            "getWrappedNode"
+        );
     }
 
     function test_supportsInterface() external view {
@@ -120,17 +164,27 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         WrapperRegistry registry = _deployWrapperRegistryProxy(address(this));
         WrapperRegistryV2Mock newImplementation = _newWrapperRegistryV2Mock();
 
-        approvedUpgradeGate.setImplementationApproval(address(newImplementation), true);
+        approvedUpgradeGate.setImplementationApproval(
+            address(newImplementation),
+            true
+        );
         registry.upgradeToAndCall(address(newImplementation), "");
 
-        assertEq(WrapperRegistryV2Mock(address(registry)).version(), 2, "version");
+        assertEq(
+            WrapperRegistryV2Mock(address(registry)).version(),
+            2,
+            "version"
+        );
     }
 
     function test_wrapperRegistryUpgrade_requiresUpgradeRole() external {
         WrapperRegistry registry = _deployWrapperRegistryProxy(address(this));
         WrapperRegistryV2Mock newImplementation = _newWrapperRegistryV2Mock();
 
-        approvedUpgradeGate.setImplementationApproval(address(newImplementation), true);
+        approvedUpgradeGate.setImplementationApproval(
+            address(newImplementation),
+            true
+        );
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -152,25 +206,40 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
     }
 
     function test_finishERC1155Migration_unauthorizedCaller() external {
-        vm.expectRevert(abi.encodeWithSelector(UnauthorizedCaller.selector, user));
+        vm.expectRevert(
+            abi.encodeWithSelector(UnauthorizedCaller.selector, user)
+        );
         vm.prank(user);
-        migrationController.finishERC1155Migration(new uint256[](0), new LibMigration.Data[](0));
+        migrationController.finishERC1155Migration(
+            new uint256[](0),
+            new LibMigration.Data[](0)
+        );
     }
 
     function test_safeTransferFrom_unauthorizedCaller() external {
         uint256 tokenId = dummy1155.mint(user);
         vm.expectRevert(
-            WrappedErrorLib.wrap(abi.encodeWithSelector(UnauthorizedCaller.selector, dummy1155))
+            WrappedErrorLib.wrap(
+                abi.encodeWithSelector(UnauthorizedCaller.selector, dummy1155)
+            )
         );
         vm.prank(user);
-        dummy1155.safeTransferFrom(user, address(migrationController), tokenId, 1, ""); // wrong
+        dummy1155.safeTransferFrom(
+            user,
+            address(migrationController),
+            tokenId,
+            1,
+            ""
+        ); // wrong
     }
 
     function test_migrate_invalidData(bytes calldata v) external {
         vm.assume(v.length < LibMigration.MIN_DATA_SIZE);
         bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         vm.expectRevert(
-            WrappedErrorLib.wrap(abi.encodeWithSelector(LibMigration.InvalidData.selector))
+            WrappedErrorLib.wrap(
+                abi.encodeWithSelector(LibMigration.InvalidData.selector)
+            )
         );
         vm.prank(user);
         nameWrapper.safeTransferFrom(
@@ -205,14 +274,22 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             )
         );
         vm.prank(user);
-        nameWrapper.safeBatchTransferFrom(user, address(migrationController), ids, amounts, payload);
+        nameWrapper.safeBatchTransferFrom(
+            user,
+            address(migrationController),
+            ids,
+            amounts,
+            payload
+        );
     }
 
     function test_migrate_invalidOwner() external {
         bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         LibMigration.Data memory md = _makeData(name);
         md.owner = address(0); // wrong
-        vm.expectRevert(WrappedErrorLib.wrap(abi.encodeWithSelector(InvalidOwner.selector)));
+        vm.expectRevert(
+            WrappedErrorLib.wrap(abi.encodeWithSelector(InvalidOwner.selector))
+        );
         vm.prank(user);
         nameWrapper.safeTransferFrom(
             user,
@@ -229,7 +306,10 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         md.owner = address(ethRegistry); // not a IERC1155Receiver
         vm.expectRevert(
             WrappedErrorLib.wrap(
-                abi.encodeWithSelector(IERC1155Errors.ERC1155InvalidReceiver.selector, md.owner)
+                abi.encodeWithSelector(
+                    IERC1155Errors.ERC1155InvalidReceiver.selector,
+                    md.owner
+                )
             )
         );
         vm.prank(user);
@@ -249,7 +329,10 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         md.label = "wrong";
         vm.expectRevert(
             WrappedErrorLib.wrap(
-                abi.encodeWithSelector(LibMigration.NameDataMismatch.selector, node)
+                abi.encodeWithSelector(
+                    LibMigration.NameDataMismatch.selector,
+                    node
+                )
             )
         );
         vm.prank(user);
@@ -267,7 +350,12 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         bytes32 node = NameCoder.namehash(name, 0);
         LibMigration.Data memory md = _makeData(name);
         vm.expectRevert(
-            WrappedErrorLib.wrap(abi.encodeWithSelector(LibMigration.NameNotLocked.selector, node))
+            WrappedErrorLib.wrap(
+                abi.encodeWithSelector(
+                    LibMigration.NameNotLocked.selector,
+                    node
+                )
+            )
         );
         vm.prank(user);
         nameWrapper.safeTransferFrom(
@@ -308,7 +396,13 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         LibMigration.Data memory md = _makeData(name);
         uint256 tokenIdV1 = LibLabel.id(md.label);
 
-        assertFalse(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, user));
+        assertFalse(
+            ethRegistry.hasRoles(
+                tokenIdV1,
+                RegistryRolesLib.ROLE_WAS_RESERVED,
+                user
+            )
+        );
 
         vm.prank(user);
         nameWrapper.safeTransferFrom(
@@ -319,7 +413,13 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             abi.encode(md)
         );
 
-        assertTrue(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, user));
+        assertTrue(
+            ethRegistry.hasRoles(
+                tokenIdV1,
+                RegistryRolesLib.ROLE_WAS_RESERVED,
+                user
+            )
+        );
     }
 
     function test_migrate() external {
@@ -328,12 +428,20 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         LibMigration.Data memory md = _makeData(name);
         bytes32 node = NameCoder.namehash(name, 0);
         uint256 salt = uint256(node);
-        address expectedRegistry =
-            _computeVerifiableFactoryAddress(address(migrationController), salt);
+        address expectedRegistry = _computeVerifiableFactoryAddress(
+            address(migrationController),
+            salt
+        );
         uint256 tokenIdV1 = LibLabel.id(md.label);
         uint256 tokenId = LibLabel.withVersion(tokenIdV1, 0);
         vm.expectEmit();
-        emit IERC1155.TransferSingle(user, user, address(migrationController), uint256(node), 1);
+        emit IERC1155.TransferSingle(
+            user,
+            user,
+            address(migrationController),
+            uint256(node),
+            1
+        );
         vm.expectEmit();
         emit ENS.NewResolver(node, address(0));
         // emit IERC1967.Upgraded()
@@ -345,11 +453,11 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             md.owner,
             0 /*old roles*/,
             RegistryRolesLib.ROLE_UPGRADE_ADMIN |
-            RegistryRolesLib.ROLE_UPGRADE |
-            RegistryRolesLib.ROLE_REGISTRAR |
-            RegistryRolesLib.ROLE_REGISTRAR_ADMIN |
-            RegistryRolesLib.ROLE_RENEW |
-            RegistryRolesLib.ROLE_RENEW_ADMIN
+                RegistryRolesLib.ROLE_UPGRADE |
+                RegistryRolesLib.ROLE_REGISTRAR |
+                RegistryRolesLib.ROLE_REGISTRAR_ADMIN |
+                RegistryRolesLib.ROLE_RENEW |
+                RegistryRolesLib.ROLE_RENEW_ADMIN
         );
         // emit Initializable.Initialized()
         vm.expectEmit();
@@ -369,7 +477,13 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             address(migrationController)
         );
         vm.expectEmit();
-        emit IERC1155.TransferSingle(address(migrationController), address(0), md.owner, tokenId, 1);
+        emit IERC1155.TransferSingle(
+            address(migrationController),
+            address(0),
+            md.owner,
+            tokenId,
+            1
+        );
         vm.expectEmit();
         emit IPermissionedRegistry.TokenResource(tokenId, tokenId);
         vm.expectEmit();
@@ -378,9 +492,9 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             md.owner,
             0 /*old roles*/,
             RegistryRolesLib.ROLE_SET_RESOLVER |
-            RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
-            RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
-            RegistryRolesLib.ROLE_WAS_RESERVED
+                RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
+                RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
+                RegistryRolesLib.ROLE_WAS_RESERVED
         );
         vm.expectEmit();
         emit IRegistryEvents.SubregistryUpdated(
@@ -389,7 +503,11 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             address(migrationController)
         );
         vm.expectEmit();
-        emit IRegistryEvents.ResolverUpdated(tokenId, md.resolver, address(migrationController));
+        emit IRegistryEvents.ResolverUpdated(
+            tokenId,
+            md.resolver,
+            address(migrationController)
+        );
         vm.prank(user);
         uint256 g = gasleft();
         nameWrapper.safeTransferFrom(
@@ -403,13 +521,21 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
 
         assertEq(ethRegistry.getTokenId(tokenIdV1), tokenId, "tokenId");
         assertEq(ethRegistry.ownerOf(tokenId), md.owner, "owner");
-        assertEq(ethRegistry.getExpiry(tokenId), ethRegistrarV1.nameExpires(tokenIdV1), "expiry");
+        assertEq(
+            ethRegistry.getExpiry(tokenId),
+            ethRegistrarV1.nameExpires(tokenIdV1),
+            "expiry"
+        );
         assertEq(ethRegistry.getResolver(md.label), md.resolver, "resolver");
         checkResolution(name, address(ensV2Resolver), md.resolver);
-        IWrapperRegistry subregistry =
-            IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
+        IWrapperRegistry subregistry = IWrapperRegistry(
+            address(ethRegistry.getSubregistry(md.label))
+        );
         assertTrue(
-            ERC165Checker.supportsInterface(address(subregistry), type(IWrapperRegistry).interfaceId),
+            ERC165Checker.supportsInterface(
+                address(subregistry),
+                type(IWrapperRegistry).interfaceId
+            ),
             "IWrapperRegistry"
         );
         assertTrue(
@@ -418,13 +544,17 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
         assertEq(
             subregistry.roleCount(subregistry.ROOT_RESOURCE()) &
-            (RegistryRolesLib.ROLE_SET_PARENT * 15),
+                (RegistryRolesLib.ROLE_SET_PARENT * 15),
             0,
             "ROLE_SET_PARENT"
         );
         assertEq(subregistry.getWrappedNode(), node, "getWrappedNode");
         assertEq(subregistry.getWrappedName(), name, "getWrappedName");
-        assertEq(universalResolver.findCanonicalName(subregistry), name, "findCanonicalName");
+        assertEq(
+            universalResolver.findCanonicalName(subregistry),
+            name,
+            "findCanonicalName"
+        );
     }
 
     function test_migrateBatch(uint8 count) external {
@@ -452,7 +582,11 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             string memory label = _label(i);
             uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(label));
             assertEq(ethRegistry.ownerOf(tokenId), user, "owner");
-            assertEq(ethRegistry.getResolver(label), address(uint160(i)), "resolver");
+            assertEq(
+                ethRegistry.getResolver(label),
+                address(uint160(i)),
+                "resolver"
+            );
             assertTrue(
                 ERC165Checker.supportsInterface(
                     address(ethRegistry.getSubregistry(label)),
@@ -469,8 +603,10 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         uint256[] memory amounts = new uint256[](count);
         LibMigration.Data[] memory mds = new LibMigration.Data[](count);
         for (uint256 i; i < count; ++i) {
-            bytes memory name =
-                registerWrappedETH2LD(_label(i), i == count - 1 ? CAN_DO_EVERYTHING : CANNOT_UNWRAP);
+            bytes memory name = registerWrappedETH2LD(
+                _label(i),
+                i == count - 1 ? CAN_DO_EVERYTHING : CANNOT_UNWRAP
+            );
             LibMigration.Data memory md = _makeData(name);
             mds[i] = md;
             ids[i] = uint256(NameCoder.namehash(name, 0));
@@ -478,7 +614,10 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         }
         vm.expectRevert(
             WrappedErrorLib.wrap(
-                abi.encodeWithSelector(LibMigration.NameNotLocked.selector, ids[count - 1])
+                abi.encodeWithSelector(
+                    LibMigration.NameNotLocked.selector,
+                    ids[count - 1]
+                )
             )
         );
         vm.prank(user);
@@ -515,7 +654,13 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(md.label));
         assertEq(ethRegistry.getResolver(md.label), frozenResolver, "frozen");
         checkResolution(name, frozenResolver, frozenResolver);
-        assertFalse(ethRegistry.hasRoles(tokenId, RegistryRolesLib.ROLE_SET_RESOLVER, user));
+        assertFalse(
+            ethRegistry.hasRoles(
+                tokenId,
+                RegistryRolesLib.ROLE_SET_RESOLVER,
+                user
+            )
+        );
         vm.expectRevert(
             abi.encodeWithSelector(
                 IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
@@ -529,11 +674,16 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
     }
 
     function test_migrate_lockedTransfer() external {
-        bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP | CANNOT_TRANSFER);
+        bytes memory name = registerWrappedETH2LD(
+            testLabel,
+            CANNOT_UNWRAP | CANNOT_TRANSFER
+        );
         bytes32 node = NameCoder.namehash(name, 0);
         LibMigration.Data memory md = _makeData(name);
 
-        vm.expectRevert(abi.encodeWithSelector(OperationProhibited.selector, node));
+        vm.expectRevert(
+            abi.encodeWithSelector(OperationProhibited.selector, node)
+        );
         vm.prank(user);
         nameWrapper.safeTransferFrom(
             user,
@@ -545,7 +695,10 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
     }
 
     function test_migrate_lockedFuses() external {
-        bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP | CANNOT_BURN_FUSES);
+        bytes memory name = registerWrappedETH2LD(
+            testLabel,
+            CANNOT_UNWRAP | CANNOT_BURN_FUSES
+        );
         LibMigration.Data memory md = _makeData(name);
 
         vm.prank(user);
@@ -563,17 +716,23 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN,
             "token"
         );
-        IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
+        IWrapperRegistry registry = IWrapperRegistry(
+            address(ethRegistry.getSubregistry(md.label))
+        );
         assertEq(
-            registry.roles(registry.ROOT_RESOURCE(), user) & EACBaseRolesLib.ADMIN_ROLES,
-            RegistryRolesLib.ROLE_UPGRADE_ADMIN | RegistryRolesLib.ROLE_RENEW_ADMIN,
+            registry.roles(registry.ROOT_RESOURCE(), user) &
+                EACBaseRolesLib.ADMIN_ROLES,
+            RegistryRolesLib.ROLE_UPGRADE_ADMIN |
+                RegistryRolesLib.ROLE_RENEW_ADMIN,
             "registry"
         );
     }
 
     function test_migrate_cannotCreateChildren() external {
-        bytes memory name =
-            registerWrappedETH2LD(testLabel, CANNOT_UNWRAP | CANNOT_CREATE_SUBDOMAIN);
+        bytes memory name = registerWrappedETH2LD(
+            testLabel,
+            CANNOT_UNWRAP | CANNOT_CREATE_SUBDOMAIN
+        );
         LibMigration.Data memory md = _makeData(name);
 
         vm.prank(user);
@@ -586,7 +745,9 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
 
         uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(md.label));
-        assertFalse(ethRegistry.hasRoles(tokenId, RegistryRolesLib.ROLE_REGISTRAR, user));
+        assertFalse(
+            ethRegistry.hasRoles(tokenId, RegistryRolesLib.ROLE_REGISTRAR, user)
+        );
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -609,13 +770,12 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
 
     function test_migrate_canExtendExpiry() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
-        bytes memory name3 =
-            createWrappedChild(
-                name2,
-                "sub",
-                friend,
-                CANNOT_UNWRAP | PARENT_CANNOT_CONTROL | CAN_EXTEND_EXPIRY
-            );
+        bytes memory name3 = createWrappedChild(
+            name2,
+            "sub",
+            friend,
+            CANNOT_UNWRAP | PARENT_CANNOT_CONTROL | CAN_EXTEND_EXPIRY
+        );
 
         // migrate 2LD
         LibMigration.Data memory data2 = _makeData(name2);
@@ -627,8 +787,9 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             1,
             abi.encode(data2)
         );
-        IWrapperRegistry registry2 =
-            IWrapperRegistry(address(ethRegistry.getSubregistry(data2.label)));
+        IWrapperRegistry registry2 = IWrapperRegistry(
+            address(ethRegistry.getSubregistry(data2.label))
+        );
 
         // migrate 3LD
         LibMigration.Data memory data3 = _makeData(name3);
@@ -642,7 +803,10 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
 
         uint256 tokenId = registry2.getTokenId(LibLabel.id(data3.label));
-        assertTrue(registry2.hasRoles(tokenId, RegistryRolesLib.ROLE_RENEW, friend), "ROLE_RENEW");
+        assertTrue(
+            registry2.hasRoles(tokenId, RegistryRolesLib.ROLE_RENEW, friend),
+            "ROLE_RENEW"
+        );
 
         uint64 expiry = registry2.getExpiry(tokenId);
         vm.prank(friend);
@@ -651,10 +815,18 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
 
     function test_migrate_lockedChildren() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
-        bytes memory name3 =
-            createWrappedChild(name2, "sub", friend, CANNOT_UNWRAP | PARENT_CANNOT_CONTROL);
-        bytes memory name3unmigrated =
-            createWrappedChild(name2, "unmigrated", friend, CANNOT_UNWRAP | PARENT_CANNOT_CONTROL);
+        bytes memory name3 = createWrappedChild(
+            name2,
+            "sub",
+            friend,
+            CANNOT_UNWRAP | PARENT_CANNOT_CONTROL
+        );
+        bytes memory name3unmigrated = createWrappedChild(
+            name2,
+            "unmigrated",
+            friend,
+            CANNOT_UNWRAP | PARENT_CANNOT_CONTROL
+        );
 
         // migrate 2LD
         LibMigration.Data memory data2 = _makeData(name2);
@@ -667,14 +839,20 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             abi.encode(data2)
         );
         assertEq(
-            ethRegistry.ownerOf(ethRegistry.getTokenId(LibLabel.id(data2.label))),
+            ethRegistry.ownerOf(
+                ethRegistry.getTokenId(LibLabel.id(data2.label))
+            ),
             data2.owner,
             "owner2"
         );
-        IWrapperRegistry registry2 =
-            IWrapperRegistry(address(ethRegistry.getSubregistry(data2.label)));
+        IWrapperRegistry registry2 = IWrapperRegistry(
+            address(ethRegistry.getSubregistry(data2.label))
+        );
         assertTrue(
-            ERC165Checker.supportsInterface(address(registry2), type(IWrapperRegistry).interfaceId),
+            ERC165Checker.supportsInterface(
+                address(registry2),
+                type(IWrapperRegistry).interfaceId
+            ),
             "registry2"
         );
 
@@ -688,7 +866,11 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             1,
             abi.encode(data3)
         );
-        assertEq(registry2.getResolver(data3.label), data3.resolver, "resolver3");
+        assertEq(
+            registry2.getResolver(data3.label),
+            data3.resolver,
+            "resolver3"
+        );
         checkResolution(name3, address(ensV2Resolver), data3.resolver);
         assertEq(
             registry2.ownerOf(registry2.getTokenId(LibLabel.id(data3.label))),
@@ -697,19 +879,34 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
         IRegistry registry3 = registry2.getSubregistry(data3.label);
         assertTrue(
-            ERC165Checker.supportsInterface(address(registry3), type(IWrapperRegistry).interfaceId),
+            ERC165Checker.supportsInterface(
+                address(registry3),
+                type(IWrapperRegistry).interfaceId
+            ),
             "registry3"
         );
 
         // check migrated 3LD child
         vm.expectRevert(
-            abi.encodeWithSelector(IStandardRegistry.LabelAlreadyRegistered.selector, data3.label)
+            abi.encodeWithSelector(
+                IStandardRegistry.LabelAlreadyRegistered.selector,
+                data3.label
+            )
         );
         vm.prank(friend);
-        registry2.register(data3.label, user, IRegistry(address(0)), address(0), 0, _soon());
+        registry2.register(
+            data3.label,
+            user,
+            IRegistry(address(0)),
+            address(0),
+            0,
+            _soon()
+        );
 
         // check unmigrated 3LD child
-        vm.expectRevert(abi.encodeWithSelector(LibMigration.NameRequiresMigration.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(LibMigration.NameRequiresMigration.selector)
+        );
         vm.prank(friend);
         registry2.register(
             NameCoder.firstLabel(name3unmigrated),
@@ -721,15 +918,27 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
 
         vm.prank(friend);
-        nameWrapper.setResolver(NameCoder.namehash(name3unmigrated, 0), testResolver);
+        nameWrapper.setResolver(
+            NameCoder.namehash(name3unmigrated, 0),
+            testResolver
+        );
         checkResolution(name3unmigrated, testResolver, address(ensV1Resolver));
     }
 
     function test_migrate_detachedChildren() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
-        bytes memory name3 = createWrappedChild(name2, "sub", friend, PARENT_CANNOT_CONTROL);
-        bytes memory name3unmigrated =
-            createWrappedChild(name2, "unmigrated", friend, PARENT_CANNOT_CONTROL);
+        bytes memory name3 = createWrappedChild(
+            name2,
+            "sub",
+            friend,
+            PARENT_CANNOT_CONTROL
+        );
+        bytes memory name3unmigrated = createWrappedChild(
+            name2,
+            "unmigrated",
+            friend,
+            PARENT_CANNOT_CONTROL
+        );
 
         // migrate 2LD
         LibMigration.Data memory data2 = _makeData(name2);
@@ -742,14 +951,20 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             abi.encode(data2)
         );
         assertEq(
-            ethRegistry.ownerOf(ethRegistry.getTokenId(LibLabel.id(data2.label))),
+            ethRegistry.ownerOf(
+                ethRegistry.getTokenId(LibLabel.id(data2.label))
+            ),
             data2.owner,
             "owner2"
         );
-        IWrapperRegistry registry2 =
-            IWrapperRegistry(address(ethRegistry.getSubregistry(data2.label)));
+        IWrapperRegistry registry2 = IWrapperRegistry(
+            address(ethRegistry.getSubregistry(data2.label))
+        );
         assertTrue(
-            ERC165Checker.supportsInterface(address(registry2), type(IWrapperRegistry).interfaceId),
+            ERC165Checker.supportsInterface(
+                address(registry2),
+                type(IWrapperRegistry).interfaceId
+            ),
             "registry2"
         );
 
@@ -764,24 +979,44 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             1,
             abi.encode(data3)
         );
-        assertEq(registry2.getResolver(data3.label), data3.resolver, "resolver3");
+        assertEq(
+            registry2.getResolver(data3.label),
+            data3.resolver,
+            "resolver3"
+        );
         checkResolution(name3, address(ensV2Resolver), data3.resolver);
         assertEq(
             registry2.ownerOf(registry2.getTokenId(LibLabel.id(data3.label))),
             data3.owner,
             "owner3"
         );
-        assertEq(address(registry2.getSubregistry(data3.label)), address(testRegistry), "registry3");
+        assertEq(
+            address(registry2.getSubregistry(data3.label)),
+            address(testRegistry),
+            "registry3"
+        );
 
         // check migrated 3LD child
         vm.expectRevert(
-            abi.encodeWithSelector(IStandardRegistry.LabelAlreadyRegistered.selector, data3.label)
+            abi.encodeWithSelector(
+                IStandardRegistry.LabelAlreadyRegistered.selector,
+                data3.label
+            )
         );
         vm.prank(friend);
-        registry2.register(data3.label, user, IRegistry(address(0)), address(0), 0, _soon());
+        registry2.register(
+            data3.label,
+            user,
+            IRegistry(address(0)),
+            address(0),
+            0,
+            _soon()
+        );
 
         // check unmigrated 3LD child
-        vm.expectRevert(abi.encodeWithSelector(LibMigration.NameRequiresMigration.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(LibMigration.NameRequiresMigration.selector)
+        );
         vm.prank(friend);
         registry2.register(
             NameCoder.firstLabel(name3unmigrated),
@@ -793,7 +1028,10 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
 
         vm.prank(friend);
-        nameWrapper.setResolver(NameCoder.namehash(name3unmigrated, 0), testResolver);
+        nameWrapper.setResolver(
+            NameCoder.namehash(name3unmigrated, 0),
+            testResolver
+        );
         checkResolution(name3unmigrated, testResolver, address(ensV1Resolver));
     }
 
@@ -804,7 +1042,11 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         // give approval
         vm.prank(user);
         nameWrapper.approve(address(this), uint256(node));
-        assertEq(nameWrapper.getApproved(uint256(node)), address(this), "approved");
+        assertEq(
+            nameWrapper.getApproved(uint256(node)),
+            address(this),
+            "approved"
+        );
 
         // freeze approval
         vm.prank(user);
@@ -813,7 +1055,10 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         LibMigration.Data memory data = _makeData(name);
         vm.expectRevert(
             WrappedErrorLib.wrap(
-                abi.encodeWithSelector(LibMigration.FrozenTokenApproval.selector, node)
+                abi.encodeWithSelector(
+                    LibMigration.FrozenTokenApproval.selector,
+                    node
+                )
             )
         );
         vm.prank(user);
@@ -826,33 +1071,47 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
-    function _makeData(bytes memory name) internal view returns (LibMigration.Data memory) {
+    function _makeData(
+        bytes memory name
+    ) internal view returns (LibMigration.Data memory) {
         return
             LibMigration.Data({
                 label: NameCoder.firstLabel(name),
-                owner: nameWrapper.ownerOf(uint256(NameCoder.namehash(name, 0))),
+                owner: nameWrapper.ownerOf(
+                    uint256(NameCoder.namehash(name, 0))
+                ),
                 subregistry: IRegistry(address(0)), // ignored by LockedMigrationController
                 resolver: testResolver
             });
     }
 
-    function _deployWrapperRegistryProxy(address rootAccount) internal returns (WrapperRegistry) {
+    function _deployWrapperRegistryProxy(
+        address rootAccount
+    ) internal returns (WrapperRegistry) {
         bytes memory name = NameCoder.encode(string.concat(testLabel, ".eth"));
         bytes32 node = NameCoder.namehash(name, 0);
         uint256 salt = uint256(node);
-        address proxyAddress =
-            verifiableFactory.deployProxy(
-                address(wrapperRegistryImpl),
-                salt,
-                abi.encodeCall(
-                    IWrapperRegistry.initialize,
-                    (node, ethRegistry, testLabel, rootAccount, RegistryRolesLib.ROLE_UPGRADE)
+        address proxyAddress = verifiableFactory.deployProxy(
+            address(wrapperRegistryImpl),
+            salt,
+            abi.encodeCall(
+                IWrapperRegistry.initialize,
+                (
+                    node,
+                    ethRegistry,
+                    testLabel,
+                    rootAccount,
+                    RegistryRolesLib.ROLE_UPGRADE
                 )
-            );
+            )
+        );
         return WrapperRegistry(proxyAddress);
     }
 
-    function _newWrapperRegistryV2Mock() internal returns (WrapperRegistryV2Mock) {
+    function _newWrapperRegistryV2Mock()
+        internal
+        returns (WrapperRegistryV2Mock)
+    {
         return
             new WrapperRegistryV2Mock(
                 nameWrapper,
@@ -865,7 +1124,6 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             );
     }
 }
-
 
 contract WrapperRegistryV2Mock is WrapperRegistry {
     constructor(

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -96,10 +96,6 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             address(wrapperRegistryImpl)
         );
         ethRegistry.grantRootRoles(
-            RegistryRolesLib.ROLE_REGISTRAR,
-            premigrationController
-        );
-        ethRegistry.grantRootRoles(
             RegistryRolesLib.ROLE_REGISTER_RESERVED,
             address(migrationController)
         );

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -19,54 +19,29 @@ import {
 import {ENS} from "@ens/contracts/registry/ENS.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
-import {
-    IERC1155Errors
-} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
-import {
-    IERC1155Receiver
-} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
-import {
-    ERC165Checker
-} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
-import {
-    IVerifiableFactory
-} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
+import {IERC1155Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
 
 import {InvalidOwner, UnauthorizedCaller} from "~src/CommonErrors.sol";
 import {LibLabel} from "~src/utils/LibLabel.sol";
 import {ILabelStore} from "~src/utils/interfaces/ILabelStore.sol";
 import {LibMigration} from "~src/migration/libraries/LibMigration.sol";
 import {WrappedErrorLib} from "~src/utils/WrappedErrorLib.sol";
-import {
-    LockedMigrationController
-} from "~src/migration/LockedMigrationController.sol";
+import {LockedMigrationController} from "~src/migration/LockedMigrationController.sol";
 import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
-import {
-    IStandardRegistry
-} from "~src/registry/interfaces/IStandardRegistry.sol";
-import {
-    IPermissionedRegistry
-} from "~src/registry/interfaces/IPermissionedRegistry.sol";
+import {IStandardRegistry} from "~src/registry/interfaces/IStandardRegistry.sol";
+import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
-import {
-    IEnhancedAccessControl
-} from "~src/access-control/interfaces/IEnhancedAccessControl.sol";
-import {
-    EACBaseRolesLib
-} from "~src/access-control/libraries/EACBaseRolesLib.sol";
+import {IEnhancedAccessControl} from "~src/access-control/interfaces/IEnhancedAccessControl.sol";
+import {EACBaseRolesLib} from "~src/access-control/libraries/EACBaseRolesLib.sol";
 import {IHCAFactoryBasic} from "~src/hca/interfaces/IHCAFactoryBasic.sol";
-import {
-    WrapperRegistry,
-    IWrapperRegistry
-} from "~src/registry/WrapperRegistry.sol";
+import {WrapperRegistry, IWrapperRegistry} from "~src/registry/WrapperRegistry.sol";
 import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
-import {
-    IRegistryMetadata
-} from "~src/registry/interfaces/IRegistryMetadata.sol";
+import {IRegistryMetadata} from "~src/registry/interfaces/IRegistryMetadata.sol";
 import {ApprovedUpgradeGate} from "~src/registry/ApprovedUpgradeGate.sol";
-import {
-    MigrationControllerFixture
-} from "~test/unit/migration/MigrationControllerFixture.sol";
+import {MigrationControllerFixture} from "~test/unit/migration/MigrationControllerFixture.sol";
 
 contract LockedMigrationControllerTest is MigrationControllerFixture {
     LockedMigrationController migrationController;
@@ -103,21 +78,9 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
     }
 
     function test_constructor_controller() external view {
-        assertEq(
-            address(migrationController.GRAVEYARD()),
-            address(graveyard),
-            "GRAVEYARD"
-        );
-        assertEq(
-            address(migrationController.NAME_WRAPPER()),
-            address(nameWrapper),
-            "NAME_WRAPPER"
-        );
-        assertEq(
-            address(migrationController.ETH_REGISTRY()),
-            address(ethRegistry),
-            "ETH_REGISTRY"
-        );
+        assertEq(address(migrationController.GRAVEYARD()), address(graveyard), "GRAVEYARD");
+        assertEq(address(migrationController.NAME_WRAPPER()), address(nameWrapper), "NAME_WRAPPER");
+        assertEq(address(migrationController.ETH_REGISTRY()), address(ethRegistry), "ETH_REGISTRY");
         assertEq(
             address(migrationController.VERIFIABLE_FACTORY()),
             address(verifiableFactory),
@@ -129,39 +92,19 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             "WRAPPER_REGISTRY_IMPL"
         );
 
-        assertEq(
-            migrationController.getWrappedName(),
-            NameCoder.encode("eth"),
-            "getWrappedName"
-        );
-        assertEq(
-            migrationController.getWrappedNode(),
-            NameCoder.ETH_NODE,
-            "getWrappedNode"
-        );
+        assertEq(migrationController.getWrappedName(), NameCoder.encode("eth"), "getWrappedName");
+        assertEq(migrationController.getWrappedNode(), NameCoder.ETH_NODE, "getWrappedNode");
     }
 
     function test_constructor_registry() external view {
-        assertEq(
-            address(wrapperRegistryImpl.GRAVEYARD()),
-            address(graveyard),
-            "GRAVEYARD"
-        );
-        assertEq(
-            address(wrapperRegistryImpl.NAME_WRAPPER()),
-            address(nameWrapper),
-            "NAME_WRAPPER"
-        );
+        assertEq(address(wrapperRegistryImpl.GRAVEYARD()), address(graveyard), "GRAVEYARD");
+        assertEq(address(wrapperRegistryImpl.NAME_WRAPPER()), address(nameWrapper), "NAME_WRAPPER");
         assertEq(
             address(wrapperRegistryImpl.VERIFIABLE_FACTORY()),
             address(verifiableFactory),
             "VERIFIABLE_FACTORY"
         );
-        assertEq(
-            wrapperRegistryImpl.V1_RESOLVER(),
-            address(ensV1Resolver),
-            "V1_RESOLVER"
-        );
+        assertEq(wrapperRegistryImpl.V1_RESOLVER(), address(ensV1Resolver), "V1_RESOLVER");
     }
 
     function test_supportsInterface_controller() external view {
@@ -208,27 +151,17 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         WrapperRegistry registry = _deployWrapperRegistryProxy(address(this));
         WrapperRegistryV2Mock newImplementation = _newWrapperRegistryV2Mock();
 
-        approvedUpgradeGate.setImplementationApproval(
-            address(newImplementation),
-            true
-        );
+        approvedUpgradeGate.setImplementationApproval(address(newImplementation), true);
         registry.upgradeToAndCall(address(newImplementation), "");
 
-        assertEq(
-            WrapperRegistryV2Mock(address(registry)).version(),
-            2,
-            "version"
-        );
+        assertEq(WrapperRegistryV2Mock(address(registry)).version(), 2, "version");
     }
 
     function test_wrapperRegistryUpgrade_requiresUpgradeRole() external {
         WrapperRegistry registry = _deployWrapperRegistryProxy(address(this));
         WrapperRegistryV2Mock newImplementation = _newWrapperRegistryV2Mock();
 
-        approvedUpgradeGate.setImplementationApproval(
-            address(newImplementation),
-            true
-        );
+        approvedUpgradeGate.setImplementationApproval(address(newImplementation), true);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -237,12 +170,6 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
                 RegistryRolesLib.ROLE_UPGRADE,
                 user
             )
-        );
-    }
-
-    function test_finishERC1155Migration_unauthorizedCaller() external {
-        vm.expectRevert(
-            abi.encodeWithSelector(UnauthorizedCaller.selector, user)
         );
         vm.prank(user);
         registry.upgradeToAndCall(address(newImplementation), "");
@@ -256,40 +183,25 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
     }
 
     function test_finishERC1155Migration_unauthorizedCaller() external {
-        vm.expectRevert(
-            abi.encodeWithSelector(UnauthorizedCaller.selector, user)
-        );
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedCaller.selector, user));
         vm.prank(user);
-        migrationController.finishERC1155Migration(
-            new uint256[](0),
-            new LibMigration.Data[](0)
-        );
+        migrationController.finishERC1155Migration(new uint256[](0), new LibMigration.Data[](0));
     }
 
     function test_safeTransferFrom_unauthorizedCaller() external {
         uint256 tokenId = dummy1155.mint(user);
         vm.expectRevert(
-            WrappedErrorLib.wrap(
-                abi.encodeWithSelector(UnauthorizedCaller.selector, dummy1155)
-            )
+            WrappedErrorLib.wrap(abi.encodeWithSelector(UnauthorizedCaller.selector, dummy1155))
         );
         vm.prank(user);
-        dummy1155.safeTransferFrom(
-            user,
-            address(migrationController),
-            tokenId,
-            1,
-            ""
-        ); // wrong
+        dummy1155.safeTransferFrom(user, address(migrationController), tokenId, 1, ""); // wrong
     }
 
     function test_migrate_invalidData(bytes calldata v) external {
         vm.assume(v.length < LibMigration.MIN_DATA_SIZE);
         bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         vm.expectRevert(
-            WrappedErrorLib.wrap(
-                abi.encodeWithSelector(LibMigration.InvalidData.selector)
-            )
+            WrappedErrorLib.wrap(abi.encodeWithSelector(LibMigration.InvalidData.selector))
         );
         vm.prank(user);
         nameWrapper.safeTransferFrom(
@@ -324,22 +236,14 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             )
         );
         vm.prank(user);
-        nameWrapper.safeBatchTransferFrom(
-            user,
-            address(migrationController),
-            ids,
-            amounts,
-            payload
-        );
+        nameWrapper.safeBatchTransferFrom(user, address(migrationController), ids, amounts, payload);
     }
 
     function test_migrate_invalidOwner() external {
         bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         LibMigration.Data memory md = _makeData(name);
         md.owner = address(0); // wrong
-        vm.expectRevert(
-            WrappedErrorLib.wrap(abi.encodeWithSelector(InvalidOwner.selector))
-        );
+        vm.expectRevert(WrappedErrorLib.wrap(abi.encodeWithSelector(InvalidOwner.selector)));
         vm.prank(user);
         nameWrapper.safeTransferFrom(
             user,
@@ -356,10 +260,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         md.owner = address(ethRegistry); // not a IERC1155Receiver
         vm.expectRevert(
             WrappedErrorLib.wrap(
-                abi.encodeWithSelector(
-                    IERC1155Errors.ERC1155InvalidReceiver.selector,
-                    md.owner
-                )
+                abi.encodeWithSelector(IERC1155Errors.ERC1155InvalidReceiver.selector, md.owner)
             )
         );
         vm.prank(user);
@@ -379,10 +280,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         md.label = "wrong";
         vm.expectRevert(
             WrappedErrorLib.wrap(
-                abi.encodeWithSelector(
-                    LibMigration.NameDataMismatch.selector,
-                    node
-                )
+                abi.encodeWithSelector(LibMigration.NameDataMismatch.selector, node)
             )
         );
         vm.prank(user);
@@ -400,12 +298,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         bytes32 node = NameCoder.namehash(name, 0);
         LibMigration.Data memory md = _makeData(name);
         vm.expectRevert(
-            WrappedErrorLib.wrap(
-                abi.encodeWithSelector(
-                    LibMigration.NameNotLocked.selector,
-                    node
-                )
-            )
+            WrappedErrorLib.wrap(abi.encodeWithSelector(LibMigration.NameNotLocked.selector, node))
         );
         vm.prank(user);
         nameWrapper.safeTransferFrom(
@@ -446,13 +339,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         LibMigration.Data memory md = _makeData(name);
         uint256 tokenIdV1 = LibLabel.id(md.label);
 
-        assertFalse(
-            ethRegistry.hasRoles(
-                tokenIdV1,
-                RegistryRolesLib.ROLE_WAS_RESERVED,
-                user
-            )
-        );
+        assertFalse(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, user));
 
         vm.prank(user);
         nameWrapper.safeTransferFrom(
@@ -463,13 +350,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             abi.encode(md)
         );
 
-        assertTrue(
-            ethRegistry.hasRoles(
-                tokenIdV1,
-                RegistryRolesLib.ROLE_WAS_RESERVED,
-                user
-            )
-        );
+        assertTrue(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, user));
     }
 
     function test_migrate() external {
@@ -478,20 +359,12 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         LibMigration.Data memory md = _makeData(name);
         bytes32 node = NameCoder.namehash(name, 0);
         uint256 salt = uint256(node);
-        address expectedRegistry = _computeVerifiableFactoryAddress(
-            address(migrationController),
-            salt
-        );
+        address expectedRegistry =
+            _computeVerifiableFactoryAddress(address(migrationController), salt);
         uint256 tokenIdV1 = LibLabel.id(md.label);
         uint256 tokenId = LibLabel.withVersion(tokenIdV1, 0);
         vm.expectEmit();
-        emit IERC1155.TransferSingle(
-            user,
-            user,
-            address(migrationController),
-            uint256(node),
-            1
-        );
+        emit IERC1155.TransferSingle(user, user, address(migrationController), uint256(node), 1);
         vm.expectEmit();
         emit ENS.NewResolver(node, address(0));
         // emit IERC1967.Upgraded()
@@ -503,11 +376,11 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             md.owner,
             0 /*old roles*/,
             RegistryRolesLib.ROLE_UPGRADE_ADMIN |
-                RegistryRolesLib.ROLE_UPGRADE |
-                RegistryRolesLib.ROLE_REGISTRAR |
-                RegistryRolesLib.ROLE_REGISTRAR_ADMIN |
-                RegistryRolesLib.ROLE_RENEW |
-                RegistryRolesLib.ROLE_RENEW_ADMIN
+            RegistryRolesLib.ROLE_UPGRADE |
+            RegistryRolesLib.ROLE_REGISTRAR |
+            RegistryRolesLib.ROLE_REGISTRAR_ADMIN |
+            RegistryRolesLib.ROLE_RENEW |
+            RegistryRolesLib.ROLE_RENEW_ADMIN
         );
         // emit Initializable.Initialized()
         vm.expectEmit();
@@ -527,13 +400,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             address(migrationController)
         );
         vm.expectEmit();
-        emit IERC1155.TransferSingle(
-            address(migrationController),
-            address(0),
-            md.owner,
-            tokenId,
-            1
-        );
+        emit IERC1155.TransferSingle(address(migrationController), address(0), md.owner, tokenId, 1);
         vm.expectEmit();
         emit IPermissionedRegistry.TokenResource(tokenId, tokenId);
         vm.expectEmit();
@@ -542,9 +409,9 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             md.owner,
             0 /*old roles*/,
             RegistryRolesLib.ROLE_SET_RESOLVER |
-                RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
-                RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
-                RegistryRolesLib.ROLE_WAS_RESERVED
+            RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
+            RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
+            RegistryRolesLib.ROLE_WAS_RESERVED
         );
         vm.expectEmit();
         emit IRegistryEvents.SubregistryUpdated(
@@ -553,11 +420,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             address(migrationController)
         );
         vm.expectEmit();
-        emit IRegistryEvents.ResolverUpdated(
-            tokenId,
-            md.resolver,
-            address(migrationController)
-        );
+        emit IRegistryEvents.ResolverUpdated(tokenId, md.resolver, address(migrationController));
         vm.prank(user);
         uint256 g = gasleft();
         nameWrapper.safeTransferFrom(
@@ -571,21 +434,13 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
 
         assertEq(ethRegistry.getTokenId(tokenIdV1), tokenId, "tokenId");
         assertEq(ethRegistry.ownerOf(tokenId), md.owner, "owner");
-        assertEq(
-            ethRegistry.getExpiry(tokenId),
-            ethRegistrarV1.nameExpires(tokenIdV1),
-            "expiry"
-        );
+        assertEq(ethRegistry.getExpiry(tokenId), ethRegistrarV1.nameExpires(tokenIdV1), "expiry");
         assertEq(ethRegistry.getResolver(md.label), md.resolver, "resolver");
         checkResolution(name, address(ensV2Resolver), md.resolver);
-        IWrapperRegistry subregistry = IWrapperRegistry(
-            address(ethRegistry.getSubregistry(md.label))
-        );
+        IWrapperRegistry subregistry =
+            IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
         assertTrue(
-            ERC165Checker.supportsInterface(
-                address(subregistry),
-                type(IWrapperRegistry).interfaceId
-            ),
+            ERC165Checker.supportsInterface(address(subregistry), type(IWrapperRegistry).interfaceId),
             "IWrapperRegistry"
         );
         assertTrue(
@@ -594,17 +449,13 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
         assertEq(
             subregistry.roleCount(subregistry.ROOT_RESOURCE()) &
-                (RegistryRolesLib.ROLE_SET_PARENT * 15),
+            (RegistryRolesLib.ROLE_SET_PARENT * 15),
             0,
             "ROLE_SET_PARENT"
         );
         assertEq(subregistry.getWrappedNode(), node, "getWrappedNode");
         assertEq(subregistry.getWrappedName(), name, "getWrappedName");
-        assertEq(
-            universalResolver.findCanonicalName(subregistry),
-            name,
-            "findCanonicalName"
-        );
+        assertEq(universalResolver.findCanonicalName(subregistry), name, "findCanonicalName");
     }
 
     function test_migrateBatch(uint8 count) external {
@@ -632,11 +483,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             string memory label = _label(i);
             uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(label));
             assertEq(ethRegistry.ownerOf(tokenId), user, "owner");
-            assertEq(
-                ethRegistry.getResolver(label),
-                address(uint160(i)),
-                "resolver"
-            );
+            assertEq(ethRegistry.getResolver(label), address(uint160(i)), "resolver");
             assertTrue(
                 ERC165Checker.supportsInterface(
                     address(ethRegistry.getSubregistry(label)),
@@ -653,10 +500,8 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         uint256[] memory amounts = new uint256[](count);
         LibMigration.Data[] memory mds = new LibMigration.Data[](count);
         for (uint256 i; i < count; ++i) {
-            bytes memory name = registerWrappedETH2LD(
-                _label(i),
-                i == count - 1 ? CAN_DO_EVERYTHING : CANNOT_UNWRAP
-            );
+            bytes memory name =
+                registerWrappedETH2LD(_label(i), i == count - 1 ? CAN_DO_EVERYTHING : CANNOT_UNWRAP);
             LibMigration.Data memory md = _makeData(name);
             mds[i] = md;
             ids[i] = uint256(NameCoder.namehash(name, 0));
@@ -664,10 +509,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         }
         vm.expectRevert(
             WrappedErrorLib.wrap(
-                abi.encodeWithSelector(
-                    LibMigration.NameNotLocked.selector,
-                    ids[count - 1]
-                )
+                abi.encodeWithSelector(LibMigration.NameNotLocked.selector, ids[count - 1])
             )
         );
         vm.prank(user);
@@ -704,13 +546,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(md.label));
         assertEq(ethRegistry.getResolver(md.label), frozenResolver, "frozen");
         checkResolution(name, frozenResolver, frozenResolver);
-        assertFalse(
-            ethRegistry.hasRoles(
-                tokenId,
-                RegistryRolesLib.ROLE_SET_RESOLVER,
-                user
-            )
-        );
+        assertFalse(ethRegistry.hasRoles(tokenId, RegistryRolesLib.ROLE_SET_RESOLVER, user));
         vm.expectRevert(
             abi.encodeWithSelector(
                 IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
@@ -724,16 +560,11 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
     }
 
     function test_migrate_lockedTransfer() external {
-        bytes memory name = registerWrappedETH2LD(
-            testLabel,
-            CANNOT_UNWRAP | CANNOT_TRANSFER
-        );
+        bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP | CANNOT_TRANSFER);
         bytes32 node = NameCoder.namehash(name, 0);
         LibMigration.Data memory md = _makeData(name);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(OperationProhibited.selector, node)
-        );
+        vm.expectRevert(abi.encodeWithSelector(OperationProhibited.selector, node));
         vm.prank(user);
         nameWrapper.safeTransferFrom(
             user,
@@ -745,10 +576,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
     }
 
     function test_migrate_lockedFuses() external {
-        bytes memory name = registerWrappedETH2LD(
-            testLabel,
-            CANNOT_UNWRAP | CANNOT_BURN_FUSES
-        );
+        bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP | CANNOT_BURN_FUSES);
         LibMigration.Data memory md = _makeData(name);
 
         vm.prank(user);
@@ -766,23 +594,17 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN,
             "token"
         );
-        IWrapperRegistry registry = IWrapperRegistry(
-            address(ethRegistry.getSubregistry(md.label))
-        );
+        IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
         assertEq(
-            registry.roles(registry.ROOT_RESOURCE(), user) &
-                EACBaseRolesLib.ADMIN_ROLES,
-            RegistryRolesLib.ROLE_UPGRADE_ADMIN |
-                RegistryRolesLib.ROLE_RENEW_ADMIN,
+            registry.roles(registry.ROOT_RESOURCE(), user) & EACBaseRolesLib.ADMIN_ROLES,
+            RegistryRolesLib.ROLE_UPGRADE_ADMIN | RegistryRolesLib.ROLE_RENEW_ADMIN,
             "registry"
         );
     }
 
     function test_migrate_cannotCreateChildren() external {
-        bytes memory name = registerWrappedETH2LD(
-            testLabel,
-            CANNOT_UNWRAP | CANNOT_CREATE_SUBDOMAIN
-        );
+        bytes memory name =
+            registerWrappedETH2LD(testLabel, CANNOT_UNWRAP | CANNOT_CREATE_SUBDOMAIN);
         LibMigration.Data memory md = _makeData(name);
 
         vm.prank(user);
@@ -795,9 +617,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
 
         uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(md.label));
-        assertFalse(
-            ethRegistry.hasRoles(tokenId, RegistryRolesLib.ROLE_REGISTRAR, user)
-        );
+        assertFalse(ethRegistry.hasRoles(tokenId, RegistryRolesLib.ROLE_REGISTRAR, user));
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -820,12 +640,13 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
 
     function test_migrate_canExtendExpiry() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
-        bytes memory name3 = createWrappedChild(
-            name2,
-            "sub",
-            friend,
-            CANNOT_UNWRAP | PARENT_CANNOT_CONTROL | CAN_EXTEND_EXPIRY
-        );
+        bytes memory name3 =
+            createWrappedChild(
+                name2,
+                "sub",
+                friend,
+                CANNOT_UNWRAP | PARENT_CANNOT_CONTROL | CAN_EXTEND_EXPIRY
+            );
 
         // migrate 2LD
         LibMigration.Data memory data2 = _makeData(name2);
@@ -837,9 +658,8 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             1,
             abi.encode(data2)
         );
-        IWrapperRegistry registry2 = IWrapperRegistry(
-            address(ethRegistry.getSubregistry(data2.label))
-        );
+        IWrapperRegistry registry2 =
+            IWrapperRegistry(address(ethRegistry.getSubregistry(data2.label)));
 
         // migrate 3LD
         LibMigration.Data memory data3 = _makeData(name3);
@@ -853,10 +673,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
 
         uint256 tokenId = registry2.getTokenId(LibLabel.id(data3.label));
-        assertTrue(
-            registry2.hasRoles(tokenId, RegistryRolesLib.ROLE_RENEW, friend),
-            "ROLE_RENEW"
-        );
+        assertTrue(registry2.hasRoles(tokenId, RegistryRolesLib.ROLE_RENEW, friend), "ROLE_RENEW");
 
         uint64 expiry = registry2.getExpiry(tokenId);
         vm.prank(friend);
@@ -865,18 +682,10 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
 
     function test_migrate_lockedChildren() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
-        bytes memory name3 = createWrappedChild(
-            name2,
-            "sub",
-            friend,
-            CANNOT_UNWRAP | PARENT_CANNOT_CONTROL
-        );
-        bytes memory name3unmigrated = createWrappedChild(
-            name2,
-            "unmigrated",
-            friend,
-            CANNOT_UNWRAP | PARENT_CANNOT_CONTROL
-        );
+        bytes memory name3 =
+            createWrappedChild(name2, "sub", friend, CANNOT_UNWRAP | PARENT_CANNOT_CONTROL);
+        bytes memory name3unmigrated =
+            createWrappedChild(name2, "unmigrated", friend, CANNOT_UNWRAP | PARENT_CANNOT_CONTROL);
 
         // migrate 2LD
         LibMigration.Data memory data2 = _makeData(name2);
@@ -889,20 +698,14 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             abi.encode(data2)
         );
         assertEq(
-            ethRegistry.ownerOf(
-                ethRegistry.getTokenId(LibLabel.id(data2.label))
-            ),
+            ethRegistry.ownerOf(ethRegistry.getTokenId(LibLabel.id(data2.label))),
             data2.owner,
             "owner2"
         );
-        IWrapperRegistry registry2 = IWrapperRegistry(
-            address(ethRegistry.getSubregistry(data2.label))
-        );
+        IWrapperRegistry registry2 =
+            IWrapperRegistry(address(ethRegistry.getSubregistry(data2.label)));
         assertTrue(
-            ERC165Checker.supportsInterface(
-                address(registry2),
-                type(IWrapperRegistry).interfaceId
-            ),
+            ERC165Checker.supportsInterface(address(registry2), type(IWrapperRegistry).interfaceId),
             "registry2"
         );
 
@@ -916,11 +719,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             1,
             abi.encode(data3)
         );
-        assertEq(
-            registry2.getResolver(data3.label),
-            data3.resolver,
-            "resolver3"
-        );
+        assertEq(registry2.getResolver(data3.label), data3.resolver, "resolver3");
         checkResolution(name3, address(ensV2Resolver), data3.resolver);
         assertEq(
             registry2.ownerOf(registry2.getTokenId(LibLabel.id(data3.label))),
@@ -929,34 +728,19 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
         IRegistry registry3 = registry2.getSubregistry(data3.label);
         assertTrue(
-            ERC165Checker.supportsInterface(
-                address(registry3),
-                type(IWrapperRegistry).interfaceId
-            ),
+            ERC165Checker.supportsInterface(address(registry3), type(IWrapperRegistry).interfaceId),
             "registry3"
         );
 
         // check migrated 3LD child
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IStandardRegistry.LabelAlreadyRegistered.selector,
-                data3.label
-            )
+            abi.encodeWithSelector(IStandardRegistry.LabelAlreadyRegistered.selector, data3.label)
         );
         vm.prank(friend);
-        registry2.register(
-            data3.label,
-            user,
-            IRegistry(address(0)),
-            address(0),
-            0,
-            _soon()
-        );
+        registry2.register(data3.label, user, IRegistry(address(0)), address(0), 0, _soon());
 
         // check unmigrated 3LD child
-        vm.expectRevert(
-            abi.encodeWithSelector(LibMigration.NameRequiresMigration.selector)
-        );
+        vm.expectRevert(abi.encodeWithSelector(LibMigration.NameRequiresMigration.selector));
         vm.prank(friend);
         registry2.register(
             NameCoder.firstLabel(name3unmigrated),
@@ -968,27 +752,15 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
 
         vm.prank(friend);
-        nameWrapper.setResolver(
-            NameCoder.namehash(name3unmigrated, 0),
-            testResolver
-        );
+        nameWrapper.setResolver(NameCoder.namehash(name3unmigrated, 0), testResolver);
         checkResolution(name3unmigrated, testResolver, address(ensV1Resolver));
     }
 
     function test_migrate_detachedChildren() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
-        bytes memory name3 = createWrappedChild(
-            name2,
-            "sub",
-            friend,
-            PARENT_CANNOT_CONTROL
-        );
-        bytes memory name3unmigrated = createWrappedChild(
-            name2,
-            "unmigrated",
-            friend,
-            PARENT_CANNOT_CONTROL
-        );
+        bytes memory name3 = createWrappedChild(name2, "sub", friend, PARENT_CANNOT_CONTROL);
+        bytes memory name3unmigrated =
+            createWrappedChild(name2, "unmigrated", friend, PARENT_CANNOT_CONTROL);
 
         // migrate 2LD
         LibMigration.Data memory data2 = _makeData(name2);
@@ -1001,20 +773,14 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             abi.encode(data2)
         );
         assertEq(
-            ethRegistry.ownerOf(
-                ethRegistry.getTokenId(LibLabel.id(data2.label))
-            ),
+            ethRegistry.ownerOf(ethRegistry.getTokenId(LibLabel.id(data2.label))),
             data2.owner,
             "owner2"
         );
-        IWrapperRegistry registry2 = IWrapperRegistry(
-            address(ethRegistry.getSubregistry(data2.label))
-        );
+        IWrapperRegistry registry2 =
+            IWrapperRegistry(address(ethRegistry.getSubregistry(data2.label)));
         assertTrue(
-            ERC165Checker.supportsInterface(
-                address(registry2),
-                type(IWrapperRegistry).interfaceId
-            ),
+            ERC165Checker.supportsInterface(address(registry2), type(IWrapperRegistry).interfaceId),
             "registry2"
         );
 
@@ -1029,49 +795,25 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             1,
             abi.encode(data3)
         );
-        assertEq(
-            registry2.getResolver(data3.label),
-            data3.resolver,
-            "resolver3"
-        );
+        assertEq(registry2.getResolver(data3.label), data3.resolver, "resolver3");
         checkResolution(name3, address(ensV2Resolver), data3.resolver);
         assertEq(
             registry2.ownerOf(registry2.getTokenId(LibLabel.id(data3.label))),
             data3.owner,
             "owner3"
         );
-        assertEq(
-            address(registry2.getSubregistry(data3.label)),
-            address(testRegistry),
-            "registry3"
-        );
-        assertEq(
-            registryV1.owner(NameCoder.namehash(name3, 0)),
-            address(graveyard),
-            "graveyard3"
-        );
+        assertEq(address(registry2.getSubregistry(data3.label)), address(testRegistry), "registry3");
+        assertEq(registryV1.owner(NameCoder.namehash(name3, 0)), address(graveyard), "graveyard3");
 
         // check migrated 3LD child
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IStandardRegistry.LabelAlreadyRegistered.selector,
-                data3.label
-            )
+            abi.encodeWithSelector(IStandardRegistry.LabelAlreadyRegistered.selector, data3.label)
         );
         vm.prank(friend);
-        registry2.register(
-            data3.label,
-            user,
-            IRegistry(address(0)),
-            address(0),
-            0,
-            _soon()
-        );
+        registry2.register(data3.label, user, IRegistry(address(0)), address(0), 0, _soon());
 
         // check unmigrated 3LD child
-        vm.expectRevert(
-            abi.encodeWithSelector(LibMigration.NameRequiresMigration.selector)
-        );
+        vm.expectRevert(abi.encodeWithSelector(LibMigration.NameRequiresMigration.selector));
         vm.prank(friend);
         registry2.register(
             NameCoder.firstLabel(name3unmigrated),
@@ -1083,10 +825,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
 
         vm.prank(friend);
-        nameWrapper.setResolver(
-            NameCoder.namehash(name3unmigrated, 0),
-            testResolver
-        );
+        nameWrapper.setResolver(NameCoder.namehash(name3unmigrated, 0), testResolver);
         checkResolution(name3unmigrated, testResolver, address(ensV1Resolver));
     }
 
@@ -1097,11 +836,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         // give approval
         vm.prank(user);
         nameWrapper.approve(address(this), uint256(node));
-        assertEq(
-            nameWrapper.getApproved(uint256(node)),
-            address(this),
-            "approved"
-        );
+        assertEq(nameWrapper.getApproved(uint256(node)), address(this), "approved");
 
         // freeze approval
         vm.prank(user);
@@ -1110,10 +845,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         LibMigration.Data memory data = _makeData(name);
         vm.expectRevert(
             WrappedErrorLib.wrap(
-                abi.encodeWithSelector(
-                    LibMigration.FrozenTokenApproval.selector,
-                    node
-                )
+                abi.encodeWithSelector(LibMigration.FrozenTokenApproval.selector, node)
             )
         );
         vm.prank(user);
@@ -1126,50 +858,37 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
-    function _makeData(
-        bytes memory name
-    ) internal view returns (LibMigration.Data memory) {
+    function _makeData(bytes memory name) internal view returns (LibMigration.Data memory) {
         return
             LibMigration.Data({
                 label: NameCoder.firstLabel(name),
-                owner: nameWrapper.ownerOf(
-                    uint256(NameCoder.namehash(name, 0))
-                ),
+                owner: nameWrapper.ownerOf(uint256(NameCoder.namehash(name, 0))),
                 subregistry: IRegistry(address(0)), // ignored by LockedMigrationController
                 resolver: testResolver
             });
     }
 
-    function _deployWrapperRegistryProxy(
-        address rootAccount
-    ) internal returns (WrapperRegistry) {
+    function _deployWrapperRegistryProxy(address rootAccount) internal returns (WrapperRegistry) {
         bytes memory name = NameCoder.encode(string.concat(testLabel, ".eth"));
         bytes32 node = NameCoder.namehash(name, 0);
         uint256 salt = uint256(node);
-        address proxyAddress = verifiableFactory.deployProxy(
-            address(wrapperRegistryImpl),
-            salt,
-            abi.encodeCall(
-                IWrapperRegistry.initialize,
-                (
-                    node,
-                    ethRegistry,
-                    testLabel,
-                    rootAccount,
-                    RegistryRolesLib.ROLE_UPGRADE
+        address proxyAddress =
+            verifiableFactory.deployProxy(
+                address(wrapperRegistryImpl),
+                salt,
+                abi.encodeCall(
+                    IWrapperRegistry.initialize,
+                    (node, ethRegistry, testLabel, rootAccount, RegistryRolesLib.ROLE_UPGRADE)
                 )
-            )
-        );
+            );
         return WrapperRegistry(proxyAddress);
     }
 
-    function _newWrapperRegistryV2Mock()
-        internal
-        returns (WrapperRegistryV2Mock)
-    {
+    function _newWrapperRegistryV2Mock() internal returns (WrapperRegistryV2Mock) {
         return
             new WrapperRegistryV2Mock(
                 nameWrapper,
+                address(graveyard),
                 verifiableFactory,
                 address(ensV1Resolver),
                 hcaFactory,
@@ -1180,9 +899,11 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
     }
 }
 
+
 contract WrapperRegistryV2Mock is WrapperRegistry {
     constructor(
         INameWrapper nameWrapper,
+        address graveyard,
         IVerifiableFactory verifiableFactory,
         address ensV1Resolver,
         IHCAFactoryBasic hcaFactory,
@@ -1192,6 +913,7 @@ contract WrapperRegistryV2Mock is WrapperRegistry {
     )
         WrapperRegistry(
             nameWrapper,
+            graveyard,
             verifiableFactory,
             ensV1Resolver,
             hcaFactory,

--- a/contracts/test/unit/migration/MigrationControllerFixture.sol
+++ b/contracts/test/unit/migration/MigrationControllerFixture.sol
@@ -12,10 +12,18 @@ import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
 import {V1Fixture} from "~test/fixtures/V1Fixture.sol";
 import {V2Fixture} from "~test/fixtures/V2Fixture.sol";
 
-// initial gas analysis
+// forge test test/unit/migration/UnlockedMigrationController.t.sol -vv
+// forge test test/unit/migration/LockedMigrationController.t.sol -vv
+
+// [initial gas analysis]
 // * Unwrapped: 160300
 // * Unlocked: 179367
 // * Locked: 658489 (~500k for VerifiedFactory => WrapperRegistry)
+
+// [after graveyard]
+// * Unwrapped: 193011 (+32K)
+// * Unlocked: 183292 (+4K)
+// * Locked: 665863 (+7K)
 
 contract MigrationControllerFixture is V1Fixture, V2Fixture {
     ENSV1Resolver ensV1Resolver;

--- a/contracts/test/unit/migration/MigrationControllerFixture.sol
+++ b/contracts/test/unit/migration/MigrationControllerFixture.sol
@@ -10,7 +10,7 @@ import {ENSV1Resolver} from "~src/resolver/ENSV1Resolver.sol";
 import {ENSV2Resolver} from "~src/resolver/ENSV2Resolver.sol";
 import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
 import {V1Fixture} from "~test/fixtures/V1Fixture.sol";
-import {V2Fixture} from "~test/fixtures/V2Fixture.sol";
+import {V2Fixture, RegistryRolesLib} from "~test/fixtures/V2Fixture.sol";
 
 // forge test test/unit/migration/UnlockedMigrationController.t.sol -vv
 // forge test test/unit/migration/LockedMigrationController.t.sol -vv
@@ -41,6 +41,10 @@ contract MigrationControllerFixture is V1Fixture, V2Fixture {
     function setUp() public virtual {
         deployV1Fixture();
         deployV2Fixture();
+        ethRegistry.grantRootRoles(
+            RegistryRolesLib.ROLE_REGISTRAR,
+            premigrationController
+        );
         graveyard = new Graveyard(nameWrapper);
         ensV1Resolver = new ENSV1Resolver(registryV1, batchGatewayProvider);
         ensV2Resolver = new ENSV2Resolver(

--- a/contracts/test/unit/migration/MigrationControllerFixture.sol
+++ b/contracts/test/unit/migration/MigrationControllerFixture.sol
@@ -5,6 +5,7 @@ import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 
+import {Graveyard} from "~src/migration/Graveyard.sol";
 import {ENSV1Resolver} from "~src/resolver/ENSV1Resolver.sol";
 import {ENSV2Resolver} from "~src/resolver/ENSV2Resolver.sol";
 import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
@@ -19,6 +20,7 @@ import {V2Fixture} from "~test/fixtures/V2Fixture.sol";
 contract MigrationControllerFixture is V1Fixture, V2Fixture {
     ENSV1Resolver ensV1Resolver;
     ENSV2Resolver ensV2Resolver;
+    Graveyard graveyard;
     MockERC721 dummy721;
     MockERC1155 dummy1155;
 
@@ -31,19 +33,22 @@ contract MigrationControllerFixture is V1Fixture, V2Fixture {
     function setUp() public virtual {
         deployV1Fixture();
         deployV2Fixture();
+        graveyard = new Graveyard(registryV1);
         ensV1Resolver = new ENSV1Resolver(registryV1, batchGatewayProvider);
-        ensV2Resolver = new ENSV2Resolver(rootRegistry, batchGatewayProvider, address(0));
+        ensV2Resolver = new ENSV2Resolver(
+            rootRegistry,
+            batchGatewayProvider,
+            address(0)
+        );
         dummy721 = new MockERC721();
         dummy1155 = new MockERC1155();
         ethRegistrarV1.setResolver(address(ensV2Resolver));
     }
 
     /// @dev Ensure premigration has occurred.
-    function registerUnwrapped(string memory label)
-        public
-        override
-        returns (bytes memory name, uint256 tokenId)
-    {
+    function registerUnwrapped(
+        string memory label
+    ) public override returns (bytes memory name, uint256 tokenId) {
         (name, tokenId) = super.registerUnwrapped(label);
         if (address(premigrationController) != address(0)) {
             vm.prank(premigrationController);
@@ -59,7 +64,11 @@ contract MigrationControllerFixture is V1Fixture, V2Fixture {
     }
 
     /// @dev Check resolver and fallback logic.
-    function checkResolution(bytes memory name, address resolverV1, address resolverV2) public view {
+    function checkResolution(
+        bytes memory name,
+        address resolverV1,
+        address resolverV2
+    ) public view {
         assertEq(findResolverV1(name), resolverV1, "findResolverV1");
         assertEq(findResolverV2(name), resolverV2, "findResolverV2");
         if (resolverV2 == address(ensV1Resolver)) {
@@ -68,7 +77,11 @@ contract MigrationControllerFixture is V1Fixture, V2Fixture {
         } else if (resolverV1 == address(ensV2Resolver)) {
             (address r, ) = ensV2Resolver.getResolver(name);
             assertEq(r, resolverV2, "compositeV2");
-            assertEq(registryV1.resolver(NameCoder.namehash(name, 0)), address(0), "resolverV1");
+            assertEq(
+                registryV1.resolver(NameCoder.namehash(name, 0)),
+                address(0),
+                "resolverV1"
+            );
         }
     }
 
@@ -81,7 +94,6 @@ contract MigrationControllerFixture is V1Fixture, V2Fixture {
     }
 }
 
-
 contract MockERC721 is ERC721 {
     uint256 _id;
     constructor() ERC721("", "") {}
@@ -90,7 +102,6 @@ contract MockERC721 is ERC721 {
         return _id++;
     }
 }
-
 
 contract MockERC1155 is ERC1155 {
     uint256 _id;

--- a/contracts/test/unit/migration/MigrationControllerFixture.sol
+++ b/contracts/test/unit/migration/MigrationControllerFixture.sol
@@ -41,26 +41,21 @@ contract MigrationControllerFixture is V1Fixture, V2Fixture {
     function setUp() public virtual {
         deployV1Fixture();
         deployV2Fixture();
-        ethRegistry.grantRootRoles(
-            RegistryRolesLib.ROLE_REGISTRAR,
-            premigrationController
-        );
+        ethRegistry.grantRootRoles(RegistryRolesLib.ROLE_REGISTRAR, premigrationController);
         graveyard = new Graveyard(nameWrapper);
         ensV1Resolver = new ENSV1Resolver(registryV1, batchGatewayProvider);
-        ensV2Resolver = new ENSV2Resolver(
-            rootRegistry,
-            batchGatewayProvider,
-            address(0)
-        );
+        ensV2Resolver = new ENSV2Resolver(rootRegistry, batchGatewayProvider, address(0));
         dummy721 = new MockERC721();
         dummy1155 = new MockERC1155();
         ethRegistrarV1.setResolver(address(ensV2Resolver));
     }
 
     /// @dev Ensure premigration has occurred.
-    function registerUnwrapped(
-        string memory label
-    ) public override returns (bytes memory name, uint256 tokenId) {
+    function registerUnwrapped(string memory label)
+        public
+        override
+        returns (bytes memory name, uint256 tokenId)
+    {
         (name, tokenId) = super.registerUnwrapped(label);
         if (address(premigrationController) != address(0)) {
             vm.prank(premigrationController);
@@ -76,11 +71,7 @@ contract MigrationControllerFixture is V1Fixture, V2Fixture {
     }
 
     /// @dev Check resolver and fallback logic.
-    function checkResolution(
-        bytes memory name,
-        address resolverV1,
-        address resolverV2
-    ) public view {
+    function checkResolution(bytes memory name, address resolverV1, address resolverV2) public view {
         assertEq(findResolverV1(name), resolverV1, "findResolverV1");
         assertEq(findResolverV2(name), resolverV2, "findResolverV2");
         if (resolverV2 == address(ensV1Resolver)) {
@@ -89,11 +80,7 @@ contract MigrationControllerFixture is V1Fixture, V2Fixture {
         } else if (resolverV1 == address(ensV2Resolver)) {
             (address r, ) = ensV2Resolver.getResolver(name);
             assertEq(r, resolverV2, "compositeV2");
-            assertEq(
-                registryV1.resolver(NameCoder.namehash(name, 0)),
-                address(0),
-                "resolverV1"
-            );
+            assertEq(registryV1.resolver(NameCoder.namehash(name, 0)), address(0), "resolverV1");
         }
     }
 
@@ -106,6 +93,7 @@ contract MigrationControllerFixture is V1Fixture, V2Fixture {
     }
 }
 
+
 contract MockERC721 is ERC721 {
     uint256 _id;
     constructor() ERC721("", "") {}
@@ -114,6 +102,7 @@ contract MockERC721 is ERC721 {
         return _id++;
     }
 }
+
 
 contract MockERC1155 is ERC1155 {
     uint256 _id;

--- a/contracts/test/unit/migration/MigrationControllerFixture.sol
+++ b/contracts/test/unit/migration/MigrationControllerFixture.sol
@@ -33,7 +33,7 @@ contract MigrationControllerFixture is V1Fixture, V2Fixture {
     function setUp() public virtual {
         deployV1Fixture();
         deployV2Fixture();
-        graveyard = new Graveyard(registryV1);
+        graveyard = new Graveyard(nameWrapper);
         ensV1Resolver = new ENSV1Resolver(registryV1, batchGatewayProvider);
         ensV2Resolver = new ENSV2Resolver(
             rootRegistry,

--- a/contracts/test/unit/migration/UnlockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/UnlockedMigrationController.t.sol
@@ -5,35 +5,61 @@ pragma solidity >=0.8.13;
 
 import {console} from "forge-std/console.sol";
 
-import {CAN_DO_EVERYTHING, CANNOT_UNWRAP} from "@ens/contracts/wrapper/INameWrapper.sol";
+import {
+    CAN_DO_EVERYTHING,
+    CANNOT_UNWRAP
+} from "@ens/contracts/wrapper/INameWrapper.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
-import {IERC1155Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
-import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
-import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import {
+    IERC1155Errors
+} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {
+    IERC721Receiver
+} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {
+    IERC1155Receiver
+} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {
+    ERC165Checker
+} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
 import {InvalidOwner, UnauthorizedCaller} from "~src/CommonErrors.sol";
 import {WrappedErrorLib} from "~src/utils/WrappedErrorLib.sol";
 import {LibLabel} from "~src/utils/LibLabel.sol";
 import {LibMigration} from "~src/migration/libraries/LibMigration.sol";
-import {IEnhancedAccessControl} from "~src/access-control/EnhancedAccessControl.sol";
+import {
+    IEnhancedAccessControl
+} from "~src/access-control/EnhancedAccessControl.sol";
 import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
 import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
-import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
+import {
+    IPermissionedRegistry
+} from "~src/registry/interfaces/IPermissionedRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
 import {REGISTRATION_ROLE_BITMAP} from "~src/registrar/ETHRegistrar.sol";
-import {UnlockedMigrationController} from "~src/migration/UnlockedMigrationController.sol";
-import {MigrationControllerFixture} from "~test/unit/migration/MigrationControllerFixture.sol";
+import {
+    UnlockedMigrationController
+} from "~src/migration/UnlockedMigrationController.sol";
+import {
+    MigrationControllerFixture
+} from "~test/unit/migration/MigrationControllerFixture.sol";
 
 contract UnlockedMigrationControllerTest is MigrationControllerFixture {
     UnlockedMigrationController migrationController;
 
     function setUp() public override {
         super.setUp();
-        migrationController = new UnlockedMigrationController(nameWrapper, ethRegistry);
-        ethRegistry.grantRootRoles(RegistryRolesLib.ROLE_REGISTRAR, premigrationController);
+        migrationController = new UnlockedMigrationController(
+            nameWrapper,
+            address(graveyard),
+            ethRegistry
+        );
+        ethRegistry.grantRootRoles(
+            RegistryRolesLib.ROLE_REGISTRAR,
+            premigrationController
+        );
         ethRegistry.grantRootRoles(
             RegistryRolesLib.ROLE_REGISTER_RESERVED,
             address(migrationController)
@@ -41,8 +67,21 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
     }
 
     function test_constructor() external view {
-        assertEq(address(migrationController.ETH_REGISTRY()), address(ethRegistry), "ETH_REGISTRY");
-        assertEq(address(migrationController.NAME_WRAPPER()), address(nameWrapper), "NAME_WRAPPER");
+        assertEq(
+            address(migrationController.NAME_WRAPPER()),
+            address(nameWrapper),
+            "NAME_WRAPPER"
+        );
+        assertEq(
+            address(migrationController.GRAVEYARD()),
+            address(graveyard),
+            "GRAVEYARD"
+        );
+        assertEq(
+            address(migrationController.ETH_REGISTRY()),
+            address(ethRegistry),
+            "ETH_REGISTRY"
+        );
     }
 
     function test_supportsInterface() external view {
@@ -63,14 +102,21 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
     }
 
     function test_finishERC1155Migration_unauthorizedCaller() external {
-        vm.expectRevert(abi.encodeWithSelector(UnauthorizedCaller.selector, user));
+        vm.expectRevert(
+            abi.encodeWithSelector(UnauthorizedCaller.selector, user)
+        );
         vm.prank(user);
-        migrationController.finishERC1155Migration(new uint256[](0), new LibMigration.Data[](0));
+        migrationController.finishERC1155Migration(
+            new uint256[](0),
+            new LibMigration.Data[](0)
+        );
     }
 
     function test_unwrapped_safeTransferFrom_unauthorizedCaller() external {
         uint256 tokenId = dummy721.mint(user);
-        vm.expectRevert(abi.encodeWithSelector(UnauthorizedCaller.selector, dummy721));
+        vm.expectRevert(
+            abi.encodeWithSelector(UnauthorizedCaller.selector, dummy721)
+        );
         vm.prank(user);
         dummy721.safeTransferFrom(user, address(migrationController), tokenId); // wrong
     }
@@ -78,16 +124,26 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
     function test_wrapped_safeTransferFrom_unauthorizedCaller() external {
         uint256 tokenId = dummy1155.mint(user);
         vm.expectRevert(
-            WrappedErrorLib.wrap(abi.encodeWithSelector(UnauthorizedCaller.selector, dummy1155))
+            WrappedErrorLib.wrap(
+                abi.encodeWithSelector(UnauthorizedCaller.selector, dummy1155)
+            )
         );
         vm.prank(user);
-        dummy1155.safeTransferFrom(user, address(migrationController), tokenId, 1, ""); // wrong
+        dummy1155.safeTransferFrom(
+            user,
+            address(migrationController),
+            tokenId,
+            1,
+            ""
+        ); // wrong
     }
 
     function test_unwrapped_invalidData(bytes calldata v) external {
         vm.assume(v.length < LibMigration.MIN_DATA_SIZE);
         (, uint256 tokenIdV1) = registerUnwrapped(testLabel);
-        vm.expectRevert(abi.encodeWithSelector(LibMigration.InvalidData.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(LibMigration.InvalidData.selector)
+        );
         vm.prank(user);
         ethRegistrarV1.safeTransferFrom(
             user,
@@ -101,7 +157,9 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         vm.assume(v.length < LibMigration.MIN_DATA_SIZE);
         bytes memory name = registerWrappedETH2LD(testLabel, CAN_DO_EVERYTHING);
         vm.expectRevert(
-            WrappedErrorLib.wrap(abi.encodeWithSelector(LibMigration.InvalidData.selector))
+            WrappedErrorLib.wrap(
+                abi.encodeWithSelector(LibMigration.InvalidData.selector)
+            )
         );
         vm.prank(user);
         nameWrapper.safeTransferFrom(
@@ -136,7 +194,13 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             )
         );
         vm.prank(user);
-        nameWrapper.safeBatchTransferFrom(user, address(migrationController), ids, amounts, payload);
+        nameWrapper.safeBatchTransferFrom(
+            user,
+            address(migrationController),
+            ids,
+            amounts,
+            payload
+        );
     }
 
     function test_unwrapped_invalidOwner() external {
@@ -157,7 +221,9 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         bytes memory name = registerWrappedETH2LD(testLabel, CAN_DO_EVERYTHING);
         LibMigration.Data memory md = _makeData(name);
         md.owner = address(0); // wrong
-        vm.expectRevert(WrappedErrorLib.wrap(abi.encodeWithSelector(InvalidOwner.selector)));
+        vm.expectRevert(
+            WrappedErrorLib.wrap(abi.encodeWithSelector(InvalidOwner.selector))
+        );
         vm.prank(user);
         nameWrapper.safeTransferFrom(
             user,
@@ -173,7 +239,10 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         LibMigration.Data memory md = _makeData(name);
         md.owner = address(ethRegistry); // not a IERC1155Receiver
         vm.expectRevert(
-            abi.encodeWithSelector(IERC1155Errors.ERC1155InvalidReceiver.selector, md.owner)
+            abi.encodeWithSelector(
+                IERC1155Errors.ERC1155InvalidReceiver.selector,
+                md.owner
+            )
         );
         vm.prank(user);
         ethRegistrarV1.safeTransferFrom(
@@ -191,7 +260,10 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
 
         vm.expectRevert(
             WrappedErrorLib.wrap(
-                abi.encodeWithSelector(IERC1155Errors.ERC1155InvalidReceiver.selector, md.owner)
+                abi.encodeWithSelector(
+                    IERC1155Errors.ERC1155InvalidReceiver.selector,
+                    md.owner
+                )
             )
         );
         vm.prank(user);
@@ -208,7 +280,12 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         (bytes memory name, uint256 tokenIdV1) = registerUnwrapped(testLabel);
         LibMigration.Data memory md = _makeData(name);
         md.label = "wrong";
-        vm.expectRevert(abi.encodeWithSelector(LibMigration.NameDataMismatch.selector, tokenIdV1));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibMigration.NameDataMismatch.selector,
+                tokenIdV1
+            )
+        );
         vm.prank(user);
         ethRegistrarV1.safeTransferFrom(
             user,
@@ -225,7 +302,10 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         md.label = "wrong";
         vm.expectRevert(
             WrappedErrorLib.wrap(
-                abi.encodeWithSelector(LibMigration.NameDataMismatch.selector, node)
+                abi.encodeWithSelector(
+                    LibMigration.NameDataMismatch.selector,
+                    node
+                )
             )
         );
         vm.prank(user);
@@ -243,7 +323,9 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         bytes32 node = NameCoder.namehash(name, 0);
         LibMigration.Data memory md = _makeData(name);
         vm.expectRevert(
-            WrappedErrorLib.wrap(abi.encodeWithSelector(LibMigration.NameIsLocked.selector, node))
+            WrappedErrorLib.wrap(
+                abi.encodeWithSelector(LibMigration.NameIsLocked.selector, node)
+            )
         );
         vm.prank(user);
         nameWrapper.safeTransferFrom(
@@ -304,7 +386,13 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         (bytes memory name, uint256 tokenIdV1) = registerUnwrapped(testLabel);
         LibMigration.Data memory md = _makeData(name);
 
-        assertFalse(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, user));
+        assertFalse(
+            ethRegistry.hasRoles(
+                tokenIdV1,
+                RegistryRolesLib.ROLE_WAS_RESERVED,
+                user
+            )
+        );
 
         vm.prank(user);
         ethRegistrarV1.safeTransferFrom(
@@ -314,7 +402,13 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             abi.encode(md)
         );
 
-        assertTrue(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, user));
+        assertTrue(
+            ethRegistry.hasRoles(
+                tokenIdV1,
+                RegistryRolesLib.ROLE_WAS_RESERVED,
+                user
+            )
+        );
     }
 
     function test_unwrapped_migrate() external {
@@ -333,7 +427,13 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             address(migrationController)
         );
         vm.expectEmit();
-        emit IERC1155.TransferSingle(address(migrationController), address(0), md.owner, tokenId, 1);
+        emit IERC1155.TransferSingle(
+            address(migrationController),
+            address(0),
+            md.owner,
+            tokenId,
+            1
+        );
         vm.expectEmit();
         emit IPermissionedRegistry.TokenResource(tokenId, tokenId);
         vm.expectEmit();
@@ -350,7 +450,11 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             address(migrationController)
         );
         vm.expectEmit();
-        emit IRegistryEvents.ResolverUpdated(tokenId, md.resolver, address(migrationController));
+        emit IRegistryEvents.ResolverUpdated(
+            tokenId,
+            md.resolver,
+            address(migrationController)
+        );
         vm.prank(user);
         uint256 g = gasleft();
         ethRegistrarV1.safeTransferFrom(
@@ -363,7 +467,11 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
 
         assertEq(ethRegistry.getTokenId(tokenIdV1), tokenId, "tokenId");
         assertEq(ethRegistry.ownerOf(tokenId), md.owner, "owner");
-        assertEq(ethRegistry.getExpiry(tokenId), ethRegistrarV1.nameExpires(tokenIdV1), "expiry");
+        assertEq(
+            ethRegistry.getExpiry(tokenId),
+            ethRegistrarV1.nameExpires(tokenIdV1),
+            "expiry"
+        );
         assertEq(ethRegistry.getResolver(md.label), md.resolver, "resolver");
         checkResolution(name, address(ensV2Resolver), md.resolver);
         assertEq(
@@ -371,7 +479,16 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             address(md.subregistry),
             "subregistry"
         );
-        assertEq(registryV1.resolver(NameCoder.namehash(name, 0)), address(0), "resolverV1");
+        assertEq(
+            registryV1.resolver(NameCoder.namehash(name, 0)),
+            address(0),
+            "resolverV1"
+        );
+        assertEq(
+            registryV1.owner(NameCoder.namehash(name, 0)),
+            address(graveyard),
+            "graveyard"
+        );
     }
 
     function test_wrapped_migrate() external {
@@ -381,7 +498,13 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         uint256 tokenId = LibLabel.withVersion(tokenIdV1, 0);
         bytes32 node = NameCoder.namehash(name, 0);
         vm.expectEmit();
-        emit IERC1155.TransferSingle(user, user, address(migrationController), uint256(node), 1);
+        emit IERC1155.TransferSingle(
+            user,
+            user,
+            address(migrationController),
+            uint256(node),
+            1
+        );
         vm.expectEmit();
         emit IRegistryEvents.LabelRegistered(
             tokenId,
@@ -392,7 +515,13 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             address(migrationController)
         );
         vm.expectEmit();
-        emit IERC1155.TransferSingle(address(migrationController), address(0), md.owner, tokenId, 1);
+        emit IERC1155.TransferSingle(
+            address(migrationController),
+            address(0),
+            md.owner,
+            tokenId,
+            1
+        );
         vm.expectEmit();
         emit IPermissionedRegistry.TokenResource(tokenId, tokenId);
         vm.expectEmit();
@@ -409,7 +538,11 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             address(migrationController)
         );
         vm.expectEmit();
-        emit IRegistryEvents.ResolverUpdated(tokenId, md.resolver, address(migrationController));
+        emit IRegistryEvents.ResolverUpdated(
+            tokenId,
+            md.resolver,
+            address(migrationController)
+        );
         vm.prank(user);
         uint256 g = gasleft();
         nameWrapper.safeTransferFrom(
@@ -423,7 +556,11 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
 
         assertEq(ethRegistry.getTokenId(tokenIdV1), tokenId, "tokenId");
         assertEq(ethRegistry.ownerOf(tokenId), md.owner, "owner");
-        assertEq(ethRegistry.getExpiry(tokenId), ethRegistrarV1.nameExpires(tokenIdV1), "expiry");
+        assertEq(
+            ethRegistry.getExpiry(tokenId),
+            ethRegistrarV1.nameExpires(tokenIdV1),
+            "expiry"
+        );
         assertEq(ethRegistry.getResolver(md.label), md.resolver, "resolver");
         checkResolution(name, address(ensV2Resolver), md.resolver);
         assertEq(
@@ -432,6 +569,11 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             "subregistry"
         );
         assertEq(registryV1.resolver(node), address(0), "resolverV1");
+        assertEq(
+            registryV1.owner(NameCoder.namehash(name, 0)),
+            address(graveyard),
+            "graveyard"
+        );
     }
 
     function test_unwrapped_migrateViaApproval(bool all) external {
@@ -495,7 +637,10 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         uint256[] memory amounts = new uint256[](count);
         LibMigration.Data[] memory mds = new LibMigration.Data[](count);
         for (uint256 i; i < count; ++i) {
-            bytes memory name = registerWrappedETH2LD(_label(i), CAN_DO_EVERYTHING);
+            bytes memory name = registerWrappedETH2LD(
+                _label(i),
+                CAN_DO_EVERYTHING
+            );
             LibMigration.Data memory md = _makeData(name);
             md.resolver = address(uint160(i));
             mds[i] = md;
@@ -519,8 +664,16 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
                 ethRegistrarV1.nameExpires(uint256(keccak256(bytes(md.label)))),
                 "expiry"
             );
-            assertEq(ethRegistry.getResolver(md.label), md.resolver, "resolver");
-            checkResolution(NameCoder.ethName(md.label), address(ensV2Resolver), address(uint160(i)));
+            assertEq(
+                ethRegistry.getResolver(md.label),
+                md.resolver,
+                "resolver"
+            );
+            checkResolution(
+                NameCoder.ethName(md.label),
+                address(ensV2Resolver),
+                address(uint160(i))
+            );
             assertEq(
                 address(ethRegistry.getSubregistry(md.label)),
                 address(md.subregistry),
@@ -535,8 +688,10 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         uint256[] memory amounts = new uint256[](count);
         LibMigration.Data[] memory mds = new LibMigration.Data[](count);
         for (uint256 i; i < count; ++i) {
-            bytes memory name =
-                registerWrappedETH2LD(_label(i), i == count - 1 ? CANNOT_UNWRAP : CAN_DO_EVERYTHING);
+            bytes memory name = registerWrappedETH2LD(
+                _label(i),
+                i == count - 1 ? CANNOT_UNWRAP : CAN_DO_EVERYTHING
+            );
             LibMigration.Data memory md = _makeData(name);
             mds[i] = md;
             ids[i] = uint256(NameCoder.namehash(name, 0));
@@ -544,7 +699,10 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         }
         vm.expectRevert(
             WrappedErrorLib.wrap(
-                abi.encodeWithSelector(LibMigration.NameIsLocked.selector, ids[count - 1])
+                abi.encodeWithSelector(
+                    LibMigration.NameIsLocked.selector,
+                    ids[count - 1]
+                )
             )
         );
         vm.prank(user);
@@ -557,8 +715,15 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
-    function _makeData(bytes memory name) internal view returns (LibMigration.Data memory) {
+    function _makeData(
+        bytes memory name
+    ) internal view returns (LibMigration.Data memory) {
         return
-            LibMigration.Data({label: NameCoder.firstLabel(name), owner: user, subregistry: testRegistry, resolver: testResolver});
+            LibMigration.Data({
+                label: NameCoder.firstLabel(name),
+                owner: user,
+                subregistry: testRegistry,
+                resolver: testResolver
+            });
     }
 }

--- a/contracts/test/unit/migration/UnlockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/UnlockedMigrationController.t.sol
@@ -57,10 +57,6 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             ethRegistry
         );
         ethRegistry.grantRootRoles(
-            RegistryRolesLib.ROLE_REGISTRAR,
-            premigrationController
-        );
-        ethRegistry.grantRootRoles(
             RegistryRolesLib.ROLE_REGISTER_RESERVED,
             address(migrationController)
         );
@@ -637,10 +633,15 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         uint256[] memory amounts = new uint256[](count);
         LibMigration.Data[] memory mds = new LibMigration.Data[](count);
         for (uint256 i; i < count; ++i) {
+<<<<<<< HEAD
             bytes memory name = registerWrappedETH2LD(
                 _label(i),
                 CAN_DO_EVERYTHING
             );
+=======
+            testDuration = uint64(vm.randomUint(1, 1000 days));
+            bytes memory name = registerWrappedETH2LD(_label(i), CAN_DO_EVERYTHING);
+>>>>>>> d04d2971 (add gracePeriodV1 and testDuration)
             LibMigration.Data memory md = _makeData(name);
             md.resolver = address(uint160(i));
             mds[i] = md;

--- a/contracts/test/unit/migration/UnlockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/UnlockedMigrationController.t.sol
@@ -5,46 +5,27 @@ pragma solidity >=0.8.13;
 
 import {console} from "forge-std/console.sol";
 
-import {
-    CAN_DO_EVERYTHING,
-    CANNOT_UNWRAP
-} from "@ens/contracts/wrapper/INameWrapper.sol";
+import {CAN_DO_EVERYTHING, CANNOT_UNWRAP} from "@ens/contracts/wrapper/INameWrapper.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
-import {
-    IERC1155Errors
-} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
-import {
-    IERC721Receiver
-} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-import {
-    IERC1155Receiver
-} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
-import {
-    ERC165Checker
-} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import {IERC1155Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
 import {InvalidOwner, UnauthorizedCaller} from "~src/CommonErrors.sol";
 import {WrappedErrorLib} from "~src/utils/WrappedErrorLib.sol";
 import {LibLabel} from "~src/utils/LibLabel.sol";
 import {LibMigration} from "~src/migration/libraries/LibMigration.sol";
-import {
-    IEnhancedAccessControl
-} from "~src/access-control/EnhancedAccessControl.sol";
+import {IEnhancedAccessControl} from "~src/access-control/EnhancedAccessControl.sol";
 import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
 import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
-import {
-    IPermissionedRegistry
-} from "~src/registry/interfaces/IPermissionedRegistry.sol";
+import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
 import {REGISTRATION_ROLE_BITMAP} from "~src/registrar/ETHRegistrar.sol";
-import {
-    UnlockedMigrationController
-} from "~src/migration/UnlockedMigrationController.sol";
-import {
-    MigrationControllerFixture
-} from "~test/unit/migration/MigrationControllerFixture.sol";
+import {UnlockedMigrationController} from "~src/migration/UnlockedMigrationController.sol";
+import {MigrationControllerFixture} from "~test/unit/migration/MigrationControllerFixture.sol";
 
 contract UnlockedMigrationControllerTest is MigrationControllerFixture {
     UnlockedMigrationController migrationController;
@@ -63,21 +44,9 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
     }
 
     function test_constructor() external view {
-        assertEq(
-            address(migrationController.NAME_WRAPPER()),
-            address(nameWrapper),
-            "NAME_WRAPPER"
-        );
-        assertEq(
-            address(migrationController.GRAVEYARD()),
-            address(graveyard),
-            "GRAVEYARD"
-        );
-        assertEq(
-            address(migrationController.ETH_REGISTRY()),
-            address(ethRegistry),
-            "ETH_REGISTRY"
-        );
+        assertEq(address(migrationController.NAME_WRAPPER()), address(nameWrapper), "NAME_WRAPPER");
+        assertEq(address(migrationController.GRAVEYARD()), address(graveyard), "GRAVEYARD");
+        assertEq(address(migrationController.ETH_REGISTRY()), address(ethRegistry), "ETH_REGISTRY");
     }
 
     function test_supportsInterface() external view {
@@ -98,21 +67,14 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
     }
 
     function test_finishERC1155Migration_unauthorizedCaller() external {
-        vm.expectRevert(
-            abi.encodeWithSelector(UnauthorizedCaller.selector, user)
-        );
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedCaller.selector, user));
         vm.prank(user);
-        migrationController.finishERC1155Migration(
-            new uint256[](0),
-            new LibMigration.Data[](0)
-        );
+        migrationController.finishERC1155Migration(new uint256[](0), new LibMigration.Data[](0));
     }
 
     function test_unwrapped_safeTransferFrom_unauthorizedCaller() external {
         uint256 tokenId = dummy721.mint(user);
-        vm.expectRevert(
-            abi.encodeWithSelector(UnauthorizedCaller.selector, dummy721)
-        );
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedCaller.selector, dummy721));
         vm.prank(user);
         dummy721.safeTransferFrom(user, address(migrationController), tokenId); // wrong
     }
@@ -120,26 +82,16 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
     function test_wrapped_safeTransferFrom_unauthorizedCaller() external {
         uint256 tokenId = dummy1155.mint(user);
         vm.expectRevert(
-            WrappedErrorLib.wrap(
-                abi.encodeWithSelector(UnauthorizedCaller.selector, dummy1155)
-            )
+            WrappedErrorLib.wrap(abi.encodeWithSelector(UnauthorizedCaller.selector, dummy1155))
         );
         vm.prank(user);
-        dummy1155.safeTransferFrom(
-            user,
-            address(migrationController),
-            tokenId,
-            1,
-            ""
-        ); // wrong
+        dummy1155.safeTransferFrom(user, address(migrationController), tokenId, 1, ""); // wrong
     }
 
     function test_unwrapped_invalidData(bytes calldata v) external {
         vm.assume(v.length < LibMigration.MIN_DATA_SIZE);
         (, uint256 tokenIdV1) = registerUnwrapped(testLabel);
-        vm.expectRevert(
-            abi.encodeWithSelector(LibMigration.InvalidData.selector)
-        );
+        vm.expectRevert(abi.encodeWithSelector(LibMigration.InvalidData.selector));
         vm.prank(user);
         ethRegistrarV1.safeTransferFrom(
             user,
@@ -153,9 +105,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         vm.assume(v.length < LibMigration.MIN_DATA_SIZE);
         bytes memory name = registerWrappedETH2LD(testLabel, CAN_DO_EVERYTHING);
         vm.expectRevert(
-            WrappedErrorLib.wrap(
-                abi.encodeWithSelector(LibMigration.InvalidData.selector)
-            )
+            WrappedErrorLib.wrap(abi.encodeWithSelector(LibMigration.InvalidData.selector))
         );
         vm.prank(user);
         nameWrapper.safeTransferFrom(
@@ -190,13 +140,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             )
         );
         vm.prank(user);
-        nameWrapper.safeBatchTransferFrom(
-            user,
-            address(migrationController),
-            ids,
-            amounts,
-            payload
-        );
+        nameWrapper.safeBatchTransferFrom(user, address(migrationController), ids, amounts, payload);
     }
 
     function test_unwrapped_invalidOwner() external {
@@ -217,9 +161,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         bytes memory name = registerWrappedETH2LD(testLabel, CAN_DO_EVERYTHING);
         LibMigration.Data memory md = _makeData(name);
         md.owner = address(0); // wrong
-        vm.expectRevert(
-            WrappedErrorLib.wrap(abi.encodeWithSelector(InvalidOwner.selector))
-        );
+        vm.expectRevert(WrappedErrorLib.wrap(abi.encodeWithSelector(InvalidOwner.selector)));
         vm.prank(user);
         nameWrapper.safeTransferFrom(
             user,
@@ -235,10 +177,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         LibMigration.Data memory md = _makeData(name);
         md.owner = address(ethRegistry); // not a IERC1155Receiver
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IERC1155Errors.ERC1155InvalidReceiver.selector,
-                md.owner
-            )
+            abi.encodeWithSelector(IERC1155Errors.ERC1155InvalidReceiver.selector, md.owner)
         );
         vm.prank(user);
         ethRegistrarV1.safeTransferFrom(
@@ -256,10 +195,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
 
         vm.expectRevert(
             WrappedErrorLib.wrap(
-                abi.encodeWithSelector(
-                    IERC1155Errors.ERC1155InvalidReceiver.selector,
-                    md.owner
-                )
+                abi.encodeWithSelector(IERC1155Errors.ERC1155InvalidReceiver.selector, md.owner)
             )
         );
         vm.prank(user);
@@ -276,12 +212,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         (bytes memory name, uint256 tokenIdV1) = registerUnwrapped(testLabel);
         LibMigration.Data memory md = _makeData(name);
         md.label = "wrong";
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                LibMigration.NameDataMismatch.selector,
-                tokenIdV1
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(LibMigration.NameDataMismatch.selector, tokenIdV1));
         vm.prank(user);
         ethRegistrarV1.safeTransferFrom(
             user,
@@ -298,10 +229,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         md.label = "wrong";
         vm.expectRevert(
             WrappedErrorLib.wrap(
-                abi.encodeWithSelector(
-                    LibMigration.NameDataMismatch.selector,
-                    node
-                )
+                abi.encodeWithSelector(LibMigration.NameDataMismatch.selector, node)
             )
         );
         vm.prank(user);
@@ -319,9 +247,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         bytes32 node = NameCoder.namehash(name, 0);
         LibMigration.Data memory md = _makeData(name);
         vm.expectRevert(
-            WrappedErrorLib.wrap(
-                abi.encodeWithSelector(LibMigration.NameIsLocked.selector, node)
-            )
+            WrappedErrorLib.wrap(abi.encodeWithSelector(LibMigration.NameIsLocked.selector, node))
         );
         vm.prank(user);
         nameWrapper.safeTransferFrom(
@@ -382,13 +308,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         (bytes memory name, uint256 tokenIdV1) = registerUnwrapped(testLabel);
         LibMigration.Data memory md = _makeData(name);
 
-        assertFalse(
-            ethRegistry.hasRoles(
-                tokenIdV1,
-                RegistryRolesLib.ROLE_WAS_RESERVED,
-                user
-            )
-        );
+        assertFalse(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, user));
 
         vm.prank(user);
         ethRegistrarV1.safeTransferFrom(
@@ -398,13 +318,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             abi.encode(md)
         );
 
-        assertTrue(
-            ethRegistry.hasRoles(
-                tokenIdV1,
-                RegistryRolesLib.ROLE_WAS_RESERVED,
-                user
-            )
-        );
+        assertTrue(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, user));
     }
 
     function test_unwrapped_migrate() external {
@@ -423,13 +337,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             address(migrationController)
         );
         vm.expectEmit();
-        emit IERC1155.TransferSingle(
-            address(migrationController),
-            address(0),
-            md.owner,
-            tokenId,
-            1
-        );
+        emit IERC1155.TransferSingle(address(migrationController), address(0), md.owner, tokenId, 1);
         vm.expectEmit();
         emit IPermissionedRegistry.TokenResource(tokenId, tokenId);
         vm.expectEmit();
@@ -446,11 +354,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             address(migrationController)
         );
         vm.expectEmit();
-        emit IRegistryEvents.ResolverUpdated(
-            tokenId,
-            md.resolver,
-            address(migrationController)
-        );
+        emit IRegistryEvents.ResolverUpdated(tokenId, md.resolver, address(migrationController));
         vm.prank(user);
         uint256 g = gasleft();
         ethRegistrarV1.safeTransferFrom(
@@ -463,11 +367,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
 
         assertEq(ethRegistry.getTokenId(tokenIdV1), tokenId, "tokenId");
         assertEq(ethRegistry.ownerOf(tokenId), md.owner, "owner");
-        assertEq(
-            ethRegistry.getExpiry(tokenId),
-            ethRegistrarV1.nameExpires(tokenIdV1),
-            "expiry"
-        );
+        assertEq(ethRegistry.getExpiry(tokenId), ethRegistrarV1.nameExpires(tokenIdV1), "expiry");
         assertEq(ethRegistry.getResolver(md.label), md.resolver, "resolver");
         checkResolution(name, address(ensV2Resolver), md.resolver);
         assertEq(
@@ -475,16 +375,8 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             address(md.subregistry),
             "subregistry"
         );
-        assertEq(
-            registryV1.resolver(NameCoder.namehash(name, 0)),
-            address(0),
-            "resolverV1"
-        );
-        assertEq(
-            registryV1.owner(NameCoder.namehash(name, 0)),
-            address(graveyard),
-            "graveyard"
-        );
+        assertEq(registryV1.resolver(NameCoder.namehash(name, 0)), address(0), "resolverV1");
+        assertEq(registryV1.owner(NameCoder.namehash(name, 0)), address(graveyard), "graveyard");
     }
 
     function test_wrapped_migrate() external {
@@ -494,13 +386,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         uint256 tokenId = LibLabel.withVersion(tokenIdV1, 0);
         bytes32 node = NameCoder.namehash(name, 0);
         vm.expectEmit();
-        emit IERC1155.TransferSingle(
-            user,
-            user,
-            address(migrationController),
-            uint256(node),
-            1
-        );
+        emit IERC1155.TransferSingle(user, user, address(migrationController), uint256(node), 1);
         vm.expectEmit();
         emit IRegistryEvents.LabelRegistered(
             tokenId,
@@ -511,13 +397,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             address(migrationController)
         );
         vm.expectEmit();
-        emit IERC1155.TransferSingle(
-            address(migrationController),
-            address(0),
-            md.owner,
-            tokenId,
-            1
-        );
+        emit IERC1155.TransferSingle(address(migrationController), address(0), md.owner, tokenId, 1);
         vm.expectEmit();
         emit IPermissionedRegistry.TokenResource(tokenId, tokenId);
         vm.expectEmit();
@@ -534,11 +414,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             address(migrationController)
         );
         vm.expectEmit();
-        emit IRegistryEvents.ResolverUpdated(
-            tokenId,
-            md.resolver,
-            address(migrationController)
-        );
+        emit IRegistryEvents.ResolverUpdated(tokenId, md.resolver, address(migrationController));
         vm.prank(user);
         uint256 g = gasleft();
         nameWrapper.safeTransferFrom(
@@ -552,11 +428,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
 
         assertEq(ethRegistry.getTokenId(tokenIdV1), tokenId, "tokenId");
         assertEq(ethRegistry.ownerOf(tokenId), md.owner, "owner");
-        assertEq(
-            ethRegistry.getExpiry(tokenId),
-            ethRegistrarV1.nameExpires(tokenIdV1),
-            "expiry"
-        );
+        assertEq(ethRegistry.getExpiry(tokenId), ethRegistrarV1.nameExpires(tokenIdV1), "expiry");
         assertEq(ethRegistry.getResolver(md.label), md.resolver, "resolver");
         checkResolution(name, address(ensV2Resolver), md.resolver);
         assertEq(
@@ -565,11 +437,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             "subregistry"
         );
         assertEq(registryV1.resolver(node), address(0), "resolverV1");
-        assertEq(
-            registryV1.owner(NameCoder.namehash(name, 0)),
-            address(graveyard),
-            "graveyard"
-        );
+        assertEq(registryV1.owner(NameCoder.namehash(name, 0)), address(graveyard), "graveyard");
     }
 
     function test_unwrapped_migrateViaApproval(bool all) external {
@@ -633,15 +501,8 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         uint256[] memory amounts = new uint256[](count);
         LibMigration.Data[] memory mds = new LibMigration.Data[](count);
         for (uint256 i; i < count; ++i) {
-<<<<<<< HEAD
-            bytes memory name = registerWrappedETH2LD(
-                _label(i),
-                CAN_DO_EVERYTHING
-            );
-=======
             testDuration = uint64(vm.randomUint(1, 1000 days));
             bytes memory name = registerWrappedETH2LD(_label(i), CAN_DO_EVERYTHING);
->>>>>>> d04d2971 (add gracePeriodV1 and testDuration)
             LibMigration.Data memory md = _makeData(name);
             md.resolver = address(uint160(i));
             mds[i] = md;
@@ -661,21 +522,9 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             uint256 tokenIdV1 = LibLabel.id(md.label);
             uint256 tokenId = ethRegistry.getTokenId(tokenIdV1);
             assertEq(ethRegistry.ownerOf(tokenId), md.owner, "owner");
-            assertEq(
-                ethRegistry.getExpiry(tokenId),
-                ethRegistrarV1.nameExpires(tokenIdV1),
-                "expiry"
-            );
-            assertEq(
-                ethRegistry.getResolver(md.label),
-                md.resolver,
-                "resolver"
-            );
-            checkResolution(
-                NameCoder.ethName(md.label),
-                address(ensV2Resolver),
-                address(uint160(i))
-            );
+            assertEq(ethRegistry.getExpiry(tokenId), ethRegistrarV1.nameExpires(tokenIdV1), "expiry");
+            assertEq(ethRegistry.getResolver(md.label), md.resolver, "resolver");
+            checkResolution(NameCoder.ethName(md.label), address(ensV2Resolver), address(uint160(i)));
             assertEq(
                 address(ethRegistry.getSubregistry(md.label)),
                 address(md.subregistry),
@@ -690,10 +539,8 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         uint256[] memory amounts = new uint256[](count);
         LibMigration.Data[] memory mds = new LibMigration.Data[](count);
         for (uint256 i; i < count; ++i) {
-            bytes memory name = registerWrappedETH2LD(
-                _label(i),
-                i == count - 1 ? CANNOT_UNWRAP : CAN_DO_EVERYTHING
-            );
+            bytes memory name =
+                registerWrappedETH2LD(_label(i), i == count - 1 ? CANNOT_UNWRAP : CAN_DO_EVERYTHING);
             LibMigration.Data memory md = _makeData(name);
             mds[i] = md;
             ids[i] = uint256(NameCoder.namehash(name, 0));
@@ -701,10 +548,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         }
         vm.expectRevert(
             WrappedErrorLib.wrap(
-                abi.encodeWithSelector(
-                    LibMigration.NameIsLocked.selector,
-                    ids[count - 1]
-                )
+                abi.encodeWithSelector(LibMigration.NameIsLocked.selector, ids[count - 1])
             )
         );
         vm.prank(user);
@@ -717,15 +561,8 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
-    function _makeData(
-        bytes memory name
-    ) internal view returns (LibMigration.Data memory) {
+    function _makeData(bytes memory name) internal view returns (LibMigration.Data memory) {
         return
-            LibMigration.Data({
-                label: NameCoder.firstLabel(name),
-                owner: user,
-                subregistry: testRegistry,
-                resolver: testResolver
-            });
+            LibMigration.Data({label: NameCoder.firstLabel(name), owner: user, subregistry: testRegistry, resolver: testResolver});
     }
 }

--- a/contracts/test/unit/migration/UnlockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/UnlockedMigrationController.t.sol
@@ -416,7 +416,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         vm.expectEmit();
         emit IRegistryEvents.LabelRegistered(
             tokenId,
-            keccak256(bytes(md.label)),
+            bytes32(tokenIdV1),
             md.label,
             md.owner,
             uint64(ethRegistrarV1.nameExpires(tokenIdV1)),
@@ -490,7 +490,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
     function test_wrapped_migrate() external {
         bytes memory name = registerWrappedETH2LD(testLabel, CAN_DO_EVERYTHING);
         LibMigration.Data memory md = _makeData(name);
-        uint256 tokenIdV1 = uint256(keccak256(bytes(md.label)));
+        uint256 tokenIdV1 = LibLabel.id(md.label);
         uint256 tokenId = LibLabel.withVersion(tokenIdV1, 0);
         bytes32 node = NameCoder.namehash(name, 0);
         vm.expectEmit();
@@ -504,7 +504,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         vm.expectEmit();
         emit IRegistryEvents.LabelRegistered(
             tokenId,
-            keccak256(bytes(md.label)),
+            bytes32(tokenIdV1),
             md.label,
             md.owner,
             uint64(ethRegistrarV1.nameExpires(tokenIdV1)),
@@ -658,11 +658,12 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         );
         for (uint256 i; i < count; ++i) {
             LibMigration.Data memory md = mds[i];
-            uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(md.label));
+            uint256 tokenIdV1 = LibLabel.id(md.label);
+            uint256 tokenId = ethRegistry.getTokenId(tokenIdV1);
             assertEq(ethRegistry.ownerOf(tokenId), md.owner, "owner");
             assertEq(
                 ethRegistry.getExpiry(tokenId),
-                ethRegistrarV1.nameExpires(uint256(keccak256(bytes(md.label)))),
+                ethRegistrarV1.nameExpires(tokenIdV1),
                 "expiry"
             );
             assertEq(


### PR DESCRIPTION
- added [Graveyard.sol](https://github.com/ensdomains/contracts-v2/blob/feat/graveyard/contracts/src/migration/Graveyard.sol) (intended as the replacement `ETHRegistrarController`) and [tests](https://github.com/ensdomains/contracts-v2/blob/feat/graveyard/contracts/test/unit/migration/Graveyard.t.sol)
    * has no ENSv2 dependencies
    * added `clear(names[])`
- moved some common migration logic to `LibMigration`
- changed `UnlockedMigrationController` to transfer unwrapped ERC-721 to `Graveyard`
```diff
  _REGISTRAR_V1.reclaim(tokenId, address(this));
- _REGISTRY_V1.setResolver(address(0));
+ _REGISTRY_V1.setRecord(
+      NameCoder.namehash(NameCoder.ETH_NODE, bytes32(tokenId)),
+      GRAVEYARD, // transfer ownership to graveyard
+      address(0), // clear ENSv1 resolver
+      0
+  );
+ _REGISTRAR_V1.safeTransferFrom(address(this), GRAVEYARD, tokenId); // transfer token to graveyard
```
- changed `UnlockedMigrationController` to unwrap unlocked ERC-1155 to `Graveyard`
```diff
- NAME_WRAPPER.setResolver(bytes32(id), address(0));
+ NAME_WRAPPER.setResolver(bytes32(id), address(0)); // clear ENSv1 resolver
+ NAME_WRAPPER.unwrapETH2LD(labelHash, GRAVEYARD, GRAVEYARD); // unwrap and transfer to graveyard
```
- changed `LockedMigrationController` to unwrap detached ERC-1155 to `Graveyard`
```diff
- NAME_WRAPPER.unwrap(parentNode, labelHash, address(this));
- _REGISTRY_V1.setResolver(node, address(0)); // clear ENSv1 resolver
+ NAME_WRAPPER.setResolver(node, address(0)); // clear ENSv1 resolver
+ NAME_WRAPPER.unwrap(parentNode, labelHash, GRAVEYARD); // unwrap and transfer to graveyard
```
- changed `LockedMigrationController` to transfer locked ERC-1155 to `Graveyard`
```diff
+ NAME_WRAPPER.safeTransferFrom(address(this), GRAVEYARD, uint256(node), 1, ""); // transfer to graveyard
```