### PR TITLE
Add `IUniversalResolverV2`

### DIFF
--- a/contracts/src/universalResolver/UniversalResolverV2.sol
+++ b/contracts/src/universalResolver/UniversalResolverV2.sol
@@ -1,16 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
+import {IGatewayProvider} from "@ens/contracts/ccipRead/IGatewayProvider.sol";
 import {
-    AbstractUniversalResolver,
-    IGatewayProvider
+    AbstractUniversalResolver
 } from "@ens/contracts/universalResolver/AbstractUniversalResolver.sol";
 
-import {LibRegistry, IRegistry} from "./libraries/LibRegistry.sol";
+import {IRegistry} from "../registry/interfaces/IRegistry.sol";
+
+import {IUniversalResolverV2} from "./interfaces/IUniversalResolverV2.sol";
+import {LibRegistry} from "./libraries/LibRegistry.sol";
 
 /// @notice ENS Universal Resolver that traverses the namechain registry hierarchy to locate
 ///         resolvers and registries for any DNS-encoded name.
-contract UniversalResolverV2 is AbstractUniversalResolver {
+contract UniversalResolverV2 is AbstractUniversalResolver, IUniversalResolverV2 {
     ////////////////////////////////////////////////////////////////////////
     // Immutables
     ////////////////////////////////////////////////////////////////////////
@@ -22,47 +25,46 @@ contract UniversalResolverV2 is AbstractUniversalResolver {
     // Initialization
     ////////////////////////////////////////////////////////////////////////
 
-    /// @param root The root registry.
+    /// @param rootRegistry The root registry.
     /// @param batchGatewayProvider The batch gateway provider.
-    constructor(IRegistry root, IGatewayProvider batchGatewayProvider)
+    constructor(IRegistry rootRegistry, IGatewayProvider batchGatewayProvider)
         AbstractUniversalResolver(batchGatewayProvider)
     {
-        ROOT_REGISTRY = root;
+        ROOT_REGISTRY = rootRegistry;
+    }
+
+    /// @inheritdoc AbstractUniversalResolver
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return
+            type(IUniversalResolverV2).interfaceId == interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 
     ////////////////////////////////////////////////////////////////////////
     // Implementation
     ////////////////////////////////////////////////////////////////////////
 
-    /// @notice Construct the canonical name for `registry`.
-    /// @param registry The registry to name.
-    /// @return The DNS-encoded name or empty if not canonical.
+    /// @inheritdoc IUniversalResolverV2
     function findCanonicalName(IRegistry registry) external view returns (bytes memory) {
         return LibRegistry.findCanonicalName(ROOT_REGISTRY, registry);
     }
 
-    /// @notice Find the canonical registry for `name`.
-    /// @param name The DNS-encoded name.
-    /// @return The canonical registry or null if not canonical.
+    /// @inheritdoc IUniversalResolverV2
     function findCanonicalRegistry(bytes calldata name) external view returns (IRegistry) {
         return LibRegistry.findCanonicalRegistry(ROOT_REGISTRY, name);
     }
 
-    /// @notice Find the exact registry for `name`.
-    /// @param name The DNS-encoded name.
-    /// @return The canonical registry or null if not found.
+    /// @inheritdoc IUniversalResolverV2
     function findExactRegistry(bytes calldata name) external view returns (IRegistry) {
         return LibRegistry.findExactRegistry(ROOT_REGISTRY, name, 0);
     }
 
-    /// @notice Find all registries in the ancestry of `name`.
-    /// * `findRegistries("") = [<root>]`
-    /// * `findRegistries("eth") = [<eth>, <root>]`
-    /// * `findRegistries("nick.eth") = [<nick>, <eth>, <root>]`
-    /// * `findRegistries("sub.nick.eth") = [null, <nick>, <eth>, <root>]`
-    ///
-    /// @param name The DNS-encoded name.
-    /// @return Array of registries in label-order.
+    /// @inheritdoc IUniversalResolverV2
+    function findParentRegistry(bytes calldata name) external view returns (IRegistry) {
+        return LibRegistry.findParentRegistry(ROOT_REGISTRY, name, 0);
+    }
+
+    /// @inheritdoc IUniversalResolverV2
     function findRegistries(bytes calldata name) external view returns (IRegistry[] memory) {
         return LibRegistry.findRegistries(ROOT_REGISTRY, name, 0);
     }

--- a/contracts/src/universalResolver/interfaces/IUniversalResolverV2.sol
+++ b/contracts/src/universalResolver/interfaces/IUniversalResolverV2.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import {IRegistry} from "../../registry/interfaces/IRegistry.sol";
+
+/// @notice Interface for ENSv2-specific UniversalResolver helper functions.
+/// @dev Interface selector: `0x6e37653d`
+interface IUniversalResolverV2 {
+    /// @notice Construct the canonical name for `registry`.
+    /// @param registry The registry to name.
+    /// @return The DNS-encoded name or empty if not canonical.
+    function findCanonicalName(IRegistry registry) external view returns (bytes memory);
+
+    /// @notice Find the canonical registry for `name`.
+    /// @param name The DNS-encoded name.
+    /// @return The canonical registry or null if not canonical.
+    function findCanonicalRegistry(bytes calldata name) external view returns (IRegistry);
+
+    /// @notice Find the exact registry for `name`.
+    /// @param name The DNS-encoded name.
+    /// @return The registry or null if not found.
+    function findExactRegistry(bytes calldata name) external view returns (IRegistry);
+
+    /// @notice Find the parent registry for `name`.
+    /// @param name The DNS-encoded name.
+    /// @return The parent registry or null if not found.
+    function findParentRegistry(bytes calldata name) external view returns (IRegistry);
+
+    /// @notice Find all registries in the ancestry of `name`.
+    /// * `findRegistries("") = [<root>]`
+    /// * `findRegistries("eth") = [<eth>, <root>]`
+    /// * `findRegistries("nick.eth") = [<nick>, <eth>, <root>]`
+    /// * `findRegistries("sub.nick.eth") = [null, <nick>, <eth>, <root>]`
+    ///
+    /// @param name The DNS-encoded name.
+    /// @return Array of registries in label-order.
+    function findRegistries(bytes calldata name) external view returns (IRegistry[] memory);
+}

--- a/contracts/src/universalResolver/libraries/LibRegistry.sol
+++ b/contracts/src/universalResolver/libraries/LibRegistry.sol
@@ -109,6 +109,21 @@ library LibRegistry {
         }
     }
 
+    /// @dev Find the parent registry for `name[offset:]`.
+    /// @param rootRegistry The root ENS registry.
+    /// @param name The DNS-encoded name to search.
+    /// @return parentRegistry The parent registry or null if not found.
+    function findParentRegistry(IRegistry rootRegistry, bytes memory name, uint256 offset)
+        internal
+        view
+        returns (IRegistry parentRegistry)
+    {
+        (bytes32 labelHash, uint256 next) = NameCoder.readLabel(name, offset);
+        if (labelHash != bytes32(0)) {
+            parentRegistry = findExactRegistry(rootRegistry, name, next);
+        }
+    }
+
     /// @dev Find all registries in the ancestry of `name`.
     /// @param rootRegistry The root ENS registry.
     /// @param name The DNS-encoded name.

--- a/contracts/test/unit/universalResolver/UniversalResolverV2.t.sol
+++ b/contracts/test/unit/universalResolver/UniversalResolverV2.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
+import {IUniversalResolver} from "@ens/contracts/universalResolver/IUniversalResolver.sol";
+
+import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
+import {IUniversalResolverV2} from "~src/universalResolver/interfaces/IUniversalResolverV2.sol";
+import {V2Fixture} from "~test/fixtures/V2Fixture.sol";
+
+// NOTE: most of these tests are covered by LibRegistry.t.sol
+
+contract UniversalResolverV2Test is V2Fixture {
+    function setUp() external {
+        deployV2Fixture();
+    }
+
+    function test_supportsInterface() external view {
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(universalResolver),
+                type(IUniversalResolver).interfaceId
+            ),
+            "IUniversalResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(universalResolver),
+                type(IUniversalResolverV2).interfaceId
+            ),
+            "IUniversalResolverV2"
+        );
+    }
+
+    function test_findCanonicalName() external view {
+        assertEq(universalResolver.findCanonicalName(rootRegistry), NameCoder.encode(""));
+        assertEq(universalResolver.findCanonicalName(ethRegistry), NameCoder.encode("eth"));
+    }
+
+    function test_findCanonicalRegistry() external view {
+        assertEq(
+            address(universalResolver.findCanonicalRegistry(NameCoder.encode(""))),
+            address(rootRegistry)
+        );
+        assertEq(
+            address(universalResolver.findCanonicalRegistry(NameCoder.encode("eth"))),
+            address(ethRegistry)
+        );
+    }
+
+    function test_findExactRegistry() external view {
+        assertEq(
+            address(universalResolver.findExactRegistry(NameCoder.encode(""))),
+            address(rootRegistry)
+        );
+        assertEq(
+            address(universalResolver.findExactRegistry(NameCoder.encode("eth"))),
+            address(ethRegistry)
+        );
+    }
+
+    function test_findParentRegistry() external view {
+        assertEq(address(universalResolver.findParentRegistry(NameCoder.encode(""))), address(0));
+        assertEq(
+            address(universalResolver.findParentRegistry(NameCoder.encode("eth"))),
+            address(rootRegistry)
+        );
+    }
+
+    function test_findRegistries() external view {
+        IRegistry[] memory v = universalResolver.findRegistries(NameCoder.encode("eth"));
+        assertEq(address(v[0]), address(ethRegistry));
+        assertEq(address(v[1]), address(rootRegistry));
+    }
+}

