### PR TITLE
Fix `EAC` and `PermissionedRegistry` onRoles callback event ordering

### DIFF
--- a/contracts/src/access-control/EnhancedAccessControl.sol
+++ b/contracts/src/access-control/EnhancedAccessControl.sol
@@ -104,9 +104,13 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
     ////////////////////////////////////////////////////////////////////////
 
     /// @inheritdoc IERC165
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC165, IERC165) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC165, IERC165)
+        returns (bool)
+    {
         return
             interfaceId == type(IEnhancedAccessControl).interfaceId ||
             super.supportsInterface(interfaceId);
@@ -119,11 +123,12 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
     /// @inheritdoc IEnhancedAccessControl
     /// @dev The caller must have all the necessary admin roles for the roles being granted.
     ///      Cannot be used with ROOT_RESOURCE directly, use grantRootRoles instead.
-    function grantRoles(
-        uint256 resource,
-        uint256 roleBitmap,
-        address account
-    ) public virtual canGrantRoles(resource, roleBitmap) returns (bool) {
+    function grantRoles(uint256 resource, uint256 roleBitmap, address account)
+        public
+        virtual
+        canGrantRoles(resource, roleBitmap)
+        returns (bool)
+    {
         if (resource == ROOT_RESOURCE) {
             revert EACRootResourceNotAllowed();
         }
@@ -132,21 +137,24 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
 
     /// @inheritdoc IEnhancedAccessControl
     /// @dev The caller must have all the necessary admin roles for the roles being granted.
-    function grantRootRoles(
-        uint256 roleBitmap,
-        address account
-    ) public virtual canGrantRoles(ROOT_RESOURCE, roleBitmap) returns (bool) {
+    function grantRootRoles(uint256 roleBitmap, address account)
+        public
+        virtual
+        canGrantRoles(ROOT_RESOURCE, roleBitmap)
+        returns (bool)
+    {
         return _grantRoles(ROOT_RESOURCE, roleBitmap, account, true);
     }
 
     /// @inheritdoc IEnhancedAccessControl
     /// @dev The caller must have all the necessary admin roles for the roles being revoked.
     ///      Cannot be used with ROOT_RESOURCE directly, use revokeRootRoles instead.
-    function revokeRoles(
-        uint256 resource,
-        uint256 roleBitmap,
-        address account
-    ) public virtual canRevokeRoles(resource, roleBitmap) returns (bool) {
+    function revokeRoles(uint256 resource, uint256 roleBitmap, address account)
+        public
+        virtual
+        canRevokeRoles(resource, roleBitmap)
+        returns (bool)
+    {
         if (resource == ROOT_RESOURCE) {
             revert EACRootResourceNotAllowed();
         }
@@ -155,10 +163,12 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
 
     /// @inheritdoc IEnhancedAccessControl
     /// @dev The caller must have all the necessary admin roles for the roles being revoked.
-    function revokeRootRoles(
-        uint256 roleBitmap,
-        address account
-    ) public virtual canRevokeRoles(ROOT_RESOURCE, roleBitmap) returns (bool) {
+    function revokeRootRoles(uint256 roleBitmap, address account)
+        public
+        virtual
+        canRevokeRoles(ROOT_RESOURCE, roleBitmap)
+        returns (bool)
+    {
         return _revokeRoles(ROOT_RESOURCE, roleBitmap, account, true);
     }
 
@@ -178,11 +188,12 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function hasRoles(
-        uint256 resource,
-        uint256 roleBitmap,
-        address account
-    ) public view virtual returns (bool) {
+    function hasRoles(uint256 resource, uint256 roleBitmap, address account)
+        public
+        view
+        virtual
+        returns (bool)
+    {
         return
             (_roles[ROOT_RESOURCE][account] | _roles[resource][account]) & roleBitmap == roleBitmap;
     }
@@ -194,10 +205,12 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function getAssigneeCount(
-        uint256 resource,
-        uint256 roleBitmap
-    ) public view virtual returns (uint256 counts, uint256 mask) {
+    function getAssigneeCount(uint256 resource, uint256 roleBitmap)
+        public
+        view
+        virtual
+        returns (uint256 counts, uint256 mask)
+    {
         mask = _roleBitmapToMask(roleBitmap);
         counts = _roleCount[resource] & mask;
     }
@@ -222,7 +235,10 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         address srcAccount,
         address dstAccount,
         bool executeCallbacks
-    ) internal virtual {
+    )
+        internal
+        virtual
+    {
         uint256 srcRoles = _roles[resource][srcAccount];
         if (srcRoles != 0) {
             // First revoke roles from source account to free up assignee slots
@@ -243,7 +259,11 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         uint256 roleBitmap,
         address account,
         bool executeCallbacks
-    ) internal virtual returns (bool) {
+    )
+        internal
+        virtual
+        returns (bool)
+    {
         if (roleBitmap == 0) {
             return false;
         }
@@ -279,7 +299,11 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         uint256 roleBitmap,
         address account,
         bool executeCallbacks
-    ) internal virtual returns (bool) {
+    )
+        internal
+        virtual
+        returns (bool)
+    {
         _checkRoleBitmap(roleBitmap);
         uint256 currentRoles = _roles[resource][account];
         uint256 updatedRoles = currentRoles & ~roleBitmap;
@@ -299,11 +323,11 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
     }
 
     /// @dev Revoke all roles for account within resource.
-    function _revokeAllRoles(
-        uint256 resource,
-        address account,
-        bool executeCallbacks
-    ) internal virtual returns (bool) {
+    function _revokeAllRoles(uint256 resource, address account, bool executeCallbacks)
+        internal
+        virtual
+        returns (bool)
+    {
         return _revokeRoles(resource, EACBaseRolesLib.ALL_ROLES, account, executeCallbacks);
     }
 
@@ -341,7 +365,10 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         uint256 oldRoles,
         uint256 newRoles,
         uint256 roleBitmap
-    ) internal virtual {
+    )
+        internal
+        virtual
+    {
         // solhint-disable-previous-line no-empty-blocks
     }
 
@@ -357,27 +384,30 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         uint256 oldRoles,
         uint256 newRoles,
         uint256 roleBitmap
-    ) internal virtual {
+    )
+        internal
+        virtual
+    {
         // solhint-disable-previous-line no-empty-blocks
     }
 
     /// @dev Reverts if `account` does not have all the given roles.
-    function _checkRoles(
-        uint256 resource,
-        uint256 roleBitmap,
-        address account
-    ) internal view virtual {
+    function _checkRoles(uint256 resource, uint256 roleBitmap, address account)
+        internal
+        view
+        virtual
+    {
         if (!hasRoles(resource, roleBitmap, account)) {
             revert EACUnauthorizedAccountRoles(resource, roleBitmap, account);
         }
     }
 
     /// @dev Reverts if `account` does not have the admin roles for all the given roles.
-    function _checkCanGrantRoles(
-        uint256 resource,
-        uint256 roleBitmap,
-        address account
-    ) internal view virtual {
+    function _checkCanGrantRoles(uint256 resource, uint256 roleBitmap, address account)
+        internal
+        view
+        virtual
+    {
         uint256 settableRoles = _getSettableRoles(resource, account);
         if ((roleBitmap & ~settableRoles) != 0) {
             revert EACCannotGrantRoles(resource, roleBitmap, account);
@@ -385,11 +415,11 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
     }
 
     /// @dev Reverts if `account` does not have the admin roles for all the given roles that are being revoked.
-    function _checkCanRevokeRoles(
-        uint256 resource,
-        uint256 roleBitmap,
-        address account
-    ) internal view virtual {
+    function _checkCanRevokeRoles(uint256 resource, uint256 roleBitmap, address account)
+        internal
+        view
+        virtual
+    {
         uint256 revokableRoles = _getRevokableRoles(resource, account);
         if ((roleBitmap & ~revokableRoles) != 0) {
             revert EACCannotRevokeRoles(resource, roleBitmap, account);
@@ -405,11 +435,14 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
     /// @param resource The resource to get settable roles for.
     /// @param account The account to get settable roles for.
     /// @return The settable roles for `account` within `resource`.
-    function _getSettableRoles(
-        uint256 resource,
-        address account
-    ) internal view virtual returns (uint256) {
-        uint256 adminRoleBitmap = (_roles[resource][account] | _roles[ROOT_RESOURCE][account]) &
+    function _getSettableRoles(uint256 resource, address account)
+        internal
+        view
+        virtual
+        returns (uint256)
+    {
+        uint256 adminRoleBitmap =
+            (_roles[resource][account] | _roles[ROOT_RESOURCE][account]) &
             EACBaseRolesLib.ADMIN_ROLES;
         return (adminRoleBitmap >> 128) | adminRoleBitmap;
     }
@@ -421,11 +454,14 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
     /// @param resource The resource to get revokable roles for.
     /// @param account The account to get revokable roles for.
     /// @return The revokable roles for `account` within `resource`.
-    function _getRevokableRoles(
-        uint256 resource,
-        address account
-    ) internal view virtual returns (uint256) {
-        uint256 adminRoleBitmap = (_roles[resource][account] | _roles[ROOT_RESOURCE][account]) &
+    function _getRevokableRoles(uint256 resource, address account)
+        internal
+        view
+        virtual
+        returns (uint256)
+    {
+        uint256 adminRoleBitmap =
+            (_roles[resource][account] | _roles[ROOT_RESOURCE][account]) &
             EACBaseRolesLib.ADMIN_ROLES;
         uint256 regularRoles = adminRoleBitmap >> 128;
         return regularRoles | adminRoleBitmap;

--- a/contracts/src/access-control/EnhancedAccessControl.sol
+++ b/contracts/src/access-control/EnhancedAccessControl.sol
@@ -258,10 +258,10 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
             _roles[resource][account] = updatedRoles;
             uint256 newlyAddedRoles = roleBitmap & ~currentRoles;
             _updateRoleCounts(resource, newlyAddedRoles, true);
+            emit EACRolesChanged(resource, account, currentRoles, updatedRoles);
             if (executeCallbacks) {
                 _onRolesGranted(resource, account, currentRoles, updatedRoles, roleBitmap);
             }
-            emit EACRolesChanged(resource, account, currentRoles, updatedRoles);
             return true;
         } else {
             return false;
@@ -288,10 +288,10 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
             _roles[resource][account] = updatedRoles;
             uint256 newlyRemovedRoles = roleBitmap & currentRoles;
             _updateRoleCounts(resource, newlyRemovedRoles, false);
+            emit EACRolesChanged(resource, account, currentRoles, updatedRoles);
             if (executeCallbacks) {
                 _onRolesRevoked(resource, account, currentRoles, updatedRoles, roleBitmap);
             }
-            emit EACRolesChanged(resource, account, currentRoles, updatedRoles);
             return true;
         } else {
             return false;

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -105,15 +105,14 @@ contract PermissionedRegistry is
         IRegistryMetadata metadata,
         address ownerAddress,
         uint256 ownerRoles
-    )
-        HCAEquivalence(hcaFactory)
-        MetadataMixin(metadata)
-    {
+    ) HCAEquivalence(hcaFactory) MetadataMixin(metadata) {
         _grantRoles(ROOT_RESOURCE, ownerRoles, ownerAddress, false);
     }
 
     /// @inheritdoc IERC165
-    function supportsInterface(bytes4 interfaceId)
+    function supportsInterface(
+        bytes4 interfaceId
+    )
         public
         view
         virtual
@@ -133,26 +132,29 @@ contract PermissionedRegistry is
 
     /// @inheritdoc IStandardRegistry
     function setSubregistry(uint256 anyId, IRegistry registry) public virtual {
-        (uint256 tokenId, Entry storage entry) =
-            _checkExpiryAndTokenRoles(anyId, RegistryRolesLib.ROLE_SET_SUBREGISTRY);
+        (uint256 tokenId, Entry storage entry) = _checkExpiryAndTokenRoles(
+            anyId,
+            RegistryRolesLib.ROLE_SET_SUBREGISTRY
+        );
         entry.subregistry = registry;
         emit SubregistryUpdated(tokenId, registry, _msgSender());
     }
 
     /// @inheritdoc IStandardRegistry
     function setResolver(uint256 anyId, address resolver) public virtual {
-        (uint256 tokenId, Entry storage entry) =
-            _checkExpiryAndTokenRoles(anyId, RegistryRolesLib.ROLE_SET_RESOLVER);
+        (uint256 tokenId, Entry storage entry) = _checkExpiryAndTokenRoles(
+            anyId,
+            RegistryRolesLib.ROLE_SET_RESOLVER
+        );
         entry.resolver = resolver;
         emit ResolverUpdated(tokenId, resolver, _msgSender());
     }
 
     /// @inheritdoc IStandardRegistry
-    function setParent(IRegistry parent, string memory label)
-        public
-        virtual
-        onlyRootRoles(RegistryRolesLib.ROLE_SET_PARENT)
-    {
+    function setParent(
+        IRegistry parent,
+        string memory label
+    ) public virtual onlyRootRoles(RegistryRolesLib.ROLE_SET_PARENT) {
         _parentRegistry = parent;
         _childLabel = label;
         emit ParentUpdated(parent, label, _msgSender());
@@ -170,12 +172,7 @@ contract PermissionedRegistry is
         address resolver,
         uint256 roleBitmap,
         uint64 expiry
-    )
-        public
-        virtual
-        override
-        returns (uint256 tokenId)
-    {
+    ) public virtual override returns (uint256 tokenId) {
         NameCoder.assertLabelSize(label);
         uint256 labelId = LibLabel.id(label);
         Entry storage entry = _entry(labelId);
@@ -235,8 +232,10 @@ contract PermissionedRegistry is
     /// @inheritdoc IStandardRegistry
     /// @dev Requires `REGISTERED | RESERVED` and `ROLE_UNREGISTER`.
     function unregister(uint256 anyId) public virtual {
-        (uint256 tokenId, Entry storage entry) =
-            _checkExpiryAndTokenRoles(anyId, RegistryRolesLib.ROLE_UNREGISTER);
+        (uint256 tokenId, Entry storage entry) = _checkExpiryAndTokenRoles(
+            anyId,
+            RegistryRolesLib.ROLE_UNREGISTER
+        );
         emit LabelUnregistered(tokenId, _msgSender());
         address owner = super.ownerOf(tokenId);
         if (owner != address(0)) {
@@ -250,8 +249,10 @@ contract PermissionedRegistry is
     /// @inheritdoc IStandardRegistry
     /// @dev Requires `REGISTERED | RESERVED` and `ROLE_RENEW`.
     function renew(uint256 anyId, uint64 newExpiry) public override {
-        (uint256 tokenId, Entry storage entry) =
-            _checkExpiryAndTokenRoles(anyId, RegistryRolesLib.ROLE_RENEW);
+        (uint256 tokenId, Entry storage entry) = _checkExpiryAndTokenRoles(
+            anyId,
+            RegistryRolesLib.ROLE_RENEW
+        );
         if (newExpiry < entry.expiry) {
             revert CannotReduceExpiry(entry.expiry, newExpiry);
         }
@@ -260,20 +261,20 @@ contract PermissionedRegistry is
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function grantRoles(uint256 anyId, uint256 roleBitmap, address account)
-        public
-        override(EnhancedAccessControl, IEnhancedAccessControl)
-        returns (bool)
-    {
+    function grantRoles(
+        uint256 anyId,
+        uint256 roleBitmap,
+        address account
+    ) public override(EnhancedAccessControl, IEnhancedAccessControl) returns (bool) {
         return super.grantRoles(getResource(anyId), roleBitmap, account);
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function revokeRoles(uint256 anyId, uint256 roleBitmap, address account)
-        public
-        override(EnhancedAccessControl, IEnhancedAccessControl)
-        returns (bool)
-    {
+    function revokeRoles(
+        uint256 anyId,
+        uint256 roleBitmap,
+        address account
+    ) public override(EnhancedAccessControl, IEnhancedAccessControl) returns (bool) {
         return super.revokeRoles(getResource(anyId), roleBitmap, account);
     }
 
@@ -339,13 +340,9 @@ contract PermissionedRegistry is
     }
 
     /// @inheritdoc IERC1155Singleton
-    function ownerOf(uint256 tokenId)
-        public
-        view
-        virtual
-        override(ERC1155Singleton, IERC1155Singleton)
-        returns (address)
-    {
+    function ownerOf(
+        uint256 tokenId
+    ) public view virtual override(ERC1155Singleton, IERC1155Singleton) returns (address) {
         Entry storage entry = _entry(tokenId);
         return
             tokenId != _constructTokenId(tokenId, entry) || _isExpired(entry.expiry)
@@ -354,47 +351,42 @@ contract PermissionedRegistry is
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function roles(uint256 anyId, address account)
-        public
-        view
-        override(EnhancedAccessControl, IEnhancedAccessControl)
-        returns (uint256)
-    {
+    function roles(
+        uint256 anyId,
+        address account
+    ) public view override(EnhancedAccessControl, IEnhancedAccessControl) returns (uint256) {
         return super.roles(getResource(anyId), account);
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function roleCount(uint256 anyId)
-        public
-        view
-        override(EnhancedAccessControl, IEnhancedAccessControl)
-        returns (uint256)
-    {
+    function roleCount(
+        uint256 anyId
+    ) public view override(EnhancedAccessControl, IEnhancedAccessControl) returns (uint256) {
         return super.roleCount(getResource(anyId));
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function hasRoles(uint256 anyId, uint256 roleBitmap, address account)
-        public
-        view
-        override(EnhancedAccessControl, IEnhancedAccessControl)
-        returns (bool)
-    {
+    function hasRoles(
+        uint256 anyId,
+        uint256 roleBitmap,
+        address account
+    ) public view override(EnhancedAccessControl, IEnhancedAccessControl) returns (bool) {
         return super.hasRoles(getResource(anyId), roleBitmap, account);
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function hasAssignees(uint256 anyId, uint256 roleBitmap)
-        public
-        view
-        override(EnhancedAccessControl, IEnhancedAccessControl)
-        returns (bool)
-    {
+    function hasAssignees(
+        uint256 anyId,
+        uint256 roleBitmap
+    ) public view override(EnhancedAccessControl, IEnhancedAccessControl) returns (bool) {
         return super.hasAssignees(getResource(anyId), roleBitmap);
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function getAssigneeCount(uint256 anyId, uint256 roleBitmap)
+    function getAssigneeCount(
+        uint256 anyId,
+        uint256 roleBitmap
+    )
         public
         view
         override(EnhancedAccessControl, IEnhancedAccessControl)
@@ -408,11 +400,12 @@ contract PermissionedRegistry is
     ////////////////////////////////////////////////////////////////////////
 
     /// @dev Override `ERC1155Singleton._update()` to transfer the roles to the new owner if the token is transferred.
-    function _update(address from, address to, uint256[] memory tokenIds, uint256[] memory amounts)
-        internal
-        virtual
-        override
-    {
+    function _update(
+        address from,
+        address to,
+        uint256[] memory tokenIds,
+        uint256[] memory amounts
+    ) internal virtual override {
         bool externalTransfer = to != address(0) && from != address(0); // skip mint and burn
         if (externalTransfer) {
             // only check ROLE_CAN_TRANSFER_ADMIN on token owner (from)
@@ -439,11 +432,7 @@ contract PermissionedRegistry is
         uint256 /*oldRoles*/,
         uint256 /*newRoles*/,
         uint256 /*roleBitmap*/
-    )
-        internal
-        virtual
-        override
-    {
+    ) internal virtual override {
         _regenerate(resource);
     }
 
@@ -454,11 +443,7 @@ contract PermissionedRegistry is
         uint256 /*oldRoles*/,
         uint256 /*newRoles*/,
         uint256 /*roleBitmap*/
-    )
-        internal
-        virtual
-        override
-    {
+    ) internal virtual override {
         _regenerate(resource);
     }
 
@@ -491,13 +476,10 @@ contract PermissionedRegistry is
     /// @param resource The resource to get settable roles for.
     /// @param account The account to get settable roles for.
     /// @return The settable roles (regular roles only, not admin roles).
-    function _getSettableRoles(uint256 resource, address account)
-        internal
-        view
-        virtual
-        override
-        returns (uint256)
-    {
+    function _getSettableRoles(
+        uint256 resource,
+        address account
+    ) internal view virtual override returns (uint256) {
         uint256 roleBitmap = super._getSettableRoles(resource, account);
         if (resource == ROOT_RESOURCE) {
             return roleBitmap;
@@ -514,13 +496,10 @@ contract PermissionedRegistry is
     ///
     /// Root roles are unaffected.
     ///
-    function _getRevokableRoles(uint256 resource, address account)
-        internal
-        view
-        virtual
-        override
-        returns (uint256)
-    {
+    function _getRevokableRoles(
+        uint256 resource,
+        address account
+    ) internal view virtual override returns (uint256) {
         if (
             resource != ROOT_RESOURCE &&
             ownerOf(_constructTokenId(resource, _entry(resource))) == address(0)
@@ -536,11 +515,10 @@ contract PermissionedRegistry is
     }
 
     /// @dev Assert token is not expired and caller has necessary roles.
-    function _checkExpiryAndTokenRoles(uint256 anyId, uint256 roleBitmap)
-        internal
-        view
-        returns (uint256 tokenId, Entry storage entry)
-    {
+    function _checkExpiryAndTokenRoles(
+        uint256 anyId,
+        uint256 roleBitmap
+    ) internal view returns (uint256 tokenId, Entry storage entry) {
         entry = _entry(anyId);
         tokenId = _constructTokenId(anyId, entry);
         if (_isExpired(entry.expiry)) {
@@ -556,7 +534,10 @@ contract PermissionedRegistry is
 
     /// @dev Create `resource` from parts.
     ///      Returns next resource if expired.
-    function _constructResource(uint256 anyId, Entry storage entry) internal view returns (uint256) {
+    function _constructResource(
+        uint256 anyId,
+        Entry storage entry
+    ) internal view returns (uint256) {
         return LibLabel.withVersion(anyId, entry.eacVersionId);
     }
 

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -84,8 +84,10 @@ contract PermissionedRegistry is
 
     /// @dev The parent registry of this registry.
     IRegistry internal _parentRegistry;
+
     /// @dev The child label of this registry.
     string internal _childLabel;
+
     /// @dev The entries of this registry.
     mapping(uint256 storageId => Entry entry) internal _entries;
 
@@ -103,14 +105,15 @@ contract PermissionedRegistry is
         IRegistryMetadata metadata,
         address ownerAddress,
         uint256 ownerRoles
-    ) HCAEquivalence(hcaFactory) MetadataMixin(metadata) {
+    )
+        HCAEquivalence(hcaFactory)
+        MetadataMixin(metadata)
+    {
         _grantRoles(ROOT_RESOURCE, ownerRoles, ownerAddress, false);
     }
 
     /// @inheritdoc IERC165
-    function supportsInterface(
-        bytes4 interfaceId
-    )
+    function supportsInterface(bytes4 interfaceId)
         public
         view
         virtual
@@ -130,29 +133,26 @@ contract PermissionedRegistry is
 
     /// @inheritdoc IStandardRegistry
     function setSubregistry(uint256 anyId, IRegistry registry) public virtual {
-        (uint256 tokenId, Entry storage entry) = _checkExpiryAndTokenRoles(
-            anyId,
-            RegistryRolesLib.ROLE_SET_SUBREGISTRY
-        );
+        (uint256 tokenId, Entry storage entry) =
+            _checkExpiryAndTokenRoles(anyId, RegistryRolesLib.ROLE_SET_SUBREGISTRY);
         entry.subregistry = registry;
         emit SubregistryUpdated(tokenId, registry, _msgSender());
     }
 
     /// @inheritdoc IStandardRegistry
     function setResolver(uint256 anyId, address resolver) public virtual {
-        (uint256 tokenId, Entry storage entry) = _checkExpiryAndTokenRoles(
-            anyId,
-            RegistryRolesLib.ROLE_SET_RESOLVER
-        );
+        (uint256 tokenId, Entry storage entry) =
+            _checkExpiryAndTokenRoles(anyId, RegistryRolesLib.ROLE_SET_RESOLVER);
         entry.resolver = resolver;
         emit ResolverUpdated(tokenId, resolver, _msgSender());
     }
 
     /// @inheritdoc IStandardRegistry
-    function setParent(
-        IRegistry parent,
-        string memory label
-    ) public virtual onlyRootRoles(RegistryRolesLib.ROLE_SET_PARENT) {
+    function setParent(IRegistry parent, string memory label)
+        public
+        virtual
+        onlyRootRoles(RegistryRolesLib.ROLE_SET_PARENT)
+    {
         _parentRegistry = parent;
         _childLabel = label;
         emit ParentUpdated(parent, label, _msgSender());
@@ -170,7 +170,12 @@ contract PermissionedRegistry is
         address resolver,
         uint256 roleBitmap,
         uint64 expiry
-    ) public virtual override returns (uint256 tokenId) {
+    )
+        public
+        virtual
+        override
+        returns (uint256 tokenId)
+    {
         NameCoder.assertLabelSize(label);
         uint256 labelId = LibLabel.id(label);
         Entry storage entry = _entry(labelId);
@@ -230,10 +235,8 @@ contract PermissionedRegistry is
     /// @inheritdoc IStandardRegistry
     /// @dev Requires `REGISTERED | RESERVED` and `ROLE_UNREGISTER`.
     function unregister(uint256 anyId) public virtual {
-        (uint256 tokenId, Entry storage entry) = _checkExpiryAndTokenRoles(
-            anyId,
-            RegistryRolesLib.ROLE_UNREGISTER
-        );
+        (uint256 tokenId, Entry storage entry) =
+            _checkExpiryAndTokenRoles(anyId, RegistryRolesLib.ROLE_UNREGISTER);
         emit LabelUnregistered(tokenId, _msgSender());
         address owner = super.ownerOf(tokenId);
         if (owner != address(0)) {
@@ -247,10 +250,8 @@ contract PermissionedRegistry is
     /// @inheritdoc IStandardRegistry
     /// @dev Requires `REGISTERED | RESERVED` and `ROLE_RENEW`.
     function renew(uint256 anyId, uint64 newExpiry) public override {
-        (uint256 tokenId, Entry storage entry) = _checkExpiryAndTokenRoles(
-            anyId,
-            RegistryRolesLib.ROLE_RENEW
-        );
+        (uint256 tokenId, Entry storage entry) =
+            _checkExpiryAndTokenRoles(anyId, RegistryRolesLib.ROLE_RENEW);
         if (newExpiry < entry.expiry) {
             revert CannotReduceExpiry(entry.expiry, newExpiry);
         }
@@ -259,20 +260,20 @@ contract PermissionedRegistry is
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function grantRoles(
-        uint256 anyId,
-        uint256 roleBitmap,
-        address account
-    ) public override(EnhancedAccessControl, IEnhancedAccessControl) returns (bool) {
+    function grantRoles(uint256 anyId, uint256 roleBitmap, address account)
+        public
+        override(EnhancedAccessControl, IEnhancedAccessControl)
+        returns (bool)
+    {
         return super.grantRoles(getResource(anyId), roleBitmap, account);
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function revokeRoles(
-        uint256 anyId,
-        uint256 roleBitmap,
-        address account
-    ) public override(EnhancedAccessControl, IEnhancedAccessControl) returns (bool) {
+    function revokeRoles(uint256 anyId, uint256 roleBitmap, address account)
+        public
+        override(EnhancedAccessControl, IEnhancedAccessControl)
+        returns (bool)
+    {
         return super.revokeRoles(getResource(anyId), roleBitmap, account);
     }
 
@@ -338,9 +339,13 @@ contract PermissionedRegistry is
     }
 
     /// @inheritdoc IERC1155Singleton
-    function ownerOf(
-        uint256 tokenId
-    ) public view virtual override(ERC1155Singleton, IERC1155Singleton) returns (address) {
+    function ownerOf(uint256 tokenId)
+        public
+        view
+        virtual
+        override(ERC1155Singleton, IERC1155Singleton)
+        returns (address)
+    {
         Entry storage entry = _entry(tokenId);
         return
             tokenId != _constructTokenId(tokenId, entry) || _isExpired(entry.expiry)
@@ -348,46 +353,48 @@ contract PermissionedRegistry is
                 : super.ownerOf(tokenId);
     }
 
-    /// @dev EAC view overrides — each translates `anyId` to the canonical EAC resource
-    ///      (via `getResource`) before delegating to the base `EnhancedAccessControl` implementation.
-
     /// @inheritdoc IEnhancedAccessControl
-    function roles(
-        uint256 anyId,
-        address account
-    ) public view override(EnhancedAccessControl, IEnhancedAccessControl) returns (uint256) {
+    function roles(uint256 anyId, address account)
+        public
+        view
+        override(EnhancedAccessControl, IEnhancedAccessControl)
+        returns (uint256)
+    {
         return super.roles(getResource(anyId), account);
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function roleCount(
-        uint256 anyId
-    ) public view override(EnhancedAccessControl, IEnhancedAccessControl) returns (uint256) {
+    function roleCount(uint256 anyId)
+        public
+        view
+        override(EnhancedAccessControl, IEnhancedAccessControl)
+        returns (uint256)
+    {
         return super.roleCount(getResource(anyId));
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function hasRoles(
-        uint256 anyId,
-        uint256 roleBitmap,
-        address account
-    ) public view override(EnhancedAccessControl, IEnhancedAccessControl) returns (bool) {
+    function hasRoles(uint256 anyId, uint256 roleBitmap, address account)
+        public
+        view
+        override(EnhancedAccessControl, IEnhancedAccessControl)
+        returns (bool)
+    {
         return super.hasRoles(getResource(anyId), roleBitmap, account);
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function hasAssignees(
-        uint256 anyId,
-        uint256 roleBitmap
-    ) public view override(EnhancedAccessControl, IEnhancedAccessControl) returns (bool) {
+    function hasAssignees(uint256 anyId, uint256 roleBitmap)
+        public
+        view
+        override(EnhancedAccessControl, IEnhancedAccessControl)
+        returns (bool)
+    {
         return super.hasAssignees(getResource(anyId), roleBitmap);
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function getAssigneeCount(
-        uint256 anyId,
-        uint256 roleBitmap
-    )
+    function getAssigneeCount(uint256 anyId, uint256 roleBitmap)
         public
         view
         override(EnhancedAccessControl, IEnhancedAccessControl)
@@ -401,12 +408,11 @@ contract PermissionedRegistry is
     ////////////////////////////////////////////////////////////////////////
 
     /// @dev Override `ERC1155Singleton._update()` to transfer the roles to the new owner if the token is transferred.
-    function _update(
-        address from,
-        address to,
-        uint256[] memory tokenIds,
-        uint256[] memory amounts
-    ) internal virtual override {
+    function _update(address from, address to, uint256[] memory tokenIds, uint256[] memory amounts)
+        internal
+        virtual
+        override
+    {
         bool externalTransfer = to != address(0) && from != address(0); // skip mint and burn
         if (externalTransfer) {
             // only check ROLE_CAN_TRANSFER_ADMIN on token owner (from)
@@ -433,7 +439,11 @@ contract PermissionedRegistry is
         uint256 /*oldRoles*/,
         uint256 /*newRoles*/,
         uint256 /*roleBitmap*/
-    ) internal virtual override {
+    )
+        internal
+        virtual
+        override
+    {
         _regenerate(resource);
     }
 
@@ -444,7 +454,11 @@ contract PermissionedRegistry is
         uint256 /*oldRoles*/,
         uint256 /*newRoles*/,
         uint256 /*roleBitmap*/
-    ) internal virtual override {
+    )
+        internal
+        virtual
+        override
+    {
         _regenerate(resource);
     }
 
@@ -477,10 +491,13 @@ contract PermissionedRegistry is
     /// @param resource The resource to get settable roles for.
     /// @param account The account to get settable roles for.
     /// @return The settable roles (regular roles only, not admin roles).
-    function _getSettableRoles(
-        uint256 resource,
-        address account
-    ) internal view virtual override returns (uint256) {
+    function _getSettableRoles(uint256 resource, address account)
+        internal
+        view
+        virtual
+        override
+        returns (uint256)
+    {
         uint256 roleBitmap = super._getSettableRoles(resource, account);
         if (resource == ROOT_RESOURCE) {
             return roleBitmap;
@@ -497,10 +514,13 @@ contract PermissionedRegistry is
     ///
     /// Root roles are unaffected.
     ///
-    function _getRevokableRoles(
-        uint256 resource,
-        address account
-    ) internal view virtual override returns (uint256) {
+    function _getRevokableRoles(uint256 resource, address account)
+        internal
+        view
+        virtual
+        override
+        returns (uint256)
+    {
         if (
             resource != ROOT_RESOURCE &&
             ownerOf(_constructTokenId(resource, _entry(resource))) == address(0)
@@ -516,10 +536,11 @@ contract PermissionedRegistry is
     }
 
     /// @dev Assert token is not expired and caller has necessary roles.
-    function _checkExpiryAndTokenRoles(
-        uint256 anyId,
-        uint256 roleBitmap
-    ) internal view returns (uint256 tokenId, Entry storage entry) {
+    function _checkExpiryAndTokenRoles(uint256 anyId, uint256 roleBitmap)
+        internal
+        view
+        returns (uint256 tokenId, Entry storage entry)
+    {
         entry = _entry(anyId);
         tokenId = _constructTokenId(anyId, entry);
         if (_isExpired(entry.expiry)) {
@@ -535,10 +556,7 @@ contract PermissionedRegistry is
 
     /// @dev Create `resource` from parts.
     ///      Returns next resource if expired.
-    function _constructResource(
-        uint256 anyId,
-        Entry storage entry
-    ) internal view returns (uint256) {
+    function _constructResource(uint256 anyId, Entry storage entry) internal view returns (uint256) {
         return LibLabel.withVersion(anyId, entry.eacVersionId);
     }
 

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -457,8 +457,8 @@ contract PermissionedRegistry is
             _burn(owner, tokenId, 1);
             ++entry.tokenVersionId;
             uint256 newTokenId = _constructTokenId(tokenId, entry);
-            _mint(owner, newTokenId, 1, "");
             emit TokenRegenerated(tokenId, newTokenId); // resource is unchanged
+            _mint(owner, newTokenId, 1, "");
         }
     }
 

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -595,6 +595,12 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         testRoles = RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
         uint256 tokenId = this._register();
         StrictERC1155Holder r = new StrictERC1155Holder(false);
+        vm.expectEmit();
+        emit IERC1155.TransferSingle(user1, user1, address(r), tokenId, 1);
+        vm.expectEmit();
+        emit IEnhancedAccessControl.EACRolesChanged(tokenId, user1, testRoles, 0); // revoke (transfer 1/2)
+        vm.expectEmit();
+        emit IEnhancedAccessControl.EACRolesChanged(tokenId, address(r), 0, testRoles); // grant (transfer 2/2)
         vm.prank(user1);
         registry.safeTransferFrom(user1, address(r), tokenId, 1, "");
     }
@@ -602,6 +608,8 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
     function test_safeTransferFrom_noop() external {
         testRoles = RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
         uint256 tokenId = this._register();
+        vm.expectEmit();
+        emit IERC1155.TransferSingle(user1, user1, user2, tokenId, 0);
         vm.recordLogs();
         vm.prank(user1);
         registry.safeTransferFrom(user1, user2, tokenId, 0, "");
@@ -943,6 +951,8 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         testRoles = roleBitmap << 128; // admin
         uint256 tokenId = this._register();
 
+        vm.expectEmit();
+        emit IRegistryEvents.TokenRegenerated(tokenId, tokenId + 1);
         vm.prank(testOwner);
         assertTrue(registry.grantRoles(tokenId, roleBitmap, user2));
     }
@@ -1030,6 +1040,8 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         uint256 tokenId = this._register();
 
         // revoke normal role
+        vm.expectEmit();
+        emit IRegistryEvents.TokenRegenerated(tokenId, tokenId + 1);
         vm.prank(testOwner);
         assertTrue(registry.revokeRoles(tokenId, roleBitmap, testOwner));
 
@@ -1166,6 +1178,69 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         registry.safeTransferFrom(user1, user2, tokenId, 1, "");
     }
 
+    // scenerio: BET-594
+    // if EACRolesChanged is emit after callback execution, it is out of order
+    // 1. role A  is granted => regenerate
+    // 2. callback triggers another action
+    // 3. role B is granted => regenerate (during callback)
+    // 4. EACRolesChanged is emit for B
+    // 5. EACRolesChanged is emit for A
+    function test_reentrantCallbackEventOrdering_grantRoles() external {
+        ReentrantReceiver r = new ReentrantReceiver(registry);
+
+        uint256 role = RegistryRolesLib.ROLE_SET_RESOLVER;
+
+        testOwner = address(r);
+        testRoles = RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN;
+        uint256 tokenId = this._register();
+
+        // make it so we grant another role during callback
+        r.setReceiverCalldata(
+            abi.encodeCall(PermissionedRegistry.grantRoles, (tokenId, role, actor))
+        );
+
+        // grant => burn+mint => grant again
+        vm.expectEmit();
+        emit IEnhancedAccessControl.EACRolesChanged(tokenId, user2, 0, role); // grant 1
+        vm.expectEmit();
+        emit IRegistryEvents.TokenRegenerated(tokenId, tokenId + 1);
+        vm.expectEmit();
+        emit IEnhancedAccessControl.EACRolesChanged(tokenId, actor, 0, role); // grant 2
+        vm.expectEmit();
+        emit IRegistryEvents.TokenRegenerated(tokenId + 1, tokenId + 2);
+        vm.prank(address(r));
+        registry.grantRoles(tokenId, role, user2);
+    }
+
+    // same as above except for revoke
+    function test_reentrantCallbackEventOrdering_revokeRoles() external {
+        ReentrantReceiver r = new ReentrantReceiver(registry);
+
+        uint256 role1 = RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
+        uint256 role2 = RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN;
+
+        testOwner = address(r);
+        testRoles = role1 | role2;
+        uint256 tokenId = this._register();
+
+        // make it so we revoke another role during callback
+        r.setReceiverCalldata(
+            abi.encodeCall(PermissionedRegistry.revokeRoles, (tokenId, role2, testOwner))
+        );
+
+        // revoke => burn+mint => revoke again
+        vm.expectEmit();
+        emit IEnhancedAccessControl.EACRolesChanged(tokenId, testOwner, testRoles, role2); // revoke 1
+        vm.expectEmit();
+        emit IRegistryEvents.TokenRegenerated(tokenId, tokenId + 1);
+        vm.expectEmit();
+        emit IEnhancedAccessControl.EACRolesChanged(tokenId, testOwner, role2, 0); // revoke 2
+        vm.expectEmit();
+        emit IRegistryEvents.TokenRegenerated(tokenId + 1, tokenId + 2);
+        vm.prank(testOwner);
+        registry.revokeRoles(tokenId, role1, testOwner);
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // Internals
     ////////////////////////////////////////////////////////////////////////
@@ -1269,8 +1344,43 @@ contract MockPermissionedRegistry is PermissionedRegistry {
         address ownerAddress,
         uint256 ownerRoles
     ) PermissionedRegistry(hcaFactory, metadata, ownerAddress, ownerRoles) {}
+
     function getEntry(uint256 anyId) external view returns (PermissionedRegistry.Entry memory) {
         return _entry(anyId);
+    }
+}
+
+contract ReentrantReceiver is ERC1155Holder {
+    PermissionedRegistry immutable REGISTRY;
+    bytes _data;
+    constructor(PermissionedRegistry registry) {
+        REGISTRY = registry;
+    }
+    function setReceiverCalldata(bytes calldata data) external {
+        _data = data;
+    }
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 value,
+        bytes memory data
+    ) public override returns (bytes4) {
+        if (from == address(0)) {
+            // during mint(), eg. token regeneration(), mutate the registry
+            bytes memory v = _data;
+            if (v.length > 0) {
+                delete _data; // consume calldata
+                bool ok;
+                (ok, v) = address(REGISTRY).call(v); // execute it
+                if (!ok) {
+                    assembly {
+                        revert(add(v, 32), mload(v)) // propagate
+                    }
+                }
+            }
+        }
+        return super.onERC1155Received(operator, from, id, value, data);
     }
 }
 

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -1180,7 +1180,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
 
     // scenerio: BET-594
     // if EACRolesChanged is emit after callback execution, it is out of order
-    // 1. role A  is granted => regenerate
+    // 1. role A is granted => regenerate
     // 2. callback triggers another action
     // 3. role B is granted => regenerate (during callback)
     // 4. EACRolesChanged is emit for B


### PR DESCRIPTION
- moved `event EnhancedAccessControl.EACRolesChanged` before callbacks
- moved `event PermissionedRegistry.TokenRegenerated` before `_mint()`
- added tests

---

Should I include a test for transfer during callback?