### PR TITLE
feat(prepareMigration): add post-pre-migration role-swap script

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -314,6 +314,11 @@ Modified ERC1155 allowing only one token per ID:
 - `LockedMigrationController`: Handles ENSv1 → ENSv2 migration for locked names
 - `UnlockedMigrationController`: Handles ENSv1 → ENSv2 migration for unlocked names
 
+Scripts for running the migration end-to-end:
+
+- [Pre-migration](docs/premigration.md) — seed v1 registrations into the v2 registry as *reserved* entries, via `BatchRegistrar`.
+- [Prepare migration](docs/prepareMigration.md) — swap registry roles from `BatchRegistrar` to `ETHRegistrar` and the two migration controllers once pre-migration is complete.
+
 ### Resolution
 
 #### `UniversalResolverV2` - One-Stop Resolution

--- a/contracts/deploy/03_ETHRegistrar.ts
+++ b/contracts/deploy/03_ETHRegistrar.ts
@@ -1,5 +1,5 @@
 import { artifacts, execute } from "@rocketh";
-import { ROLES } from "../script/deploy-constants.js";
+import { DEPLOYMENT_ROLES } from "../script/deploy-constants.js";
 
 export default execute(
   async ({
@@ -37,10 +37,7 @@ export default execute(
 
     await write(ethRegistry, {
       functionName: "grantRootRoles",
-      args: [
-        ROLES.REGISTRY.REGISTRAR | ROLES.REGISTRY.RENEW,
-        ethRegistrar.address,
-      ],
+      args: [DEPLOYMENT_ROLES.ETH_REGISTRAR_ROOT, ethRegistrar.address],
       account: deployer,
     });
   },

--- a/contracts/deploy/04_BatchRegistrar.ts
+++ b/contracts/deploy/04_BatchRegistrar.ts
@@ -1,5 +1,5 @@
 import { artifacts, execute } from "@rocketh";
-import { ROLES } from "../script/deploy-constants.js";
+import { DEPLOYMENT_ROLES } from "../script/deploy-constants.js";
 
 export default execute(
   async ({ deploy, execute: write, get, namedAccounts: { deployer } }) => {
@@ -15,10 +15,7 @@ export default execute(
     await write(ethRegistry, {
       account: deployer,
       functionName: "grantRootRoles",
-      args: [
-        ROLES.REGISTRY.REGISTRAR | ROLES.REGISTRY.RENEW,
-        batchRegistrar.address,
-      ],
+      args: [DEPLOYMENT_ROLES.ETH_REGISTRAR_ROOT, batchRegistrar.address],
     });
   },
   {

--- a/contracts/docs/prepareMigration.md
+++ b/contracts/docs/prepareMigration.md
@@ -37,7 +37,7 @@ For background on these roles and the EAC admin/base pairing used by registry co
   - `ETHRegistrar` — will receive `ROLE_REGISTRAR`
   - `UnlockedMigrationController` — will receive `ROLE_REGISTER_RESERVED`
   - `LockedMigrationController` — will receive `ROLE_REGISTER_RESERVED`
-- **Signer** holding the admin-role counterparts for every role being moved. In practice this means holding `ROLE_REGISTRAR_ADMIN` and `ROLE_REGISTER_RESERVED_ADMIN` at the registry root. The script runs a pre-flight check against the signer's root roles and aborts with a clear error if any required admin bits are missing — no transactions are broadcast.
+- **Signer** holding the admin-role counterparts for every role being moved. In practice this means holding `ROLE_REGISTRAR_ADMIN`, `ROLE_REGISTER_RESERVED_ADMIN`, and `ROLE_RENEW_ADMIN` at the registry root. The script runs a pre-flight check against the signer's root roles and aborts with a clear error if any required admin bits are missing — no transactions are broadcast.
 - **RPC endpoint** for the chain the registry is deployed on. The chain ID is auto-detected from the RPC.
 
 `--execute` additionally requires `--private-key`; without it the script stays in dry-run mode.

--- a/contracts/docs/prepareMigration.md
+++ b/contracts/docs/prepareMigration.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The prepare-migration script (`contracts/script/prepareMigration.ts`) rewires role grants on the `.eth` `PermissionedRegistry` to flip the registry from its **seeding** configuration (only `BatchRegistrar` can register names) to its **live** configuration (`ETHRegistrar` handles new registrations; `UnlockedMigrationController` and `LockedMigrationController` promote reserved names to registered as ENSv1 owners migrate in).
+The prepare-migration script (`contracts/script/prepareMigration.ts`) rewires role grants on the `.eth` `PermissionedRegistry` to flip the registry from its **seeding** configuration (only `BatchRegistrar` can register names) to its **live** configuration (`ETHRegistrar` handles new registrations and renewals; `UnlockedMigrationController` and `LockedMigrationController` promote reserved names to registered as ENSv1 owners migrate in). `BatchRegistrar` retains no roles after this script runs — it is fully decommissioned on hand-off.
 
 Run this once, after all pre-migration seeding via [`preMigration.ts`](./premigration.md) has completed and before opening registration traffic to users. The script is idempotent at the role level — re-running it against a registry that is already in the live configuration will show every planned op as already satisfied and simply broadcast the same grants/revokes again.
 
@@ -10,14 +10,22 @@ Run this once, after all pre-migration seeding via [`preMigration.ts`](./premigr
 
 The script performs exactly four root-level role operations on the target registry:
 
-| Target | Op | Roles |
-|---|---|---|
-| `BatchRegistrar` | **REVOKE** | `ROLE_REGISTRAR` · `ROLE_REGISTRAR_ADMIN` · `ROLE_REGISTER_RESERVED` · `ROLE_REGISTER_RESERVED_ADMIN` |
-| `ETHRegistrar` | **GRANT** | `ROLE_REGISTRAR` |
-| `UnlockedMigrationController` | **GRANT** | `ROLE_REGISTER_RESERVED` |
-| `LockedMigrationController` | **GRANT** | `ROLE_REGISTER_RESERVED` |
+| Target | Op | Roles | Expected prior state |
+|---|---|---|---|
+| `BatchRegistrar` | **REVOKE** | `ROLE_REGISTRAR` · `ROLE_REGISTRAR_ADMIN` · `ROLE_REGISTER_RESERVED` · `ROLE_REGISTER_RESERVED_ADMIN` · `ROLE_RENEW` · `ROLE_RENEW_ADMIN` | Holds `ROLE_REGISTRAR \| ROLE_RENEW` on a canonically-deployed registry. The four admin bits and `ROLE_REGISTER_RESERVED` are revoked defensively and are no-ops on a canonical deploy — they exist in the bitmap to guarantee the post-state is unambiguously "no roles" regardless of what the registry looked like going in. |
+| `ETHRegistrar` | **GRANT** | `ROLE_REGISTRAR` · `ROLE_RENEW` | None of the granted bits. |
+| `UnlockedMigrationController` | **GRANT** | `ROLE_REGISTER_RESERVED` | None of the granted bit. |
+| `LockedMigrationController` | **GRANT** | `ROLE_REGISTER_RESERVED` | None of the granted bit. |
+
+> **Note for devnet users.** The canonical devnet deploy scripts (`deploy/03_ETHRegistrar.ts`, `deploy/02_UnlockedMigrationController.ts`, `deploy/04_LockedMigrationController.ts`) *already* pre-grant the roles this script would otherwise grant, as a convenience for local dev. That means running this script against a fresh devnet will show every GRANT op as already satisfied and only the `BatchRegistrar` revoke will produce observable state change. The test fixture `revertPrePrepareMigrationRoles` in `test/utils/mockPrepareMigration.ts` undoes those pre-grants so the grant paths can be exercised end-to-end in the e2e tests.
 
 For background on these roles and the EAC admin/base pairing used by registry contracts, see the [EAC section of the contracts README](../README.md#access-control) and [`RegistryRolesLib.sol`](../src/registry/libraries/RegistryRolesLib.sol).
+
+### Why these specific roles
+
+- `ROLE_REGISTRAR` is checked by `PermissionedRegistry.register()` when the entry is expired or never existed. `BatchRegistrar` seeds names via this path (`owner = address(0)`, entering the expired branch), so it holds the role during pre-migration. After hand-off, `ETHRegistrar` holds it to handle live new registrations.
+- `ROLE_REGISTER_RESERVED` is checked by the same `register()` entry point when the entry is currently **reserved** (owner zero, not expired) and an actual owner is being set. This is the promotion path the migration controllers use to flip a pre-seeded reserved name into a registered name owned by its ENSv1 claimant — hence both controllers receive it here.
+- `ROLE_RENEW` gates `PermissionedRegistry.renew()`. During pre-migration `BatchRegistrar` uses it to bump expiries on reserved names; afterwards the live renewal path runs through `ETHRegistrar.renew()` (see `src/registrar/ETHRegistrar.sol`), so the role moves from `BatchRegistrar` to `ETHRegistrar`.
 
 ## Prerequisites
 

--- a/contracts/docs/prepareMigration.md
+++ b/contracts/docs/prepareMigration.md
@@ -1,0 +1,124 @@
+# ENS Prepare-Migration Script
+
+## Overview
+
+The prepare-migration script (`contracts/script/prepareMigration.ts`) rewires role grants on the `.eth` `PermissionedRegistry` to flip the registry from its **seeding** configuration (only `BatchRegistrar` can register names) to its **live** configuration (`ETHRegistrar` handles new registrations; `UnlockedMigrationController` and `LockedMigrationController` promote reserved names to registered as ENSv1 owners migrate in).
+
+Run this once, after all pre-migration seeding via [`preMigration.ts`](./premigration.md) has completed and before opening registration traffic to users. The script is idempotent at the role level — re-running it against a registry that is already in the live configuration will show every planned op as already satisfied and simply broadcast the same grants/revokes again.
+
+## Role changes
+
+The script performs exactly four root-level role operations on the target registry:
+
+| Target | Op | Roles |
+|---|---|---|
+| `BatchRegistrar` | **REVOKE** | `ROLE_REGISTRAR` · `ROLE_REGISTRAR_ADMIN` · `ROLE_REGISTER_RESERVED` · `ROLE_REGISTER_RESERVED_ADMIN` |
+| `ETHRegistrar` | **GRANT** | `ROLE_REGISTRAR` |
+| `UnlockedMigrationController` | **GRANT** | `ROLE_REGISTER_RESERVED` |
+| `LockedMigrationController` | **GRANT** | `ROLE_REGISTER_RESERVED` |
+
+For background on these roles and the EAC admin/base pairing used by registry contracts, see the [EAC section of the contracts README](../README.md#access-control) and [`RegistryRolesLib.sol`](../src/registry/libraries/RegistryRolesLib.sol).
+
+## Prerequisites
+
+- **Bun** runtime installed
+- **Forge artifacts** compiled (`forge build` in `contracts/`) — the script loads the `PermissionedRegistry` ABI from `contracts/out/`
+- **Deployed contracts:**
+  - `PermissionedRegistry` (the `.eth` registry)
+  - `BatchRegistrar` — currently holding the seeding roles
+  - `ETHRegistrar` — will receive `ROLE_REGISTRAR`
+  - `UnlockedMigrationController` — will receive `ROLE_REGISTER_RESERVED`
+  - `LockedMigrationController` — will receive `ROLE_REGISTER_RESERVED`
+- **Signer** holding the admin-role counterparts for every role being moved. In practice this means holding `ROLE_REGISTRAR_ADMIN` and `ROLE_REGISTER_RESERVED_ADMIN` at the registry root. The script runs a pre-flight check against the signer's root roles and aborts with a clear error if any required admin bits are missing — no transactions are broadcast.
+- **RPC endpoint** for the chain the registry is deployed on. The chain ID is auto-detected from the RPC.
+
+`--execute` additionally requires `--private-key`; without it the script stays in dry-run mode.
+
+## CLI Reference
+
+Run from the `contracts/` directory:
+
+```bash
+bun run script/prepareMigration.ts [options]
+```
+
+### Required Options
+
+| Option | Description |
+|---|---|
+| `--rpc-url <url>` | JSON-RPC endpoint for the target chain |
+| `--registry <address>` | `.eth` `PermissionedRegistry` address |
+| `--batch-registrar <address>` | `BatchRegistrar` address (roles revoked from this target) |
+| `--eth-registrar <address>` | `ETHRegistrar` address (receives `ROLE_REGISTRAR`) |
+| `--unlocked-migration-controller <address>` | `UnlockedMigrationController` address (receives `ROLE_REGISTER_RESERVED`) |
+| `--locked-migration-controller <address>` | `LockedMigrationController` address (receives `ROLE_REGISTER_RESERVED`) |
+
+### Optional
+
+| Option | Default | Description |
+|---|---|---|
+| `--private-key <hex>` | — | Signer private key. Required when `--execute` is passed; enables the admin-role pre-flight check when running dry. |
+| `--execute` | `false` | Broadcast transactions. Without this flag the script performs a dry run and never sends anything on-chain. |
+
+## How It Works
+
+1. **Parse CLI options** and build viem clients via `createV2Clients` in `scriptUtils.ts`. When no private key is supplied the script runs with a read-only public client.
+2. **Load the `PermissionedRegistry` ABI** from the forge artifact under `contracts/out/`.
+3. **Build the op list** — the fixed four-entry sequence shown in the [Role changes](#role-changes) table.
+4. **Preview each op.** For every target the script reads the current root-role bitmap from the registry and prints it next to the planned change, so the diff is visible before anything is broadcast.
+5. **Signer admin-role pre-flight** (when a signer is configured). The script computes the admin bits required for each planned grant/revoke and checks the signer's root roles on the registry. Any missing admin bit aborts the run with a description of which op needs which missing admin role.
+6. **Dry-run exit.** If `--execute` is not set (or no wallet client is available) the script stops here after printing a "Dry run complete" summary.
+7. **Execute.** If `--execute` is set, the script submits `grantRootRoles` / `revokeRootRoles` transactions sequentially, waiting for each receipt before moving on. After the last op it re-reads the role bitmap for every target and prints the final state.
+
+## Dry Run vs. Execute
+
+**Dry run is the default.** Running without `--execute` always produces the full preview — planned operations, the current on-chain state for every target, and (if a signer is supplied) the admin pre-flight result. No transactions are broadcast.
+
+Passing `--execute` along with `--private-key` broadcasts the role changes. Transactions run **sequentially, one per op**, so an interruption part-way through leaves the registry in a partially-applied state. Re-running the script with `--execute` is safe: ops that have already been applied simply re-issue the same grant/revoke, and the preview will show the current state matching the desired state before each re-broadcast.
+
+## Examples
+
+### Dry run without a signer
+
+Prints planned ops and current on-chain state for each target. No admin pre-flight (nothing to check against).
+
+```bash
+bun run script/prepareMigration.ts \
+  --rpc-url https://v2-rpc.example.com \
+  --registry 0x1234...abcd \
+  --batch-registrar 0x5678...ef01 \
+  --eth-registrar 0xaaaa...1111 \
+  --unlocked-migration-controller 0xbbbb...2222 \
+  --locked-migration-controller 0xcccc...3333
+```
+
+### Dry run with a signer (admin pre-flight)
+
+Same preview, plus the pre-flight check that the signer holds every admin bit the execute phase would need.
+
+```bash
+bun run script/prepareMigration.ts \
+  --rpc-url https://v2-rpc.example.com \
+  --registry 0x1234...abcd \
+  --batch-registrar 0x5678...ef01 \
+  --eth-registrar 0xaaaa...1111 \
+  --unlocked-migration-controller 0xbbbb...2222 \
+  --locked-migration-controller 0xcccc...3333 \
+  --private-key 0xabc...def
+```
+
+### Execute
+
+Broadcasts the full role swap. Prints the final on-chain role state for every target on completion.
+
+```bash
+bun run script/prepareMigration.ts \
+  --rpc-url https://v2-rpc.example.com \
+  --registry 0x1234...abcd \
+  --batch-registrar 0x5678...ef01 \
+  --eth-registrar 0xaaaa...1111 \
+  --unlocked-migration-controller 0xbbbb...2222 \
+  --locked-migration-controller 0xcccc...3333 \
+  --private-key 0xabc...def \
+  --execute
+```

--- a/contracts/script/deploy-constants.ts
+++ b/contracts/script/deploy-constants.ts
@@ -84,6 +84,9 @@ export const DEPLOYMENT_ROLES = {
     ROLES.REGISTRY.SET_PARENT |
     ROLES.ADMIN.REGISTRY.SET_PARENT |
     ROLES.ADMIN.REGISTRY.RENEW,
+  // ETHRegistrar and BatchRegistrar are granted REGISTRAR and RENEW at the
+  // ETHRegistry root at static deploy.
+  ETH_REGISTRAR_ROOT: ROLES.REGISTRY.REGISTRAR | ROLES.REGISTRY.RENEW,
   // UnlockedMigrationController and LockedMigrationController
   // only need to register() pre-migrated reservations on ETHRegistry (see: "ENSv2 Migration Case Study")
   MIGRATION_CONTROLLER_ROOT: ROLES.REGISTRY.REGISTER_RESERVED,

--- a/contracts/script/preMigration.ts
+++ b/contracts/script/preMigration.ts
@@ -7,11 +7,9 @@ import {
   readFileSync,
   writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
 import {
   createPublicClient,
   createWalletClient,
-  defineChain,
   getContract,
   http,
   keccak256,
@@ -19,7 +17,6 @@ import {
   toHex,
   zeroAddress,
   type Address,
-  type Chain,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { mainnet } from "viem/chains";
@@ -36,15 +33,7 @@ import {
   yellow,
 } from "./logger.js";
 
-// Load ABI from forge compilation artifacts
-function loadArtifact(contractName: string): { abi: any[] } {
-  const artifactPath = join(
-    import.meta.dirname,
-    `../out/${contractName}.sol/${contractName}.json`,
-  );
-  const artifact = JSON.parse(readFileSync(artifactPath, "utf-8"));
-  return { abi: artifact.abi };
-}
+import { loadArtifact, resolveChain } from "./scriptUtils.js";
 
 // ABI fragments for v1 BaseRegistrar
 const BASE_REGISTRAR_ABI = [
@@ -467,20 +456,7 @@ interface MigrationClients {
 async function createMigrationClients(
   config: PreMigrationConfig,
 ): Promise<MigrationClients> {
-  const tempClient = createPublicClient({
-    transport: http(config.rpcUrl, { retryCount: 0, timeout: RPC_TIMEOUT_MS }),
-  });
-  const chainId = await tempClient.getChainId();
-
-  const v2Chain: Chain =
-    chainId === 1
-      ? mainnet
-      : defineChain({
-          id: chainId,
-          name: "Custom",
-          nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
-          rpcUrls: { default: { http: [config.rpcUrl] } },
-        });
+  const v2Chain = await resolveChain(config.rpcUrl, RPC_TIMEOUT_MS);
 
   const client = createWalletClient({
     account: privateKeyToAccount(config.privateKey),

--- a/contracts/script/prepareMigration.ts
+++ b/contracts/script/prepareMigration.ts
@@ -16,12 +16,16 @@ const ROLE_REGISTRAR = 1n << 0n;
 const ROLE_REGISTRAR_ADMIN = 1n << 128n;
 const ROLE_REGISTER_RESERVED = 1n << 4n;
 const ROLE_REGISTER_RESERVED_ADMIN = 1n << 132n;
+const ROLE_RENEW = 1n << 16n;
+const ROLE_RENEW_ADMIN = 1n << 144n;
 
 const ROLE_NAMES: Array<[bigint, string]> = [
   [ROLE_REGISTRAR, "ROLE_REGISTRAR"],
   [ROLE_REGISTRAR_ADMIN, "ROLE_REGISTRAR_ADMIN"],
   [ROLE_REGISTER_RESERVED, "ROLE_REGISTER_RESERVED"],
   [ROLE_REGISTER_RESERVED_ADMIN, "ROLE_REGISTER_RESERVED_ADMIN"],
+  [ROLE_RENEW, "ROLE_RENEW"],
+  [ROLE_RENEW_ADMIN, "ROLE_RENEW_ADMIN"],
 ];
 
 function describeRoles(bitmap: bigint): string {
@@ -57,7 +61,7 @@ function parseArgs(argv: string[]): Config {
   const program = new Command()
     .name("prepareMigration")
     .description(
-      "Prepare .eth PermissionedRegistry for live migration: revoke BatchRegistrar's seeding roles and grant registration roles to ETHRegistrar and both migration controllers.",
+      "Prepare .eth PermissionedRegistry for live migration: fully decommission BatchRegistrar (revoke all its roles) and grant registration and renewal roles to ETHRegistrar plus the reservation-promotion role to both migration controllers.",
     )
     .requiredOption("--rpc-url <url>", "JSON-RPC endpoint")
     .requiredOption("--registry <address>", ".eth PermissionedRegistry address")
@@ -114,13 +118,15 @@ function buildOps(cfg: Config): Op[] {
         ROLE_REGISTRAR |
         ROLE_REGISTRAR_ADMIN |
         ROLE_REGISTER_RESERVED |
-        ROLE_REGISTER_RESERVED_ADMIN,
+        ROLE_REGISTER_RESERVED_ADMIN |
+        ROLE_RENEW |
+        ROLE_RENEW_ADMIN,
     },
     {
       kind: "grant",
       label: "ETHRegistrar",
       account: cfg.ethRegistrarAddress,
-      roles: ROLE_REGISTRAR,
+      roles: ROLE_REGISTRAR | ROLE_RENEW,
     },
     {
       kind: "grant",

--- a/contracts/script/prepareMigration.ts
+++ b/contracts/script/prepareMigration.ts
@@ -1,0 +1,245 @@
+#!/usr/bin/env bun
+
+import { Command } from "commander";
+import { getContract, isAddress, type Address, type Hex } from "viem";
+import { waitForSuccessfulTransactionReceipt } from "../test/utils/waitForSuccessfulTransactionReceipt.js";
+import { bold, cyan, dim, green, Logger, red, yellow } from "./logger.js";
+import { createV2Clients, loadArtifact } from "./scriptUtils.js";
+
+class PrepareLogger extends Logger {
+  line(msg: string): void {
+    this.raw(msg);
+  }
+}
+
+const ROLE_REGISTRAR = 1n << 0n;
+const ROLE_REGISTRAR_ADMIN = 1n << 128n;
+const ROLE_REGISTER_RESERVED = 1n << 4n;
+const ROLE_REGISTER_RESERVED_ADMIN = 1n << 132n;
+
+const ROLE_NAMES: Array<[bigint, string]> = [
+  [ROLE_REGISTRAR, "ROLE_REGISTRAR"],
+  [ROLE_REGISTRAR_ADMIN, "ROLE_REGISTRAR_ADMIN"],
+  [ROLE_REGISTER_RESERVED, "ROLE_REGISTER_RESERVED"],
+  [ROLE_REGISTER_RESERVED_ADMIN, "ROLE_REGISTER_RESERVED_ADMIN"],
+];
+
+function describeRoles(bitmap: bigint): string {
+  const matched = ROLE_NAMES.filter(([bit]) => (bitmap & bit) === bit).map(
+    ([, name]) => name,
+  );
+  return matched.length ? matched.join(" | ") : "(none)";
+}
+
+type Op =
+  | { kind: "grant"; label: string; account: Address; roles: bigint }
+  | { kind: "revoke"; label: string; account: Address; roles: bigint };
+
+interface Config {
+  rpcUrl: string;
+  registryAddress: Address;
+  batchRegistrarAddress: Address;
+  ethRegistrarAddress: Address;
+  unlockedMigrationControllerAddress: Address;
+  lockedMigrationControllerAddress: Address;
+  privateKey: Hex | null;
+  execute: boolean;
+}
+
+function requireAddress(value: string | undefined, flag: string): Address {
+  if (!value || !isAddress(value)) {
+    throw new Error(`${flag} must be a valid 0x-prefixed address`);
+  }
+  return value as Address;
+}
+
+function parseArgs(argv: string[]): Config {
+  const program = new Command()
+    .name("prepareMigration")
+    .description(
+      "Prepare .eth PermissionedRegistry for live migration: revoke BatchRegistrar's seeding roles and grant registration roles to ETHRegistrar and both migration controllers.",
+    )
+    .requiredOption("--rpc-url <url>", "JSON-RPC endpoint")
+    .requiredOption("--registry <address>", ".eth PermissionedRegistry address")
+    .requiredOption("--batch-registrar <address>", "BatchRegistrar address")
+    .requiredOption("--eth-registrar <address>", "ETHRegistrar address")
+    .requiredOption(
+      "--unlocked-migration-controller <address>",
+      "UnlockedMigrationController address",
+    )
+    .requiredOption(
+      "--locked-migration-controller <address>",
+      "LockedMigrationController address",
+    )
+    .option("--private-key <hex>", "signer private key (required with --execute)")
+    .option("--execute", "broadcast transactions (default: dry run)", false)
+    .parse(argv);
+
+  const opts = program.opts();
+  const privateKey = opts.privateKey
+    ? ((opts.privateKey.startsWith("0x")
+        ? opts.privateKey
+        : `0x${opts.privateKey}`) as Hex)
+    : null;
+
+  if (opts.execute && !privateKey) {
+    throw new Error("--execute requires --private-key");
+  }
+
+  return {
+    rpcUrl: opts.rpcUrl,
+    registryAddress: requireAddress(opts.registry, "--registry"),
+    batchRegistrarAddress: requireAddress(opts.batchRegistrar, "--batch-registrar"),
+    ethRegistrarAddress: requireAddress(opts.ethRegistrar, "--eth-registrar"),
+    unlockedMigrationControllerAddress: requireAddress(
+      opts.unlockedMigrationController,
+      "--unlocked-migration-controller",
+    ),
+    lockedMigrationControllerAddress: requireAddress(
+      opts.lockedMigrationController,
+      "--locked-migration-controller",
+    ),
+    privateKey,
+    execute: !!opts.execute,
+  };
+}
+
+function buildOps(cfg: Config): Op[] {
+  return [
+    {
+      kind: "revoke",
+      label: "BatchRegistrar",
+      account: cfg.batchRegistrarAddress,
+      roles:
+        ROLE_REGISTRAR |
+        ROLE_REGISTRAR_ADMIN |
+        ROLE_REGISTER_RESERVED |
+        ROLE_REGISTER_RESERVED_ADMIN,
+    },
+    {
+      kind: "grant",
+      label: "ETHRegistrar",
+      account: cfg.ethRegistrarAddress,
+      roles: ROLE_REGISTRAR,
+    },
+    {
+      kind: "grant",
+      label: "UnlockedMigrationController",
+      account: cfg.unlockedMigrationControllerAddress,
+      roles: ROLE_REGISTER_RESERVED,
+    },
+    {
+      kind: "grant",
+      label: "LockedMigrationController",
+      account: cfg.lockedMigrationControllerAddress,
+      roles: ROLE_REGISTER_RESERVED,
+    },
+  ];
+}
+
+// Admin bits needed to grant/revoke a given role bitmap: each low-128 role bit
+// requires its paired admin bit at (bit << 128); admin bits are self-admin.
+function requiredAdminBits(roles: bigint): bigint {
+  const LOW_MASK = (1n << 128n) - 1n;
+  const low = roles & LOW_MASK;
+  const high = roles & ~LOW_MASK;
+  return (low << 128n) | high;
+}
+
+export async function main(argv: string[] = process.argv): Promise<void> {
+  const cfg = parseArgs(argv);
+  const logger = new PrepareLogger();
+
+  const { abi: registryAbi } = loadArtifact("PermissionedRegistry");
+  const { publicClient, walletClient, account } = await createV2Clients({
+    rpcUrl: cfg.rpcUrl,
+    privateKey: cfg.privateKey,
+  });
+
+  const registryRead = getContract({
+    abi: registryAbi,
+    address: cfg.registryAddress,
+    client: publicClient,
+  });
+  const registryWrite = walletClient
+    ? getContract({
+        abi: registryAbi,
+        address: cfg.registryAddress,
+        client: walletClient,
+      })
+    : null;
+
+  const ops = buildOps(cfg);
+
+  logger.header("Prepare-Migration");
+  logger.config("RPC", cfg.rpcUrl);
+  logger.config("Registry", cfg.registryAddress);
+  logger.config("Signer", account?.address ?? "(none — dry run)");
+  logger.config("Mode", cfg.execute ? "EXECUTE" : "DRY RUN");
+
+  logger.header("Planned operations");
+  for (const op of ops) {
+    const current = (await registryRead.read.roles([0n, op.account])) as bigint;
+    logger.line(
+      `${op.kind === "grant" ? green("+ GRANT ") : red("- REVOKE")} ${bold(op.label)} ${dim(op.account)}`,
+    );
+    logger.line(`    roles: ${describeRoles(op.roles)}`);
+    logger.line(dim(`    current on-chain: ${describeRoles(current)}`));
+  }
+
+  if (account) {
+    logger.header("Signer admin-role pre-flight");
+    const signerRoles = (await registryRead.read.roles([
+      0n,
+      account.address,
+    ])) as bigint;
+    logger.line(dim(`    signer root roles: ${describeRoles(signerRoles)}`));
+    let missing = 0n;
+    for (const op of ops) {
+      const lacks = requiredAdminBits(op.roles) & ~signerRoles;
+      if (lacks !== 0n) {
+        logger.error(
+          `signer missing admin bits for ${op.label} ${op.kind}: ${describeRoles(lacks)}`,
+        );
+        missing |= lacks;
+      }
+    }
+    if (missing !== 0n) {
+      throw new Error("signer lacks required admin roles; aborting");
+    }
+    logger.success("signer holds all required admin roles");
+  }
+
+  if (!cfg.execute || !registryWrite) {
+    logger.header("Dry run complete");
+    logger.line(yellow("no transactions broadcast; pass --execute to proceed"));
+    return;
+  }
+
+  logger.header("Executing");
+  for (const op of ops) {
+    logger.line(
+      cyan(`→ ${op.kind.toUpperCase()} ${op.label} ${dim(op.account)}`),
+    );
+    const fn = op.kind === "grant" ? "grantRootRoles" : "revokeRootRoles";
+    const hash = await (registryWrite.write as any)[fn]([op.roles, op.account]);
+    logger.line(dim(`    tx: ${hash}`));
+    await waitForSuccessfulTransactionReceipt(publicClient, { hash });
+    logger.success(`${op.label} ${op.kind} confirmed`);
+  }
+
+  logger.header("Final state");
+  for (const op of ops) {
+    const after = (await registryRead.read.roles([0n, op.account])) as bigint;
+    logger.line(`${bold(op.label)} ${dim(op.account)}`);
+    logger.line(dim(`    roles: ${describeRoles(after)}`));
+  }
+  logger.success("prepare-migration complete");
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/contracts/script/prepareMigration.ts
+++ b/contracts/script/prepareMigration.ts
@@ -3,6 +3,7 @@
 import { Command } from "commander";
 import { getContract, isAddress, type Address, type Hex } from "viem";
 import { waitForSuccessfulTransactionReceipt } from "../test/utils/waitForSuccessfulTransactionReceipt.js";
+import { DEPLOYMENT_ROLES, ROLES } from "./deploy-constants.js";
 import { bold, cyan, dim, green, Logger, red, yellow } from "./logger.js";
 import { createV2Clients, loadArtifact } from "./scriptUtils.js";
 
@@ -12,20 +13,13 @@ class PrepareLogger extends Logger {
   }
 }
 
-const ROLE_REGISTRAR = 1n << 0n;
-const ROLE_REGISTRAR_ADMIN = 1n << 128n;
-const ROLE_REGISTER_RESERVED = 1n << 4n;
-const ROLE_REGISTER_RESERVED_ADMIN = 1n << 132n;
-const ROLE_RENEW = 1n << 16n;
-const ROLE_RENEW_ADMIN = 1n << 144n;
-
 const ROLE_NAMES: Array<[bigint, string]> = [
-  [ROLE_REGISTRAR, "ROLE_REGISTRAR"],
-  [ROLE_REGISTRAR_ADMIN, "ROLE_REGISTRAR_ADMIN"],
-  [ROLE_REGISTER_RESERVED, "ROLE_REGISTER_RESERVED"],
-  [ROLE_REGISTER_RESERVED_ADMIN, "ROLE_REGISTER_RESERVED_ADMIN"],
-  [ROLE_RENEW, "ROLE_RENEW"],
-  [ROLE_RENEW_ADMIN, "ROLE_RENEW_ADMIN"],
+  [ROLES.REGISTRY.REGISTRAR, "ROLE_REGISTRAR"],
+  [ROLES.ADMIN.REGISTRY.REGISTRAR, "ROLE_REGISTRAR_ADMIN"],
+  [ROLES.REGISTRY.REGISTER_RESERVED, "ROLE_REGISTER_RESERVED"],
+  [ROLES.ADMIN.REGISTRY.REGISTER_RESERVED, "ROLE_REGISTER_RESERVED_ADMIN"],
+  [ROLES.REGISTRY.RENEW, "ROLE_RENEW"],
+  [ROLES.ADMIN.REGISTRY.RENEW, "ROLE_RENEW_ADMIN"],
 ];
 
 function describeRoles(bitmap: bigint): string {
@@ -114,31 +108,32 @@ function buildOps(cfg: Config): Op[] {
       kind: "revoke",
       label: "BatchRegistrar",
       account: cfg.batchRegistrarAddress,
+      // Revoke every bit granted at static deploy plus admin counterparts and
+      // REGISTER_RESERVED pair so the post-state is unambiguously empty.
       roles:
-        ROLE_REGISTRAR |
-        ROLE_REGISTRAR_ADMIN |
-        ROLE_REGISTER_RESERVED |
-        ROLE_REGISTER_RESERVED_ADMIN |
-        ROLE_RENEW |
-        ROLE_RENEW_ADMIN,
+        DEPLOYMENT_ROLES.ETH_REGISTRAR_ROOT |
+        ROLES.ADMIN.REGISTRY.REGISTRAR |
+        ROLES.ADMIN.REGISTRY.RENEW |
+        DEPLOYMENT_ROLES.MIGRATION_CONTROLLER_ROOT |
+        ROLES.ADMIN.REGISTRY.REGISTER_RESERVED,
     },
     {
       kind: "grant",
       label: "ETHRegistrar",
       account: cfg.ethRegistrarAddress,
-      roles: ROLE_REGISTRAR | ROLE_RENEW,
+      roles: DEPLOYMENT_ROLES.ETH_REGISTRAR_ROOT,
     },
     {
       kind: "grant",
       label: "UnlockedMigrationController",
       account: cfg.unlockedMigrationControllerAddress,
-      roles: ROLE_REGISTER_RESERVED,
+      roles: DEPLOYMENT_ROLES.MIGRATION_CONTROLLER_ROOT,
     },
     {
       kind: "grant",
       label: "LockedMigrationController",
       account: cfg.lockedMigrationControllerAddress,
-      roles: ROLE_REGISTER_RESERVED,
+      roles: DEPLOYMENT_ROLES.MIGRATION_CONTROLLER_ROOT,
     },
   ];
 }

--- a/contracts/script/scriptUtils.ts
+++ b/contracts/script/scriptUtils.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  createPublicClient,
+  createWalletClient,
+  defineChain,
+  http,
+  publicActions,
+  type Chain,
+  type Hex,
+  type PublicClient,
+} from "viem";
+import { privateKeyToAccount, type PrivateKeyAccount } from "viem/accounts";
+import { mainnet } from "viem/chains";
+
+export const DEFAULT_RPC_TIMEOUT_MS = 30_000;
+
+/// Load an ABI from the forge compilation artifact under `contracts/out/`.
+export function loadArtifact(contractName: string): { abi: any[] } {
+  const artifactPath = join(
+    import.meta.dirname,
+    `../out/${contractName}.sol/${contractName}.json`,
+  );
+  const artifact = JSON.parse(readFileSync(artifactPath, "utf-8"));
+  return { abi: artifact.abi };
+}
+
+/// Resolve the viem Chain for a given RPC endpoint: mainnet if chainId===1,
+/// otherwise a synthesized custom chain wrapping the provided RPC URL.
+export async function resolveChain(
+  rpcUrl: string,
+  timeoutMs = DEFAULT_RPC_TIMEOUT_MS,
+): Promise<Chain> {
+  const probe = createPublicClient({
+    transport: http(rpcUrl, { retryCount: 0, timeout: timeoutMs }),
+  });
+  const chainId = await probe.getChainId();
+  if (chainId === 1) return mainnet;
+  return defineChain({
+    id: chainId,
+    name: "Custom",
+    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    rpcUrls: { default: { http: [rpcUrl] } },
+  });
+}
+
+export interface V2ClientBundle {
+  chain: Chain;
+  account: PrivateKeyAccount | null;
+  publicClient: PublicClient;
+  // When `privateKey` is supplied this is a wallet client extended with
+  // public actions (so it can be used for reads as well as writes).
+  walletClient: ReturnType<typeof createWalletClient> | null;
+}
+
+/// Build viem clients for the target v2 chain. When `privateKey` is absent,
+/// only a read-only `publicClient` is returned — suitable for dry-run flows.
+export async function createV2Clients(opts: {
+  rpcUrl: string;
+  privateKey?: Hex | null;
+  timeoutMs?: number;
+}): Promise<V2ClientBundle> {
+  const timeout = opts.timeoutMs ?? DEFAULT_RPC_TIMEOUT_MS;
+  const chain = await resolveChain(opts.rpcUrl, timeout);
+  const transport = http(opts.rpcUrl, { retryCount: 0, timeout });
+
+  const publicClient = createPublicClient({ chain, transport });
+
+  if (!opts.privateKey) {
+    return { chain, account: null, publicClient, walletClient: null };
+  }
+
+  const account = privateKeyToAccount(opts.privateKey);
+  const walletClient = createWalletClient({
+    account,
+    chain,
+    transport,
+  }).extend(publicActions);
+
+  return { chain, account, publicClient, walletClient };
+}

--- a/contracts/test/e2e/prepareMigration.test.ts
+++ b/contracts/test/e2e/prepareMigration.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, setDefaultTimeout } from "bun:test";
+setDefaultTimeout(60_000);
+
+import type { Address } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { main } from "../../script/prepareMigration.js";
+import { revertPrePrepareMigrationRoles } from "../utils/mockPrepareMigration.js";
+
+const DEPLOYER_PRIVATE_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as const;
+
+const ROLE_REGISTRAR = 1n << 0n;
+const ROLE_REGISTRAR_ADMIN = 1n << 128n;
+const ROLE_REGISTER_RESERVED = 1n << 4n;
+const ROLE_REGISTER_RESERVED_ADMIN = 1n << 132n;
+
+describe("PrepareMigration", () => {
+  const { env, setupEnv } = process.env.TEST_GLOBALS!;
+
+  setupEnv({
+    resetOnEach: true,
+    async initialize() {
+      await revertPrePrepareMigrationRoles(env);
+    },
+  });
+
+  function getAddresses() {
+    return {
+      rpcUrl: `http://${env.hostPort}`,
+      registry: env.v2.ETHRegistry.address,
+      batchRegistrar: env.rocketh.get("BatchRegistrar").address as Address,
+      ethRegistrar: env.v2.ETHRegistrar.address,
+      unlocked: env.v2.UnlockedMigrationController.address,
+      locked: env.v2.LockedMigrationController.address,
+    };
+  }
+
+  function buildArgs(
+    addrs: ReturnType<typeof getAddresses>,
+    overrides: { privateKey?: string | null; execute?: boolean } = {},
+  ): string[] {
+    const args = [
+      "node",
+      "prepareMigration",
+      "--rpc-url",
+      addrs.rpcUrl,
+      "--registry",
+      addrs.registry,
+      "--batch-registrar",
+      addrs.batchRegistrar,
+      "--eth-registrar",
+      addrs.ethRegistrar,
+      "--unlocked-migration-controller",
+      addrs.unlocked,
+      "--locked-migration-controller",
+      addrs.locked,
+    ];
+    const pk =
+      overrides.privateKey === undefined
+        ? DEPLOYER_PRIVATE_KEY
+        : overrides.privateKey;
+    if (pk !== null) args.push("--private-key", pk);
+    if (overrides.execute) args.push("--execute");
+    return args;
+  }
+
+  async function readRoles(account: Address): Promise<bigint> {
+    return (await env.v2.ETHRegistry.read.roles([0n, account])) as bigint;
+  }
+
+  it("devnet starts in pre-prepareMigration state", async () => {
+    const addrs = getAddresses();
+
+    expect((await readRoles(addrs.batchRegistrar)) & ROLE_REGISTRAR).toBe(
+      ROLE_REGISTRAR,
+    );
+    expect((await readRoles(addrs.ethRegistrar)) & ROLE_REGISTRAR).toBe(0n);
+    expect((await readRoles(addrs.unlocked)) & ROLE_REGISTER_RESERVED).toBe(0n);
+    expect((await readRoles(addrs.locked)) & ROLE_REGISTER_RESERVED).toBe(0n);
+  });
+
+  it("dry run does not mutate on-chain role state", async () => {
+    const addrs = getAddresses();
+
+    const before = {
+      batch: await readRoles(addrs.batchRegistrar),
+      eth: await readRoles(addrs.ethRegistrar),
+      unlocked: await readRoles(addrs.unlocked),
+      locked: await readRoles(addrs.locked),
+    };
+
+    await main(buildArgs(addrs));
+
+    expect(await readRoles(addrs.batchRegistrar)).toBe(before.batch);
+    expect(await readRoles(addrs.ethRegistrar)).toBe(before.eth);
+    expect(await readRoles(addrs.unlocked)).toBe(before.unlocked);
+    expect(await readRoles(addrs.locked)).toBe(before.locked);
+  });
+
+  it("execute revokes BatchRegistrar registrar roles and grants controller roles", async () => {
+    const addrs = getAddresses();
+
+    const batchBefore = await readRoles(addrs.batchRegistrar);
+    expect(batchBefore & ROLE_REGISTRAR).toBe(ROLE_REGISTRAR);
+
+    await main(buildArgs(addrs, { execute: true }));
+
+    const batchAfter = await readRoles(addrs.batchRegistrar);
+    expect(batchAfter & ROLE_REGISTRAR).toBe(0n);
+    expect(batchAfter & ROLE_REGISTRAR_ADMIN).toBe(0n);
+    expect(batchAfter & ROLE_REGISTER_RESERVED).toBe(0n);
+    expect(batchAfter & ROLE_REGISTER_RESERVED_ADMIN).toBe(0n);
+
+    expect((await readRoles(addrs.ethRegistrar)) & ROLE_REGISTRAR).toBe(
+      ROLE_REGISTRAR,
+    );
+    expect((await readRoles(addrs.unlocked)) & ROLE_REGISTER_RESERVED).toBe(
+      ROLE_REGISTER_RESERVED,
+    );
+    expect((await readRoles(addrs.locked)) & ROLE_REGISTER_RESERVED).toBe(
+      ROLE_REGISTER_RESERVED,
+    );
+  });
+
+  it("execute preserves unrelated roles on BatchRegistrar", async () => {
+    const addrs = getAddresses();
+    const batchBefore = await readRoles(addrs.batchRegistrar);
+    const ROLE_RENEW = 1n << 16n;
+    expect(batchBefore & ROLE_RENEW).toBe(ROLE_RENEW);
+
+    await main(buildArgs(addrs, { execute: true }));
+
+    const batchAfter = await readRoles(addrs.batchRegistrar);
+    expect(batchAfter & ROLE_RENEW).toBe(ROLE_RENEW);
+  });
+
+  it("is idempotent on repeated execute", async () => {
+    const addrs = getAddresses();
+
+    await main(buildArgs(addrs, { execute: true }));
+    const snapshot = {
+      batch: await readRoles(addrs.batchRegistrar),
+      eth: await readRoles(addrs.ethRegistrar),
+      unlocked: await readRoles(addrs.unlocked),
+      locked: await readRoles(addrs.locked),
+    };
+
+    await main(buildArgs(addrs, { execute: true }));
+
+    expect(await readRoles(addrs.batchRegistrar)).toBe(snapshot.batch);
+    expect(await readRoles(addrs.ethRegistrar)).toBe(snapshot.eth);
+    expect(await readRoles(addrs.unlocked)).toBe(snapshot.unlocked);
+    expect(await readRoles(addrs.locked)).toBe(snapshot.locked);
+  });
+
+  it("aborts when signer lacks required admin roles", async () => {
+    const addrs = getAddresses();
+    // user account is funded but has no root admin roles on ETHRegistry
+    const userPk =
+      "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" as const;
+    const userAddr = privateKeyToAccount(userPk).address;
+    expect(await readRoles(userAddr)).toBe(0n);
+
+    await expect(
+      main(buildArgs(addrs, { privateKey: userPk, execute: true })),
+    ).rejects.toThrow(/admin roles/);
+
+    // state untouched
+    expect(
+      (await readRoles(addrs.batchRegistrar)) & ROLE_REGISTRAR,
+    ).toBe(ROLE_REGISTRAR);
+  });
+
+  it("rejects --execute without --private-key", async () => {
+    const addrs = getAddresses();
+    await expect(
+      main(buildArgs(addrs, { privateKey: null, execute: true })),
+    ).rejects.toThrow(/--execute requires --private-key/);
+  });
+});

--- a/contracts/test/e2e/prepareMigration.test.ts
+++ b/contracts/test/e2e/prepareMigration.test.ts
@@ -3,18 +3,19 @@ setDefaultTimeout(60_000);
 
 import type { Address } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
+import { ROLES } from "../../script/deploy-constants.js";
 import { main } from "../../script/prepareMigration.js";
 import { revertPrePrepareMigrationRoles } from "../utils/mockPrepareMigration.js";
 
 const DEPLOYER_PRIVATE_KEY =
   "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as const;
 
-const ROLE_REGISTRAR = 1n << 0n;
-const ROLE_REGISTRAR_ADMIN = 1n << 128n;
-const ROLE_REGISTER_RESERVED = 1n << 4n;
-const ROLE_REGISTER_RESERVED_ADMIN = 1n << 132n;
-const ROLE_RENEW = 1n << 16n;
-const ROLE_RENEW_ADMIN = 1n << 144n;
+const ROLE_REGISTRAR = ROLES.REGISTRY.REGISTRAR;
+const ROLE_REGISTRAR_ADMIN = ROLES.ADMIN.REGISTRY.REGISTRAR;
+const ROLE_REGISTER_RESERVED = ROLES.REGISTRY.REGISTER_RESERVED;
+const ROLE_REGISTER_RESERVED_ADMIN = ROLES.ADMIN.REGISTRY.REGISTER_RESERVED;
+const ROLE_RENEW = ROLES.REGISTRY.RENEW;
+const ROLE_RENEW_ADMIN = ROLES.ADMIN.REGISTRY.RENEW;
 
 describe("PrepareMigration", () => {
   const { env, setupEnv } = process.env.TEST_GLOBALS!;

--- a/contracts/test/e2e/prepareMigration.test.ts
+++ b/contracts/test/e2e/prepareMigration.test.ts
@@ -13,6 +13,8 @@ const ROLE_REGISTRAR = 1n << 0n;
 const ROLE_REGISTRAR_ADMIN = 1n << 128n;
 const ROLE_REGISTER_RESERVED = 1n << 4n;
 const ROLE_REGISTER_RESERVED_ADMIN = 1n << 132n;
+const ROLE_RENEW = 1n << 16n;
+const ROLE_RENEW_ADMIN = 1n << 144n;
 
 describe("PrepareMigration", () => {
   const { env, setupEnv } = process.env.TEST_GLOBALS!;
@@ -97,11 +99,12 @@ describe("PrepareMigration", () => {
     expect(await readRoles(addrs.locked)).toBe(before.locked);
   });
 
-  it("execute revokes BatchRegistrar registrar roles and grants controller roles", async () => {
+  it("execute strips all migration-relevant roles from BatchRegistrar and hands them to the live targets", async () => {
     const addrs = getAddresses();
 
     const batchBefore = await readRoles(addrs.batchRegistrar);
     expect(batchBefore & ROLE_REGISTRAR).toBe(ROLE_REGISTRAR);
+    expect(batchBefore & ROLE_RENEW).toBe(ROLE_RENEW);
 
     await main(buildArgs(addrs, { execute: true }));
 
@@ -110,10 +113,12 @@ describe("PrepareMigration", () => {
     expect(batchAfter & ROLE_REGISTRAR_ADMIN).toBe(0n);
     expect(batchAfter & ROLE_REGISTER_RESERVED).toBe(0n);
     expect(batchAfter & ROLE_REGISTER_RESERVED_ADMIN).toBe(0n);
+    expect(batchAfter & ROLE_RENEW).toBe(0n);
+    expect(batchAfter & ROLE_RENEW_ADMIN).toBe(0n);
 
-    expect((await readRoles(addrs.ethRegistrar)) & ROLE_REGISTRAR).toBe(
-      ROLE_REGISTRAR,
-    );
+    const ethAfter = await readRoles(addrs.ethRegistrar);
+    expect(ethAfter & ROLE_REGISTRAR).toBe(ROLE_REGISTRAR);
+    expect(ethAfter & ROLE_RENEW).toBe(ROLE_RENEW);
     expect((await readRoles(addrs.unlocked)) & ROLE_REGISTER_RESERVED).toBe(
       ROLE_REGISTER_RESERVED,
     );
@@ -122,16 +127,14 @@ describe("PrepareMigration", () => {
     );
   });
 
-  it("execute preserves unrelated roles on BatchRegistrar", async () => {
+  it("execute fully decommissions BatchRegistrar (no roles remain)", async () => {
     const addrs = getAddresses();
     const batchBefore = await readRoles(addrs.batchRegistrar);
-    const ROLE_RENEW = 1n << 16n;
     expect(batchBefore & ROLE_RENEW).toBe(ROLE_RENEW);
 
     await main(buildArgs(addrs, { execute: true }));
 
-    const batchAfter = await readRoles(addrs.batchRegistrar);
-    expect(batchAfter & ROLE_RENEW).toBe(ROLE_RENEW);
+    expect(await readRoles(addrs.batchRegistrar)).toBe(0n);
   });
 
   it("is idempotent on repeated execute", async () => {

--- a/contracts/test/utils/mockPrepareMigration.ts
+++ b/contracts/test/utils/mockPrepareMigration.ts
@@ -1,0 +1,32 @@
+import { ROLES } from "../../script/deploy-constants.js";
+import type { DevnetEnvironment } from "../../script/setup.js";
+
+/// Revoke the roles that `deploy/03_ETHRegistrar.ts`,
+/// `deploy/02_UnlockedMigrationController.ts`, and
+/// `deploy/04_LockedMigrationController.ts` pre-grant on the .eth registry.
+///
+/// The devnet's deploy scripts grant the three registrars/controllers the same
+/// roles that `prepareMigration` is meant to grant later in the migration
+/// sequence. Calling this from a test `initialize()` puts the devnet into the
+/// true pre-`prepareMigration` state so the grant path can be exercised
+/// end-to-end.
+export async function revertPrePrepareMigrationRoles(
+  env: DevnetEnvironment,
+): Promise<void> {
+  const registry = env.v2.ETHRegistry;
+
+  await registry.write.revokeRootRoles([
+    ROLES.REGISTRY.REGISTRAR | ROLES.REGISTRY.RENEW,
+    env.v2.ETHRegistrar.address,
+  ]);
+
+  await registry.write.revokeRootRoles([
+    ROLES.REGISTRY.REGISTER_RESERVED,
+    env.v2.UnlockedMigrationController.address,
+  ]);
+
+  await registry.write.revokeRootRoles([
+    ROLES.REGISTRY.REGISTER_RESERVED,
+    env.v2.LockedMigrationController.address,
+  ]);
+}


### PR DESCRIPTION
Introduces `prepareMigration.ts` to revoke BatchRegistrar's seeding roles on the .eth PermissionedRegistry and grant registration roles to ETHRegistrar and the Unlocked/Locked migration controllers. Extracts shared viem client/artifact helpers into `scriptUtils.ts` and refactors `preMigration.ts` to consume them. Adds e2e coverage plus a test helper that reverts the devnet into a true pre-prepareMigration state.