### PR TITLE
Fix `ResolverProfileRewriterLib` memory overflow

### DIFF
--- a/contracts/src/resolver/libraries/ResolverProfileRewriterLib.sol
+++ b/contracts/src/resolver/libraries/ResolverProfileRewriterLib.sol
@@ -10,6 +10,8 @@ pragma solidity >=0.8.13;
 /// the original calldata must be updated with the new node before forwarding to the actual
 /// resolver logic.
 ///
+/// Reverts `Panic(0x32)` if write is out of bounds.
+///
 library ResolverProfileRewriterLib {
     /// @dev Replace the node in the calldata with a new node.
     ///      Supports `multicall()` to arbitrary depth.
@@ -20,25 +22,46 @@ library ResolverProfileRewriterLib {
         bytes calldata call,
         bytes32 newNode
     ) internal pure returns (bytes memory copy) {
+        // 0xac9650d8                                                       // selector
+        // 0000000000000000000000000000000000000000000000000000000000000020 // jump
+        // 0000000000000000000000000000000000000000000000000000000000000002 // .length @ jump
+        // 0000000000000000000000000000000000000000000000000000000000000040 // jump[0]
+        // 00000000000000000000000000000000000000000000000000000000000000a0 // jump[1]
+        // 0000000000000000000000000000000000000000000000000000000000000024 // [0].length @ jump[0]
+        // ...
+        // 0000000000000000000000000000000000000000000000000000000000000024 // [1].length @ jump[1]
+        // ...
         copy = call; // make a copy
         assembly {
-            function replace(ptr, node) {
-                switch shr(224, mload(add(ptr, 32))) // call selector
+            function replace(ptr, bound, node) {
+                ptr := add(ptr, 36) // skip length + selector
+                switch shr(224, mload(sub(ptr, 4))) // read selector
                 case 0xac9650d8 {
                     // multicall(bytes[])
-                    let off := add(ptr, 36)
-                    off := add(off, mload(off))
-                    let size := shl(5, mload(off))
+                    ptr := add(ptr, mload(ptr)) // follow jump
+                    let size := shl(5, mload(ptr)) // read word count as size
                     // prettier-ignore
-                    for { } size { size := sub(size, 32) } {
-                        replace(add(add(off, 32), mload(add(off, size))), node)
+                    for { } size { size := sub(size, 32) } { // backwards
+                        let p := mload(add(ptr, size)) // jump[i]
+                        p := add(add(ptr, 32), p) // local ptr
+                        let b := add(p, mload(p)) // local bound w/room for 1 word
+                        if lt(bound, b) {
+                            b := bound // global bound is smaller
+                        }
+                        replace(p, b, node)
                     }
                 }
                 default {
-                    mstore(add(ptr, 36), node) // replace node
+                    // only bound checks on write
+                    if lt(bound, ptr) {
+                        mstore(0, 0x4e487b71) // error Panic(uint256)
+                        mstore(32, 0x32) // code
+                        revert(28, 36) // 32-4, 4+32
+                    }
+                    mstore(ptr, node) // replace node
                 }
             }
-            replace(copy, newNode)
+            replace(copy, add(copy, mload(copy)), newNode) // bound w/room for 1 word
         }
     }
 }

--- a/contracts/src/resolver/libraries/ResolverProfileRewriterLib.sol
+++ b/contracts/src/resolver/libraries/ResolverProfileRewriterLib.sol
@@ -10,8 +10,6 @@ pragma solidity >=0.8.13;
 /// the original calldata must be updated with the new node before forwarding to the actual
 /// resolver logic.
 ///
-/// Reverts `Panic(0x32)` if write is out of bounds.
-///
 library ResolverProfileRewriterLib {
     /// @dev Replace the node in the calldata with a new node.
     ///      Supports `multicall()` to arbitrary depth.
@@ -54,9 +52,10 @@ library ResolverProfileRewriterLib {
                 default {
                     // only bound checks on write
                     if lt(bound, ptr) {
-                        mstore(0, 0x4e487b71) // error Panic(uint256)
-                        mstore(32, 0x32) // code
-                        revert(28, 36) // 32-4, 4+32
+                        // mstore(0, 0x4e487b71) // error Panic(uint256)
+                        // mstore(32, 0x32) // code
+                        // revert(28, 36) // 32-4, 4+32
+                        leave
                     }
                     mstore(ptr, node) // replace node
                 }

--- a/contracts/test/unit/resolver/libraries/ResolverProfileRewriterLib.t.sol
+++ b/contracts/test/unit/resolver/libraries/ResolverProfileRewriterLib.t.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.13;
 
 // solhint-disable no-console, private-vars-leading-underscore, state-visibility, func-name-mixedcase, contracts-v2/ordering, one-contract-per-file
 
-import {Test, console, stdError} from "forge-std/Test.sol";
+import {Test, stdError} from "forge-std/Test.sol";
 
 import {IMulticallable} from "@ens/contracts/resolvers/IMulticallable.sol";
 import {IAddressResolver} from "@ens/contracts/resolvers/profiles/IAddressResolver.sol";

--- a/contracts/test/unit/resolver/libraries/ResolverProfileRewriterLib.t.sol
+++ b/contracts/test/unit/resolver/libraries/ResolverProfileRewriterLib.t.sol
@@ -3,42 +3,38 @@ pragma solidity >=0.8.13;
 
 // solhint-disable no-console, private-vars-leading-underscore, state-visibility, func-name-mixedcase, contracts-v2/ordering, one-contract-per-file
 
-import {Test} from "forge-std/Test.sol";
+import {Test, console, stdError} from "forge-std/Test.sol";
 
 import {IMulticallable} from "@ens/contracts/resolvers/IMulticallable.sol";
 import {IAddressResolver} from "@ens/contracts/resolvers/profiles/IAddressResolver.sol";
 
-import {
-    ResolverProfileRewriterLib
-} from "~src/resolver/libraries/ResolverProfileRewriterLib.sol";
+import {ResolverProfileRewriterLib} from "~src/resolver/libraries/ResolverProfileRewriterLib.sol";
 
 contract ResolverProfileRewriterLibTest is Test {
-    function replaceNode(bytes calldata call, bytes32 node) public pure returns (bytes memory) {
+    function replaceNode(bytes calldata call, bytes32 node) external pure returns (bytes memory) {
         return ResolverProfileRewriterLib.replaceNode(call, node);
     }
 
-    function drop4(bytes calldata v) public pure returns (bytes memory) {
+    function drop4(bytes calldata v) external pure returns (bytes memory) {
         return v[4:];
     }
 
-    function testFuzz_replaceNode_call(bytes32 node, uint256 coinType) external view {
-        (bytes32 x, uint256 c) = abi.decode(
+    function resolverProfile(bytes32) external {}
+
+    function testFuzz_replaceNode_call(bytes32 node) external view {
+        bytes32 x = abi.decode(
             this.drop4(
-                this.replaceNode(
-                    abi.encodeCall(IAddressResolver.addr, (keccak256("a"), coinType)),
-                    node
-                )
+                this.replaceNode(abi.encodeCall(this.resolverProfile, (keccak256("a"))), node)
             ),
-            (bytes32, uint256)
+            (bytes32)
         );
         assertEq(x, node, "node");
-        assertEq(c, coinType, "coinType");
     }
 
     function testFuzz_replaceNode_multicall(bytes32 node, uint8 calls) external view {
         bytes[] memory m = new bytes[](calls);
         for (uint256 i; i < calls; i++) {
-            m[i] = abi.encodeCall(IAddressResolver.addr, (keccak256("a"), i));
+            m[i] = abi.encodeCall(this.resolverProfile, (keccak256("a")));
         }
         m = abi.decode(
             this.drop4(this.replaceNode(abi.encodeCall(IMulticallable.multicall, (m)), node)),
@@ -46,9 +42,50 @@ contract ResolverProfileRewriterLibTest is Test {
         );
         assertEq(m.length, calls, "count");
         for (uint256 i; i < calls; i++) {
-            (bytes32 x, uint256 c) = abi.decode(this.drop4(m[i]), (bytes32, uint256));
+            bytes32 x = abi.decode(this.drop4(m[i]), (bytes32));
             assertEq(x, node, "node");
-            assertEq(c, i, "coinType");
         }
+    }
+
+    function testFuzz_replaceNode_nestedMulticall(bytes32 node, uint8 depth) external view {
+        vm.assume(depth < 10);
+        bytes memory v = abi.encodeCall(this.resolverProfile, (keccak256("a")));
+        bytes[] memory m = new bytes[](1);
+        for (uint256 i; i < depth; ++i) {
+            m[0] = v;
+            v = abi.encodeCall(IMulticallable.multicall, (m));
+        }
+        v = this.replaceNode(v, node);
+        for (uint256 i; i < depth; ++i) {
+            m = abi.decode(this.drop4(v), (bytes[]));
+            v = m[0];
+        }
+        bytes32 x = abi.decode(this.drop4(v), (bytes32));
+        assertEq(x, node, "node");
+    }
+
+    function test_replaceNode_call_outOfBounds() external {
+        this.replaceNode(new bytes(36), bytes32(0)); // min
+        vm.expectRevert(stdError.indexOOBError);
+        this.replaceNode(new bytes(35), bytes32(0)); // min-1
+    }
+
+    function test_replaceNode_multicall_outOfBounds() external {
+        bytes[] memory m = new bytes[](1);
+        m[0] = new bytes(36); // min from above
+        this.replaceNode(abi.encodeCall(IMulticallable.multicall, (m)), bytes32(0));
+
+        // malicious array[0] start
+        bytes memory v = abi.encodeCall(IMulticallable.multicall, (m));
+        assembly {
+            mstore(add(v, 100), mload(v))
+        }
+        vm.expectRevert(stdError.indexOOBError);
+        this.replaceNode(v, bytes32(0));
+
+        // malicious array[0] size
+        m[0] = new bytes(35); // min-1 from above
+        vm.expectRevert(stdError.indexOOBError);
+        this.replaceNode(abi.encodeCall(IMulticallable.multicall, (m)), bytes32(0));
     }
 }

--- a/contracts/test/unit/resolver/libraries/ResolverProfileRewriterLib.t.sol
+++ b/contracts/test/unit/resolver/libraries/ResolverProfileRewriterLib.t.sol
@@ -1,16 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-// solhint-disable no-console, private-vars-leading-underscore, state-visibility, func-name-mixedcase, contracts-v2/ordering, one-contract-per-file
-
 import {Test, stdError} from "forge-std/Test.sol";
 
 import {IMulticallable} from "@ens/contracts/resolvers/IMulticallable.sol";
-import {IAddressResolver} from "@ens/contracts/resolvers/profiles/IAddressResolver.sol";
 
 import {ResolverProfileRewriterLib} from "~src/resolver/libraries/ResolverProfileRewriterLib.sol";
 
 contract ResolverProfileRewriterLibTest is Test {
+    bytes vMin = abi.encodeCall(this.resolverProfile, bytes32(0)); // 36 bytes
+    bytes vBad = new bytes(vMin.length - 1);
+
+    function resolverProfile(bytes32) external {}
+
     function replaceNode(bytes calldata call, bytes32 node) external pure returns (bytes memory) {
         return ResolverProfileRewriterLib.replaceNode(call, node);
     }
@@ -19,16 +21,24 @@ contract ResolverProfileRewriterLibTest is Test {
         return v[4:];
     }
 
-    function resolverProfile(bytes32) external {}
-
     function testFuzz_replaceNode_call(bytes32 node) external view {
-        bytes32 x = abi.decode(
-            this.drop4(
-                this.replaceNode(abi.encodeCall(this.resolverProfile, (keccak256("a"))), node)
+        assertEq(
+            abi.decode(
+                this.drop4(
+                    this.replaceNode(abi.encodeCall(this.resolverProfile, (keccak256("a"))), node)
+                ),
+                (bytes32)
             ),
-            (bytes32)
+            node
         );
-        assertEq(x, node, "node");
+    }
+
+    function test_replaceNode_call_smallestWrite(bytes32 node) external view {
+        assertEq(bytes32(this.drop4(this.replaceNode(vMin, node))), node);
+    }
+
+    function test_replaceNode_call_outOfBounds(bytes32 node) external view {
+        assertEq(this.replaceNode(vBad, node), vBad); // unchanged
     }
 
     function testFuzz_replaceNode_multicall(bytes32 node, uint8 calls) external view {
@@ -40,11 +50,46 @@ contract ResolverProfileRewriterLibTest is Test {
             this.drop4(this.replaceNode(abi.encodeCall(IMulticallable.multicall, (m)), node)),
             (bytes[])
         );
-        assertEq(m.length, calls, "count");
+        assertEq(m.length, calls);
         for (uint256 i; i < calls; i++) {
-            bytes32 x = abi.decode(this.drop4(m[i]), (bytes32));
-            assertEq(x, node, "node");
+            assertEq(abi.decode(this.drop4(m[i]), (bytes32)), node);
         }
+    }
+
+    function test_replaceNode_multicall_smallestWrite(bytes32 node) external view {
+        bytes[] memory m = new bytes[](1);
+        m[0] = vMin;
+        m = abi.decode(
+            this.drop4(this.replaceNode(abi.encodeCall(IMulticallable.multicall, (m)), node)),
+            (bytes[])
+        );
+        assertEq(bytes32(this.drop4(m[0])), node);
+    }
+
+    function test_replaceNode_multicall_outOfBounds(bytes32 node) external view {
+        bytes[] memory m = new bytes[](1);
+        m[0] = vBad;
+        bytes memory v0 = abi.encodeCall(IMulticallable.multicall, (m));
+        bytes memory v = this.replaceNode(v0, node);
+        assertEq(v0, v); // unchanged
+    }
+
+    function test_replaceNode_multicall_outOfBounds_arrayStart(bytes32 node) external view {
+        bytes[] memory m = new bytes[](1);
+        m[0] = vMin;
+        bytes memory v0 = abi.encodeCall(IMulticallable.multicall, (m));
+        uint256 offset = 100; // offset of first element
+        uint256 save;
+        bytes memory v = abi.encodePacked(v0);
+        assembly {
+            save := mload(add(v, offset))
+            mstore(add(v, offset), mload(v)) // mangle
+        }
+        v = this.replaceNode(v, node);
+        assembly {
+            mstore(add(v, offset), save) // unmangle
+        }
+        assertEq(v0, v); // unchanged
     }
 
     function testFuzz_replaceNode_nestedMulticall(bytes32 node, uint8 depth) external view {
@@ -60,32 +105,6 @@ contract ResolverProfileRewriterLibTest is Test {
             m = abi.decode(this.drop4(v), (bytes[]));
             v = m[0];
         }
-        bytes32 x = abi.decode(this.drop4(v), (bytes32));
-        assertEq(x, node, "node");
-    }
-
-    function test_replaceNode_call_outOfBounds() external {
-        this.replaceNode(new bytes(36), bytes32(0)); // min
-        vm.expectRevert(stdError.indexOOBError);
-        this.replaceNode(new bytes(35), bytes32(0)); // min-1
-    }
-
-    function test_replaceNode_multicall_outOfBounds() external {
-        bytes[] memory m = new bytes[](1);
-        m[0] = new bytes(36); // min from above
-        this.replaceNode(abi.encodeCall(IMulticallable.multicall, (m)), bytes32(0));
-
-        // malicious array[0] start
-        bytes memory v = abi.encodeCall(IMulticallable.multicall, (m));
-        assembly {
-            mstore(add(v, 100), mload(v))
-        }
-        vm.expectRevert(stdError.indexOOBError);
-        this.replaceNode(v, bytes32(0));
-
-        // malicious array[0] size
-        m[0] = new bytes(35); // min-1 from above
-        vm.expectRevert(stdError.indexOOBError);
-        this.replaceNode(abi.encodeCall(IMulticallable.multicall, (m)), bytes32(0));
+        assertEq(abi.decode(this.drop4(v), (bytes32)), node);
     }
 }


### PR DESCRIPTION
- fixed `ResolverProfileRewriterLib.replaceNode()`
     * avoids writing if out of bounds
- added tests for malicious calldata