--- a/contracts/test/unit/universalResolver/libraries/LibRegistry.t.sol
+++ b/contracts/test/unit/universalResolver/libraries/LibRegistry.t.sol
@@ -7,53 +7,22 @@ import {Test} from "forge-std/Test.sol";
 
 import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 
 import {EACBaseRolesLib} from "~src/access-control/EnhancedAccessControl.sol";
 import {IHCAFactoryBasic} from "~src/hca/interfaces/IHCAFactoryBasic.sol";
-import {
-    PermissionedRegistry,
-    IStandardRegistry,
-    IRegistry,
-    IRegistryMetadata
-} from "~src/registry/PermissionedRegistry.sol";
-import {LibRegistry, NameCoder} from "~src/universalResolver/libraries/LibRegistry.sol";
+import {IStandardRegistry} from "~src/registry/interfaces/IStandardRegistry.sol";
+import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
+import {IRegistryMetadata} from "~src/registry/interfaces/IRegistryMetadata.sol";
+import {PermissionedRegistry} from "~src/registry/PermissionedRegistry.sol";
+import {LibRegistry} from "~src/universalResolver/libraries/LibRegistry.sol";
 import {LabelStore} from "~src/utils/LabelStore.sol";
 
 contract LibRegistryTest is Test, ERC1155Holder {
     PermissionedRegistry rootRegistry;
     LabelStore labelStore;
-    address resolverAddress = makeAddr("resolver");
 
-    function _createRegistry() internal returns (PermissionedRegistry) {
-        return
-            new PermissionedRegistry(
-                IHCAFactoryBasic(address(0)),
-                IRegistryMetadata(address(0)),
-                labelStore,
-                address(this),
-                EACBaseRolesLib.ALL_ROLES
-            );
-    }
-    function _register(
-        PermissionedRegistry parentRegistry,
-        string memory label,
-        IRegistry registry,
-        address resolver
-    )
-        internal
-    {
-        parentRegistry.register(
-            label,
-            address(this),
-            registry,
-            resolver,
-            EACBaseRolesLib.ALL_ROLES,
-            uint64(block.timestamp + 1000)
-        );
-        if (ERC165Checker.supportsInterface(address(registry), type(IStandardRegistry).interfaceId)) {
-            IStandardRegistry(address(registry)).setParent(parentRegistry, label);
-        }
-    }
+    address resolverAddress = makeAddr("resolver");
 
     function setUp() external {
         labelStore = new LabelStore();
@@ -326,5 +295,41 @@ contract LibRegistryTest is Test, ERC1155Holder {
             address(0),
             "xyz:test.eth"
         );
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Helpers
+    ////////////////////////////////////////////////////////////////////////
+
+    function _createRegistry() internal returns (PermissionedRegistry) {
+        return
+            new PermissionedRegistry(
+                IHCAFactoryBasic(address(0)),
+                IRegistryMetadata(address(0)),
+                labelStore,
+                address(this),
+                EACBaseRolesLib.ALL_ROLES
+            );
+    }
+
+    function _register(
+        PermissionedRegistry parentRegistry,
+        string memory label,
+        IRegistry registry,
+        address resolver
+    )
+        internal
+    {
+        parentRegistry.register(
+            label,
+            address(this),
+            registry,
+            resolver,
+            EACBaseRolesLib.ALL_ROLES,
+            uint64(block.timestamp + 1000)
+        );
+        if (ERC165Checker.supportsInterface(address(registry), type(IStandardRegistry).interfaceId)) {
+            IStandardRegistry(address(registry)).setParent(parentRegistry, label);
+        }
     }
 }


### PR DESCRIPTION
- added `IUniversalResolverV2`
- updated `UniversalResolverV2`
     * restored `findParentRegistry()`
     * added `IUniversalResolverV2`
- added `UniversalResolverV2.t.sol`