### PR TITLE
Close role-revoke front run transfer

### DIFF
--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -88,6 +88,8 @@ contract PermissionedRegistry is
     string internal _childLabel;
     /// @dev The entries of this registry.
     mapping(uint256 storageId => Entry entry) internal _entries;
+    /// @dev Per-name transfer lock. When set, ERC1155 transfers are blocked regardless of per-account roles.
+    mapping(uint256 storageId => bool locked) private _transferLocks;
 
     ////////////////////////////////////////////////////////////////////////
     // Initialization
@@ -206,6 +208,7 @@ contract PermissionedRegistry is
             ++entry.tokenVersionId;
             tokenId = _constructTokenId(tokenId, entry);
         }
+        delete _transferLocks[LibLabel.withVersion(labelId, 0)];
         entry.expiry = expiry;
         entry.subregistry = registry;
         entry.resolver = resolver;
@@ -242,6 +245,7 @@ contract PermissionedRegistry is
             ++entry.tokenVersionId;
         }
         entry.expiry = uint64(block.timestamp);
+        delete _transferLocks[LibLabel.withVersion(anyId, 0)];
     }
 
     /// @inheritdoc IStandardRegistry
@@ -274,6 +278,33 @@ contract PermissionedRegistry is
         address account
     ) public override(EnhancedAccessControl, IEnhancedAccessControl) returns (bool) {
         return super.revokeRoles(getResource(anyId), roleBitmap, account);
+    }
+
+    /// @inheritdoc IPermissionedRegistry
+    function revokeRolesAndLockTransfer(
+        uint256 anyId,
+        uint256 roleBitmap,
+        address account
+    ) public virtual {
+        uint256 resource = getResource(anyId);
+        if (resource == ROOT_RESOURCE) {
+            revert EACRootResourceNotAllowed();
+        }
+        _checkRoles(ROOT_RESOURCE, RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, _msgSender());
+        _checkCanRevokeRoles(resource, roleBitmap, _msgSender());
+        _setTransferLock(anyId, true);
+        _revokeRoles(resource, roleBitmap, account, true);
+    }
+
+    /// @inheritdoc IPermissionedRegistry
+    function setTransferLock(uint256 anyId, bool locked) public virtual {
+        _checkRoles(ROOT_RESOURCE, RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, _msgSender());
+        _setTransferLock(anyId, locked);
+    }
+
+    /// @inheritdoc IPermissionedRegistry
+    function isTransferLocked(uint256 anyId) public view returns (bool) {
+        return _transferLocks[LibLabel.withVersion(anyId, 0)];
     }
 
     /// @inheritdoc IRegistry
@@ -409,8 +440,10 @@ contract PermissionedRegistry is
     ) internal virtual override {
         bool externalTransfer = to != address(0) && from != address(0); // skip mint and burn
         if (externalTransfer) {
-            // only check ROLE_CAN_TRANSFER_ADMIN on token owner (from)
             for (uint256 i; i < tokenIds.length; ++i) {
+                if (_transferLocks[LibLabel.withVersion(tokenIds[i], 0)]) {
+                    revert TransferLocked(tokenIds[i]);
+                }
                 if (!hasRoles(tokenIds[i], RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, from)) {
                     revert TransferDisallowed(tokenIds[i], from);
                 }
@@ -460,6 +493,13 @@ contract PermissionedRegistry is
             _mint(owner, newTokenId, 1, "");
             emit TokenRegenerated(tokenId, newTokenId); // resource is unchanged
         }
+    }
+
+    /// @dev Sets or clears the per-name transfer lock and emits an event.
+    function _setTransferLock(uint256 anyId, bool locked) internal {
+        uint256 storageId = LibLabel.withVersion(anyId, 0);
+        _transferLocks[storageId] = locked;
+        emit TransferLockChanged(_constructTokenId(anyId, _entry(anyId)), locked, _msgSender());
     }
 
     /// @inheritdoc EnhancedAccessControl

--- a/contracts/src/registry/interfaces/IPermissionedRegistry.sol
+++ b/contracts/src/registry/interfaces/IPermissionedRegistry.sol
@@ -5,7 +5,7 @@ import {IEnhancedAccessControl} from "../../access-control/interfaces/IEnhancedA
 
 import {IStandardRegistry} from "./IStandardRegistry.sol";
 
-/// @dev Interface selector: `0xafff3a63`
+/// @dev Interface selector: `0x937fca22`
 interface IPermissionedRegistry is IStandardRegistry, IEnhancedAccessControl {
     ////////////////////////////////////////////////////////////////////////
     // Types
@@ -44,9 +44,43 @@ interface IPermissionedRegistry is IStandardRegistry, IEnhancedAccessControl {
     /// @dev Error selector: `0xf60759e0`
     error LabelAlreadyReserved(string label);
 
+    /// @notice Transfer is blocked by a name-level transfer lock.
+    /// @dev Error selector: `0xa9de8c6f`
+    error TransferLocked(uint256 tokenId);
+
     ////////////////////////////////////////////////////////////////////////
     // Functions
     ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Atomically locks transfers on a name and revokes the specified roles from an account.
+    ///
+    /// The lock prevents any ERC1155 token transfers for the name regardless of per-account
+    /// `ROLE_CAN_TRANSFER_ADMIN` grants, closing the front-running window where a user could
+    /// transfer the token to evade a pending role revocation.
+    ///
+    /// @param anyId The labelhash, token ID, or resource.
+    /// @param roleBitmap The roles bitmap to revoke from `account`.
+    /// @param account The account to revoke roles from.
+    function revokeRolesAndLockTransfer(
+        uint256 anyId,
+        uint256 roleBitmap,
+        address account
+    ) external;
+
+    /// @notice Sets or clears the transfer lock on a name.
+    ///
+    /// When locked, all ERC1155 token transfers for this name are blocked regardless of
+    /// per-account roles. Only callable by accounts holding `ROLE_CAN_TRANSFER_ADMIN`
+    /// on the `ROOT_RESOURCE`.
+    ///
+    /// @param anyId The labelhash, token ID, or resource.
+    /// @param locked Whether to lock (`true`) or unlock (`false`) transfers.
+    function setTransferLock(uint256 anyId, bool locked) external;
+
+    /// @notice Returns whether transfers are locked for the given name.
+    /// @param anyId The labelhash, token ID, or resource.
+    /// @return `true` if transfers are locked, `false` otherwise.
+    function isTransferLocked(uint256 anyId) external view returns (bool);
 
     /// @notice Get the latest owner of a token.
     ///         If the token was burned, returns null.

--- a/contracts/src/registry/interfaces/IRegistryEvents.sol
+++ b/contracts/src/registry/interfaces/IRegistryEvents.sol
@@ -77,4 +77,10 @@ interface IRegistryEvents {
     /// @param label The new label.
     /// @param sender The sender of the call to update the parent.
     event ParentUpdated(IRegistry indexed parent, string label, address indexed sender);
+
+    /// @notice Transfer lock state changed for a name.
+    /// @param tokenId The current token ID of the name.
+    /// @param locked Whether transfers are now locked or unlocked.
+    /// @param sender The sender of the call.
+    event TransferLockChanged(uint256 indexed tokenId, bool indexed locked, address indexed sender);
 }


### PR DESCRIPTION
When an admin broadcasts a `revokeRoles()` transaction to remove a user's roles (e.g., `ROLE_CAN_TRANSFER_ADMIN`), the user can front-run by transferring the token to another address they control. The transfer atomically moves ALL roles to the recipient via `_transferRoles()`, causing the admin's revocation to become a no-op (returns false, no revert). The recipient retains all original roles, completely bypassing admin governance.