### PR TITLE
Fix revoke of fine-grained `PermissionedResolver` roles

### DIFF
--- a/contracts/src/access-control/EnhancedAccessControl.sol
+++ b/contracts/src/access-control/EnhancedAccessControl.sol
@@ -409,9 +409,8 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         uint256 resource,
         address account
     ) internal view virtual returns (uint256) {
-        uint256 adminRoleBitmap = (_roles[resource][account] | _roles[ROOT_RESOURCE][account]) &
-            EACBaseRolesLib.ADMIN_ROLES;
-        return (adminRoleBitmap >> 128) | adminRoleBitmap;
+        uint256 roleBitmap = (_roles[resource][account] | _roles[ROOT_RESOURCE][account]) >> 128;
+        return (roleBitmap << 128) | roleBitmap;
     }
 
     /// @dev Returns the revokable roles for `account` within `resource`.
@@ -425,10 +424,8 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         uint256 resource,
         address account
     ) internal view virtual returns (uint256) {
-        uint256 adminRoleBitmap = (_roles[resource][account] | _roles[ROOT_RESOURCE][account]) &
-            EACBaseRolesLib.ADMIN_ROLES;
-        uint256 regularRoles = adminRoleBitmap >> 128;
-        return regularRoles | adminRoleBitmap;
+        uint256 roleBitmap = (_roles[resource][account] | _roles[ROOT_RESOURCE][account]) >> 128;
+        return (roleBitmap << 128) | roleBitmap;
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/src/resolver/PermissionedResolver.sol
+++ b/contracts/src/resolver/PermissionedResolver.sol
@@ -6,6 +6,7 @@ import {IABIResolver} from "@ens/contracts/resolvers/profiles/IABIResolver.sol";
 import {IAddressResolver} from "@ens/contracts/resolvers/profiles/IAddressResolver.sol";
 import {IAddrResolver} from "@ens/contracts/resolvers/profiles/IAddrResolver.sol";
 import {IContentHashResolver} from "@ens/contracts/resolvers/profiles/IContentHashResolver.sol";
+import {IDataResolver} from "@ens/contracts/resolvers/profiles/IDataResolver.sol";
 import {IExtendedResolver} from "@ens/contracts/resolvers/profiles/IExtendedResolver.sol";
 import {IHasAddressResolver} from "@ens/contracts/resolvers/profiles/IHasAddressResolver.sol";
 import {IInterfaceResolver} from "@ens/contracts/resolvers/profiles/IInterfaceResolver.sol";
@@ -48,7 +49,7 @@ import {ResolverProfileRewriterLib} from "./libraries/ResolverProfileRewriterLib
 /// - ENSIP-8: interfaceImplementer()
 /// - ENSIP-9 / EIP-2304: addr(coinType)
 /// - ENSIP-19: addr(default)
-/// - ENSIP-24: data(key) --- TODO
+/// - ENSIP-24: data(key)
 /// - IERC7996: supportsFeature()
 /// - IVersionableResolver: version()
 /// - IHasAddrResolver: hasAddr()
@@ -69,8 +70,9 @@ import {ResolverProfileRewriterLib} from "./libraries/ResolverProfileRewriterLib
 ///
 /// Fine-grained Permissions:
 ///
-/// `setText(key)` can be restricted to a key using: `part = textPart(<key>)`.
-/// `setAddr(coinType)` can be restricted to a coinType using: `part = addrPart(<coinType>)`.
+/// `setText(key)` can be restricted to a key using: `part = partHash(<key>)`.
+/// `setData(key)` can be restricted to a key using: `part = partHash(<key>)`.
+/// `setAddr(coinType)` can be restricted to a coinType using: `part = partHash(<coinType>)`.
 ///
 /// Setters with `node` check (4) EAC resources:
 ///                                           Parts
@@ -93,6 +95,7 @@ contract PermissionedResolver is
     IAddrResolver,
     IAddressResolver,
     IContentHashResolver,
+    IDataResolver,
     IHasAddressResolver,
     IInterfaceResolver,
     INameResolver,
@@ -110,7 +113,8 @@ contract PermissionedResolver is
         string name;
         mapping(uint256 coinType => bytes addressBytes) addresses;
         mapping(string key => string value) texts;
-        mapping(uint256 contentType => bytes data) abis;
+        mapping(string key => bytes value) datas;
+        mapping(uint256 contentType => bytes value) abis;
         mapping(bytes4 interfaceId => address implementer) interfaces;
     }
 
@@ -146,6 +150,18 @@ contract PermissionedResolver is
         string key
     );
 
+    /// @notice Associate an EAC resource with a name and specific `data(key)` record.
+    /// @param resource The EAC resource.
+    /// @param name The name.
+    /// @param keyHash The hash of the key.
+    /// @param key The key.
+    event NamedDataResource(
+        uint256 indexed resource,
+        bytes name,
+        bytes32 indexed keyHash,
+        string key
+    );
+
     /// @notice Associate an EAC resource with a name and specific `addr(coinType)` record.
     /// @param resource The EAC resource.
     /// @param name The name.
@@ -159,8 +175,9 @@ contract PermissionedResolver is
     modifier onlyPartRoles(bytes32 node, bytes32 part, uint256 roleBitmap) {
         address sender = _msgSender();
         if (
-            !hasRoles(PermissionedResolverLib.resource(node, part), roleBitmap, sender) &&
-            !hasRoles(PermissionedResolverLib.resource(0, part), roleBitmap, sender)
+            part == bytes32(0) ||
+            (!hasRoles(PermissionedResolverLib.resource(node, part), roleBitmap, sender) &&
+                !hasRoles(PermissionedResolverLib.resource(0, part), roleBitmap, sender))
         ) {
             _checkRoles(PermissionedResolverLib.resource(node, 0), roleBitmap, sender); // reverts using "widest" resource
         }
@@ -190,6 +207,7 @@ contract PermissionedResolver is
             type(IAddrResolver).interfaceId == interfaceId ||
             type(IAddressResolver).interfaceId == interfaceId ||
             type(IContentHashResolver).interfaceId == interfaceId ||
+            type(IDataResolver).interfaceId == interfaceId ||
             type(IHasAddressResolver).interfaceId == interfaceId ||
             type(IInterfaceResolver).interfaceId == interfaceId ||
             type(INameResolver).interfaceId == interfaceId ||
@@ -236,22 +254,31 @@ contract PermissionedResolver is
         emit AliasChanged(fromName, toName, fromName, toName);
     }
 
-    /// @notice Grant `roleBitmap` permissions to `account` for `toName`.
+    /// @notice Authorize `roleBitmap` permissions to `account` for `toName`.
     ///         Use `NameCoder.encode("")` for any name, which is equivalent to `grantRootRoles()`.
-    /// @param toName The name to grant roles for.
-    /// @param roleBitmap The roles to grant.
-    /// @param account The account to grant roles to.
+    /// @param toName The name to authorize roles for.
+    /// @param roleBitmap The roles to authorize.
+    /// @param account The account to authorize roles to.
+    /// @param grant If `true`, grants, otherwise, revokes.
     /// @return success Whether the roles were updated.
-    function grantNameRoles(
+    function authorizeNameRoles(
         bytes calldata toName,
         uint256 roleBitmap,
-        address account
+        address account,
+        bool grant
     ) external returns (bool) {
         bytes32 node = NameCoder.namehash(toName, 0);
         uint256 resource = PermissionedResolverLib.resource(node, 0);
-        _checkCanGrantRoles(resource, roleBitmap, _msgSender());
-        emit NamedResource(resource, toName);
-        return _grantRoles(resource, roleBitmap, account, true);
+        if (grant) {
+            _checkCanGrantRoles(resource, roleBitmap, _msgSender());
+            if (resource != ROOT_RESOURCE && roleCount(resource) == 0) {
+                emit NamedResource(resource, toName);
+            }
+            return _grantRoles(resource, roleBitmap, account, true);
+        } else {
+            _checkCanRevokeRoles(resource, roleBitmap, _msgSender());
+            return _revokeRoles(resource, roleBitmap, account, true);
+        }
     }
 
     /// @notice Authorize `setText(key)` permission to `account` for `toName`.
@@ -272,7 +299,7 @@ contract PermissionedResolver is
         uint256 nodeResource = PermissionedResolverLib.resource(node, bytes32(0));
         uint256 partResource = PermissionedResolverLib.resource(
             node,
-            PermissionedResolverLib.textPart(key)
+            PermissionedResolverLib.partHash(key)
         );
         if (grant) {
             _checkCanGrantRoles(nodeResource, roleBit, _msgSender());
@@ -286,10 +313,42 @@ contract PermissionedResolver is
         }
     }
 
+    /// @notice Authorize `setData(key)` permission to `account` for `toName`.
+    ///         Use `NameCoder.encode("")` for any name.
+    /// @param toName The name to authorize roles for.
+    /// @param key The data key to authorize roles for.
+    /// @param account The account to authorize roles to.
+    /// @param grant If `true`, grants, otherwise, revokes.
+    /// @return `true` if the roles were updated.
+    function authorizeDataRoles(
+        bytes calldata toName,
+        string calldata key,
+        address account,
+        bool grant
+    ) external returns (bool) {
+        bytes32 node = NameCoder.namehash(toName, 0);
+        uint256 roleBit = PermissionedResolverLib.ROLE_SET_DATA;
+        uint256 nodeResource = PermissionedResolverLib.resource(node, bytes32(0));
+        uint256 partResource = PermissionedResolverLib.resource(
+            node,
+            PermissionedResolverLib.partHash(key)
+        );
+        if (grant) {
+            _checkCanGrantRoles(nodeResource, roleBit, _msgSender());
+            if (roleCount(partResource) == 0) {
+                emit NamedDataResource(partResource, toName, keccak256(bytes(key)), key);
+            }
+            return _grantRoles(partResource, roleBit, account, true);
+        } else {
+            _checkCanRevokeRoles(nodeResource, roleBit, _msgSender());
+            return _revokeRoles(partResource, roleBit, account, true);
+        }
+    }
+
     /// @notice Authorize `setAddr(coinType)` permission to `account` for `toName`.
     ///         Use `NameCoder.encode("")` for any name.
     /// @param toName The name to authorize roles for.
-    /// @param coinType The coin type to granauthorizet roles for.
+    /// @param coinType The coin type to authorize roles for.
     /// @param account The account to authorize roles to.
     /// @param grant If `true`, grants, otherwise, revokes.
     /// @return updated `true` if the roles were updated.
@@ -304,7 +363,7 @@ contract PermissionedResolver is
         uint256 nodeResource = PermissionedResolverLib.resource(node, bytes32(0));
         uint256 partResource = PermissionedResolverLib.resource(
             node,
-            PermissionedResolverLib.addrPart(coinType)
+            PermissionedResolverLib.partHash(coinType)
         );
         if (grant) {
             _checkCanGrantRoles(nodeResource, roleBit, _msgSender());
@@ -321,16 +380,16 @@ contract PermissionedResolver is
     /// @notice Set ABI data of the associated ENS node.
     /// @param node The node to update.
     /// @param contentType The content type of the ABI.
-    /// @param data The ABI data.
+    /// @param value The ABI data.
     function setABI(
         bytes32 node,
         uint256 contentType,
-        bytes calldata data
+        bytes calldata value
     ) external onlyPartRoles(node, 0, PermissionedResolverLib.ROLE_SET_ABI) {
         if (!_isPowerOf2(contentType)) {
             revert InvalidContentType(contentType);
         }
-        _record(node).abis[contentType] = data;
+        _record(node).abis[contentType] = value;
         emit ABIChanged(node, contentType);
     }
 
@@ -351,6 +410,26 @@ contract PermissionedResolver is
     ) external onlyPartRoles(node, 0, PermissionedResolverLib.ROLE_SET_CONTENTHASH) {
         _record(node).contenthash = hash;
         emit ContenthashChanged(node, hash);
+    }
+
+    /// @notice Set the data for `key` of the associated ENS node.
+    /// @param node The node to update.
+    /// @param key The data key.
+    /// @param value The data value.
+    function setData(
+        bytes32 node,
+        string calldata key,
+        bytes calldata value
+    )
+        external
+        onlyPartRoles(
+            node,
+            PermissionedResolverLib.partHash(key),
+            PermissionedResolverLib.ROLE_SET_DATA
+        )
+    {
+        _record(node).datas[key] = value;
+        emit DataChanged(node, key, key, value);
     }
 
     /// @notice Set an interface of the associated ENS node.
@@ -402,7 +481,7 @@ contract PermissionedResolver is
         external
         onlyPartRoles(
             node,
-            PermissionedResolverLib.textPart(key),
+            PermissionedResolverLib.partHash(key),
             PermissionedResolverLib.ROLE_SET_TEXT
         )
     {
@@ -473,13 +552,13 @@ contract PermissionedResolver is
     function ABI(
         bytes32 node,
         uint256 contentTypes
-    ) external view returns (uint256 contentType, bytes memory data) {
+    ) external view returns (uint256 contentType, bytes memory value) {
         Record storage R = _record(node);
         for (contentType = 1; contentType > 0 && contentType <= contentTypes; contentType <<= 1) {
             if ((contentType & contentTypes) != 0) {
-                data = R.abis[contentType];
-                if (data.length > 0) {
-                    return (contentType, data);
+                value = R.abis[contentType];
+                if (value.length > 0) {
+                    return (contentType, value);
                 }
             }
         }
@@ -494,6 +573,11 @@ contract PermissionedResolver is
     /// @inheritdoc IContentHashResolver
     function contenthash(bytes32 node) external view returns (bytes memory) {
         return _record(node).contenthash;
+    }
+
+    /// @inheritdoc IDataResolver
+    function data(bytes32 node, string calldata key) external view returns (bytes memory) {
+        return _record(node).datas[key];
     }
 
     /// @inheritdoc IInterfaceResolver
@@ -558,7 +642,7 @@ contract PermissionedResolver is
         public
         onlyPartRoles(
             node,
-            PermissionedResolverLib.addrPart(coinType),
+            PermissionedResolverLib.partHash(coinType),
             PermissionedResolverLib.ROLE_SET_ADDR
         )
     {
@@ -602,7 +686,7 @@ contract PermissionedResolver is
         }
     }
 
-    /// @notice Function is disabled.  Use `grant(Name|Text|Addr)Roles()` instead.
+    /// @notice Function is disabled.  Use `authorize(Name|Text|Addr)Roles()` instead.
     /// @param resource Ignored.
     /// @param roleBitmap Ignored.
     /// @param account Ignored.
@@ -613,6 +697,19 @@ contract PermissionedResolver is
         address account
     ) public pure override(EnhancedAccessControl, IEnhancedAccessControl) returns (bool) {
         revert EACCannotGrantRoles(resource, roleBitmap, account);
+    }
+
+    /// @notice Function is disabled.  Use `authorize(Name|Text|Addr)Roles()` instead.
+    /// @param resource Ignored.
+    /// @param roleBitmap Ignored.
+    /// @param account Ignored.
+    /// @return success Ignored, always reverts.
+    function revokeRoles(
+        uint256 resource,
+        uint256 roleBitmap,
+        address account
+    ) public pure override(EnhancedAccessControl, IEnhancedAccessControl) returns (bool) {
+        revert EACCannotRevokeRoles(resource, roleBitmap, account);
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/src/resolver/PermissionedResolver.sol
+++ b/contracts/src/resolver/PermissionedResolver.sol
@@ -70,14 +70,20 @@ import {ResolverProfileRewriterLib} from "./libraries/ResolverProfileRewriterLib
 ///
 /// Fine-grained Permissions:
 ///
-/// `setText(key)` can be restricted to a key using: `part = partHash(<key>)`.
-/// `setData(key)` can be restricted to a key using: `part = partHash(<key>)`.
-/// `setAddr(coinType)` can be restricted to a coinType using: `part = partHash(<coinType>)`.
+/// * `setText(key)` can be permissioned with `authorizeTextRoles()`
+///    - caller requires `ROLE_SET_TEXT_ADMIN` on `resource(<namehash>, 0)`
+///    - `ROLE_SET_TEXT` is authorized on `resource(<namehash>, <part>)`
+/// * `setData(key)` can be permissioned with `authorizeDataRoles()`
+///    - caller requires `ROLE_SET_DATA_ADMIN` on `resource(<namehash>, 0)`
+///    - `ROLE_SET_DATA` is authorized on `resource(<namehash>, <part>)`
+/// * `setAddr(coinType)` can be permissioned with `authorizeAddrRoles()`
+///    - caller requires `ROLE_SET_ADDR_ADMIN` on `resource(<namehash>, 0)`
+///    - `ROLE_SET_ADDR` is authorized on `resource(<namehash>, <part>)`
 ///
 /// Setters with `node` check (4) EAC resources:
 ///                                           Parts
 ///        Resources      +-----------------------------+------------------------------+
-///               |           Any (*)           |         Specific (1)         |
+///                       |           Any (*)           |         Specific (1)         |
 ///        +--------------+-----------------------------+------------------------------+
 ///        |      Any (*) |       resource(0, 0)        |      resource(0, <part>)     |
 ///  Names |--------------+-----------------------------+------------------------------+

--- a/contracts/src/resolver/PermissionedResolver.sol
+++ b/contracts/src/resolver/PermissionedResolver.sol
@@ -254,54 +254,68 @@ contract PermissionedResolver is
         return _grantRoles(resource, roleBitmap, account, true);
     }
 
-    /// @notice Grant `setText(key)` permission to `account` for `toName`.
+    /// @notice Authorize `setText(key)` permission to `account` for `toName`.
     ///         Use `NameCoder.encode("")` for any name.
-    /// @param toName The name to grant roles for.
-    /// @param key The text key to grant roles for.
-    /// @param account The account to grant roles to.
-    /// @return success Whether the roles were updated.
-    function grantTextRoles(
+    /// @param toName The name to authorize roles for.
+    /// @param key The text key to authorize roles for.
+    /// @param account The account to authorize roles to.
+    /// @param grant If `true`, grants, otherwise, revokes.
+    /// @return `true` if the roles were updated.
+    function authorizeTextRoles(
         bytes calldata toName,
         string calldata key,
-        address account
+        address account,
+        bool grant
     ) external returns (bool) {
         bytes32 node = NameCoder.namehash(toName, 0);
-        _checkCanGrantRoles(
-            PermissionedResolverLib.resource(node, 0),
-            PermissionedResolverLib.ROLE_SET_TEXT,
-            _msgSender()
-        );
-        uint256 resource = PermissionedResolverLib.resource(
+        uint256 roleBit = PermissionedResolverLib.ROLE_SET_TEXT;
+        uint256 nodeResource = PermissionedResolverLib.resource(node, bytes32(0));
+        uint256 partResource = PermissionedResolverLib.resource(
             node,
             PermissionedResolverLib.textPart(key)
         );
-        emit NamedTextResource(resource, toName, keccak256(bytes(key)), key);
-        return _grantRoles(resource, PermissionedResolverLib.ROLE_SET_TEXT, account, true);
+        if (grant) {
+            _checkCanGrantRoles(nodeResource, roleBit, _msgSender());
+            if (roleCount(partResource) == 0) {
+                emit NamedTextResource(partResource, toName, keccak256(bytes(key)), key);
+            }
+            return _grantRoles(partResource, roleBit, account, true);
+        } else {
+            _checkCanRevokeRoles(nodeResource, roleBit, _msgSender());
+            return _revokeRoles(partResource, roleBit, account, true);
+        }
     }
 
-    /// @notice Grant `setAddr(coinType)` permission to `account` for `toName`.
+    /// @notice Authorize `setAddr(coinType)` permission to `account` for `toName`.
     ///         Use `NameCoder.encode("")` for any name.
-    /// @param toName The name to grant roles for.
-    /// @param coinType The coin type to grant roles for.
-    /// @param account The account to grant roles to.
-    /// @return success Whether the roles were updated.
-    function grantAddrRoles(
+    /// @param toName The name to authorize roles for.
+    /// @param coinType The coin type to granauthorizet roles for.
+    /// @param account The account to authorize roles to.
+    /// @param grant If `true`, grants, otherwise, revokes.
+    /// @return updated `true` if the roles were updated.
+    function authorizeAddrRoles(
         bytes calldata toName,
         uint256 coinType,
-        address account
-    ) external returns (bool) {
+        address account,
+        bool grant
+    ) external returns (bool updated) {
         bytes32 node = NameCoder.namehash(toName, 0);
-        _checkCanGrantRoles(
-            PermissionedResolverLib.resource(node, 0),
-            PermissionedResolverLib.ROLE_SET_ADDR,
-            _msgSender()
-        );
-        uint256 resource = PermissionedResolverLib.resource(
+        uint256 roleBit = PermissionedResolverLib.ROLE_SET_ADDR;
+        uint256 nodeResource = PermissionedResolverLib.resource(node, bytes32(0));
+        uint256 partResource = PermissionedResolverLib.resource(
             node,
             PermissionedResolverLib.addrPart(coinType)
         );
-        emit NamedAddrResource(resource, toName, coinType);
-        return _grantRoles(resource, PermissionedResolverLib.ROLE_SET_ADDR, account, true);
+        if (grant) {
+            _checkCanGrantRoles(nodeResource, roleBit, _msgSender());
+            if (roleCount(partResource) == 0) {
+                emit NamedAddrResource(partResource, toName, coinType);
+            }
+            return _grantRoles(partResource, roleBit, account, true);
+        } else {
+            _checkCanRevokeRoles(nodeResource, roleBit, _msgSender());
+            return _revokeRoles(partResource, roleBit, account, true);
+        }
     }
 
     /// @notice Set ABI data of the associated ENS node.

--- a/contracts/src/resolver/libraries/PermissionedResolverLib.sol
+++ b/contracts/src/resolver/libraries/PermissionedResolverLib.sol
@@ -3,54 +3,54 @@ pragma solidity >=0.8.13;
 
 /// @dev Roles for PermissionedResolver.
 library PermissionedResolverLib {
-    /// @dev Nybble 0 — authorizes setting address records. Root or name.
+    /// @dev Nybble 0: authorizes setting address records. Root or name.
     uint256 internal constant ROLE_SET_ADDR = 1 << 0;
-    /// @dev Nybble 32 — authorizes setting ROLE_SET_ADDR.
+    /// @dev Nybble 32: authorizes setting ROLE_SET_ADDR.
     uint256 internal constant ROLE_SET_ADDR_ADMIN = ROLE_SET_ADDR << 128;
 
-    /// @dev Nybble 1 — authorizes setting text records. Root or name.
+    /// @dev Nybble 1: authorizes setting text records. Root or name.
     uint256 internal constant ROLE_SET_TEXT = 1 << 4;
-    /// @dev Nybble 33 - authorizes setting ROLE_SET_TEXT.
+    /// @dev Nybble 33: authorizes setting ROLE_SET_TEXT.
     uint256 internal constant ROLE_SET_TEXT_ADMIN = ROLE_SET_TEXT << 128;
 
-    /// @dev Nybble 2 — authorizes setting the contenthash record. Root or name.
+    /// @dev Nybble 2: authorizes setting the contenthash record. Root or name.
     uint256 internal constant ROLE_SET_CONTENTHASH = 1 << 8;
-    /// @dev Nybble 34 - authorizes setting ROLE_SET_CONTENTHASH.
+    /// @dev Nybble 34: authorizes setting ROLE_SET_CONTENTHASH.
     uint256 internal constant ROLE_SET_CONTENTHASH_ADMIN = ROLE_SET_CONTENTHASH << 128;
 
-    /// @dev Nybble 3 — authorizes setting the public key record. Root or name.
+    /// @dev Nybble 3: authorizes setting the public key record. Root or name.
     uint256 internal constant ROLE_SET_PUBKEY = 1 << 12;
-    /// @dev Nybble 35 - authorizes setting ROLE_SET_PUBKEY.
+    /// @dev Nybble 35: authorizes setting ROLE_SET_PUBKEY.
     uint256 internal constant ROLE_SET_PUBKEY_ADMIN = ROLE_SET_PUBKEY << 128;
 
-    /// @dev Nybble 4 — authorizes setting ABI records. Root or name.
+    /// @dev Nybble 4: authorizes setting ABI records. Root or name.
     uint256 internal constant ROLE_SET_ABI = 1 << 16;
-    /// @dev Nybble 36 - authorizes setting ROLE_SET_ABI.
+    /// @dev Nybble 36: authorizes setting ROLE_SET_ABI.
     uint256 internal constant ROLE_SET_ABI_ADMIN = ROLE_SET_ABI << 128;
 
-    /// @dev Nybble 5 — authorizes setting interface implementer records. Root or name.
+    /// @dev Nybble 5: authorizes setting interface implementer records. Root or name.
     uint256 internal constant ROLE_SET_INTERFACE = 1 << 20;
-    /// @dev Nybble 37 - authorizes setting ROLE_SET_INTERFACE.
+    /// @dev Nybble 37: authorizes setting ROLE_SET_INTERFACE.
     uint256 internal constant ROLE_SET_INTERFACE_ADMIN = ROLE_SET_INTERFACE << 128;
 
-    /// @dev Nybble 6 — authorizes setting the reverse name record. Root or name.
+    /// @dev Nybble 6: authorizes setting the reverse name record. Root or name.
     uint256 internal constant ROLE_SET_NAME = 1 << 24;
-    /// @dev Nybble 38 - authorizes setting ROLE_SET_NAME.
+    /// @dev Nybble 38: authorizes setting ROLE_SET_NAME.
     uint256 internal constant ROLE_SET_NAME_ADMIN = ROLE_SET_NAME << 128;
 
-    /// @dev Nybble 7 — authorizes setting alias targets for name rewriting. Root-only.
+    /// @dev Nybble 7: authorizes setting alias targets for name rewriting. Root-only.
     uint256 internal constant ROLE_SET_ALIAS = 1 << 28;
-    /// @dev Nybble 39 - authorizes setting ROLE_SET_ALIAS.
+    /// @dev Nybble 39: authorizes setting ROLE_SET_ALIAS.
     uint256 internal constant ROLE_SET_ALIAS_ADMIN = ROLE_SET_ALIAS << 128;
 
-    /// @dev Nybble 8 — authorizes clearing (version-bumping) all records for a node. Root or name.
+    /// @dev Nybble 8: authorizes clearing (version-bumping) all records for a node. Root or name.
     uint256 internal constant ROLE_CLEAR = 1 << 32;
-    /// @dev Nybble 40 - authorizes setting ROLE_CLEAR.
+    /// @dev Nybble 40: authorizes setting ROLE_CLEAR.
     uint256 internal constant ROLE_CLEAR_ADMIN = ROLE_CLEAR << 128;
 
-    /// @dev Nybble 31 — authorizes UUPS proxy upgrades. Root-only.
+    /// @dev Nybble 31: authorizes UUPS proxy upgrades. Root-only.
     uint256 internal constant ROLE_UPGRADE = 1 << 124;
-    /// @dev Nybble 63 - authorizes setting ROLE_UPGRADE.
+    /// @dev Nybble 63: authorizes setting ROLE_UPGRADE.
     uint256 internal constant ROLE_UPGRADE_ADMIN = ROLE_UPGRADE << 128;
 
     /// @dev Computes `keccak256(node, part)` to create a unique EAC resource ID scoped to both
@@ -59,12 +59,14 @@ library PermissionedResolverLib {
     /// @param part The record-type identifier (e.g. from `addrPart` or `textPart`).
     /// @return ret The computed resource ID.
     function resource(bytes32 node, bytes32 part) internal pure returns (uint256 ret) {
-        assembly {
-            mstore(0, node)
-            mstore(32, part)
-            ret := keccak256(0, 64)
+        if (node != bytes32(0) || part != bytes32(0)) {
+            assembly {
+                mstore(0, node)
+                mstore(32, part)
+                ret := keccak256(0, 64)
+            }
+            // Equivalent: return uint256(keccak256(abi.encode(node, part)));
         }
-        // Equivalent: return uint256(keccak256(abi.encode(node, part)));
     }
 
     /// @dev Computes a record-type identifier for address records, namespaced by coin type.

--- a/contracts/src/resolver/libraries/PermissionedResolverLib.sol
+++ b/contracts/src/resolver/libraries/PermissionedResolverLib.sol
@@ -48,6 +48,11 @@ library PermissionedResolverLib {
     /// @dev Nybble 40: authorizes setting ROLE_CLEAR.
     uint256 internal constant ROLE_CLEAR_ADMIN = ROLE_CLEAR << 128;
 
+    /// @dev Nybble 9: authorizes setting data records. Root or name.
+    uint256 internal constant ROLE_SET_DATA = 1 << 36;
+    /// @dev Nybble 41: authorizes setting ROLE_SET_DATA.
+    uint256 internal constant ROLE_SET_DATA_ADMIN = ROLE_SET_DATA << 128;
+
     /// @dev Nybble 31: authorizes UUPS proxy upgrades. Root-only.
     uint256 internal constant ROLE_UPGRADE = 1 << 124;
     /// @dev Nybble 63: authorizes setting ROLE_UPGRADE.
@@ -69,27 +74,20 @@ library PermissionedResolverLib {
         }
     }
 
-    /// @dev Computes a record-type identifier for address records, namespaced by coin type.
-    /// @param coinType The SLIP-44 coin type.
+    /// @dev Computes a record-type identifier for uint256-keyed records.
+    /// @param x The uint256 value.
     /// @return part The computed record-type identifier.
-    function addrPart(uint256 coinType) internal pure returns (bytes32 part) {
+    function partHash(uint256 x) internal pure returns (bytes32 part) {
         assembly {
-            mstore8(0, 1)
-            mstore(1, coinType)
-            part := keccak256(0, 33)
+            mstore(0, x)
+            part := keccak256(0, 32)
         }
-        // Equivalent: return keccak256(abi.encodePacked(uint8(1), coinType));
     }
 
-    /// @dev Computes a record-type identifier for text records, namespaced by key.
-    /// @param key The text record key.
+    /// @dev Computes a record-type identifier for string-keyed records.
+    /// @param x The string value.
     /// @return part The computed record-type identifier.
-    function textPart(string memory key) internal pure returns (bytes32 part) {
-        assembly {
-            mstore8(0, 2)
-            mstore(1, keccak256(add(key, 32), mload(key)))
-            part := keccak256(0, 33)
-        }
-        // Equivalent: return keccak256(abi.encodePacked(uint8(2), key));
+    function partHash(string memory x) internal pure returns (bytes32) {
+        return keccak256(bytes(x));
     }
 }

--- a/contracts/test/unit/resolver/PermissionedResolver.t.sol
+++ b/contracts/test/unit/resolver/PermissionedResolver.t.sol
@@ -19,6 +19,7 @@ import {
     IAddrResolver,
     IAddressResolver,
     IContentHashResolver,
+    IDataResolver,
     IExtendedResolver,
     IHasAddressResolver,
     IInterfaceResolver,
@@ -130,6 +131,7 @@ contract PermissionedResolverTest is Test {
             resolver.supportsInterface(type(IContentHashResolver).interfaceId),
             "IContentHashResolver"
         );
+        assertTrue(resolver.supportsInterface(type(IDataResolver).interfaceId), "IDataResolver");
         assertTrue(
             resolver.supportsInterface(type(IHasAddressResolver).interfaceId),
             "IHasAddressResolver"
@@ -235,27 +237,51 @@ contract PermissionedResolverTest is Test {
     }
 
     ////////////////////////////////////////////////////////////////////////
-    // grantNameRoles() and revokeRoles()
+    // authorizeNameRoles()
     ////////////////////////////////////////////////////////////////////////
 
-    function test_grantNameRoles() external {
+    function test_grantRoles_disabled(uint256 resource, address account) external {
+        vm.assume(resource > 0);
+        uint256 roleBitmap = EACBaseRolesLib.ALL_ROLES;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACCannotGrantRoles.selector,
+                resource,
+                roleBitmap,
+                account
+            )
+        );
+        resolver.grantRoles(resource, roleBitmap, account);
+    }
+
+    function test_authorizeNameRoles() external {
         uint256 roleBitmap = EACBaseRolesLib.ALL_ROLES;
         uint256 resource = PermissionedResolverLib.resource(NameCoder.namehash(testName, 0), 0);
         vm.expectEmit();
         emit PermissionedResolver.NamedResource(resource, testName);
         vm.prank(owner);
-        resolver.grantNameRoles(testName, roleBitmap, friend);
-        assertTrue(resolver.hasRoles(resource, roleBitmap, friend));
+        assertTrue(resolver.authorizeNameRoles(testName, roleBitmap, friend, true), "grant");
+        assertTrue(resolver.hasRoles(resource, roleBitmap, friend), "granted");
+
+        vm.prank(owner);
+        assertTrue(resolver.authorizeNameRoles(testName, roleBitmap, friend, false), "revoked");
+        assertFalse(resolver.hasRoles(resource, roleBitmap, friend), "revoked");
     }
 
-    function test_grantNameRoles_root() external {
+    function test_authorizeNameRoles_root() external {
+        bytes memory name = NameCoder.encode("");
         uint256 roleBitmap = EACBaseRolesLib.ALL_ROLES;
         vm.prank(owner);
-        resolver.grantNameRoles(NameCoder.encode(""), roleBitmap, friend);
-        assertTrue(resolver.hasRootRoles(roleBitmap, friend));
+        assertTrue(resolver.authorizeNameRoles(name, roleBitmap, friend, true), "grant");
+        assertTrue(resolver.hasRootRoles(roleBitmap, friend), "granted");
+
+        vm.prank(owner);
+        assertTrue(resolver.authorizeNameRoles(name, roleBitmap, friend, false), "revoke");
+        assertFalse(resolver.hasRootRoles(roleBitmap, friend), "revoked");
     }
 
-    function test_grantNameRoles_notAuthorized() external {
+    function test_authorizeNameRoles_notAuthorized() external {
         uint256 roleBitmap = EACBaseRolesLib.ALL_ROLES;
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -266,29 +292,7 @@ contract PermissionedResolverTest is Test {
             )
         );
         vm.prank(friend);
-        resolver.grantNameRoles(testName, roleBitmap, owner);
-    }
-
-    function test_revokeRoles() external {
-        uint256 roleBitmap = EACBaseRolesLib.ALL_ROLES;
-        vm.prank(owner);
-        resolver.grantNameRoles(testName, roleBitmap, friend);
-        vm.prank(owner);
-        assertTrue(
-            resolver.revokeRoles(
-                PermissionedResolverLib.resource(NameCoder.namehash(testName, 0), 0),
-                PermissionedResolverLib.ROLE_SET_TEXT,
-                friend
-            )
-        );
-    }
-
-    function test_revokeRoles_root() external {
-        uint256 roleBitmap = EACBaseRolesLib.ALL_ROLES;
-        vm.prank(owner);
-        resolver.grantNameRoles(NameCoder.encode(""), roleBitmap, friend);
-        vm.prank(owner);
-        assertTrue(resolver.revokeRootRoles(roleBitmap, friend));
+        resolver.authorizeNameRoles(testName, roleBitmap, owner, true);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -298,7 +302,7 @@ contract PermissionedResolverTest is Test {
     function test_authorizeTextRoles() external {
         uint256 resource = PermissionedResolverLib.resource(
             NameCoder.namehash(testName, 0),
-            PermissionedResolverLib.textPart(testString)
+            PermissionedResolverLib.partHash(testString)
         );
         vm.expectEmit();
         emit PermissionedResolver.NamedTextResource(
@@ -325,7 +329,12 @@ contract PermissionedResolverTest is Test {
 
     function test_authorizeTextRoles_notRoot() external {
         vm.prank(owner);
-        resolver.grantNameRoles(testName, PermissionedResolverLib.ROLE_SET_TEXT_ADMIN, actor);
+        resolver.authorizeNameRoles(
+            testName,
+            PermissionedResolverLib.ROLE_SET_TEXT_ADMIN,
+            actor,
+            true
+        );
         vm.prank(actor);
         resolver.authorizeTextRoles(testName, testString, friend, true);
         vm.prank(actor);
@@ -348,7 +357,7 @@ contract PermissionedResolverTest is Test {
     function test_authorizeAddrRoles(uint256 coinType) external {
         uint256 resource = PermissionedResolverLib.resource(
             NameCoder.namehash(testName, 0),
-            PermissionedResolverLib.addrPart(coinType)
+            PermissionedResolverLib.partHash(coinType)
         );
         vm.expectEmit();
         emit PermissionedResolver.NamedAddrResource(resource, testName, coinType);
@@ -372,7 +381,12 @@ contract PermissionedResolverTest is Test {
     function test_authorizeAddrRoles_notRoot() external {
         uint256 coinType = 0;
         vm.prank(owner);
-        resolver.grantNameRoles(testName, PermissionedResolverLib.ROLE_SET_ADDR_ADMIN, actor);
+        resolver.authorizeNameRoles(
+            testName,
+            PermissionedResolverLib.ROLE_SET_ADDR_ADMIN,
+            actor,
+            true
+        );
         vm.prank(actor);
         resolver.authorizeAddrRoles(testName, coinType, friend, true);
         vm.prank(actor);
@@ -873,6 +887,69 @@ contract PermissionedResolverTest is Test {
         );
         vm.prank(friend);
         resolver.setText(~testNode, testString, "C");
+    }
+
+    function test_setData_anyNode_onePart() external {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                PermissionedResolverLib.resource(testNode, 0),
+                PermissionedResolverLib.ROLE_SET_DATA,
+                friend
+            )
+        );
+        vm.prank(friend);
+        resolver.setData(testNode, testString, "A");
+
+        vm.prank(owner);
+        resolver.authorizeDataRoles(NameCoder.encode(""), testString, friend, true);
+
+        vm.prank(friend);
+        resolver.setData(testNode, testString, "B");
+
+        vm.prank(friend);
+        resolver.setData(~testNode, testString, "C");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                PermissionedResolverLib.resource(testNode, 0),
+                PermissionedResolverLib.ROLE_SET_DATA,
+                friend
+            )
+        );
+        vm.prank(friend);
+        resolver.setData(testNode, string.concat(testString, testString), "D");
+    }
+
+    function test_setData_oneNode_onePart() external {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                PermissionedResolverLib.resource(testNode, 0),
+                PermissionedResolverLib.ROLE_SET_DATA,
+                friend
+            )
+        );
+        vm.prank(friend);
+        resolver.setData(testNode, testString, "A");
+
+        vm.prank(owner);
+        resolver.authorizeDataRoles(testName, testString, friend, true);
+
+        vm.prank(friend);
+        resolver.setData(testNode, testString, "B");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                PermissionedResolverLib.resource(~testNode, 0),
+                PermissionedResolverLib.ROLE_SET_DATA,
+                friend
+            )
+        );
+        vm.prank(friend);
+        resolver.setData(~testNode, testString, "C");
     }
 
     function test_setAddr_anyNode_onePart() external {

--- a/contracts/test/unit/resolver/PermissionedResolver.t.sol
+++ b/contracts/test/unit/resolver/PermissionedResolver.t.sol
@@ -44,6 +44,7 @@ contract PermissionedResolverTest is Test {
     PermissionedResolver resolver;
 
     address owner = makeAddr("owner");
+    address actor = makeAddr("actor");
     address friend = makeAddr("friend");
 
     bytes testName;
@@ -234,7 +235,7 @@ contract PermissionedResolverTest is Test {
     }
 
     ////////////////////////////////////////////////////////////////////////
-    // grantNameRoles(), grantTextRoles(), and grantAddrRoles()
+    // grantNameRoles() and revokeRoles()
     ////////////////////////////////////////////////////////////////////////
 
     function test_grantNameRoles() external {
@@ -245,6 +246,13 @@ contract PermissionedResolverTest is Test {
         vm.prank(owner);
         resolver.grantNameRoles(testName, roleBitmap, friend);
         assertTrue(resolver.hasRoles(resource, roleBitmap, friend));
+    }
+
+    function test_grantNameRoles_root() external {
+        uint256 roleBitmap = EACBaseRolesLib.ALL_ROLES;
+        vm.prank(owner);
+        resolver.grantNameRoles(NameCoder.encode(""), roleBitmap, friend);
+        assertTrue(resolver.hasRootRoles(roleBitmap, friend));
     }
 
     function test_grantNameRoles_notAuthorized() external {
@@ -261,7 +269,33 @@ contract PermissionedResolverTest is Test {
         resolver.grantNameRoles(testName, roleBitmap, owner);
     }
 
-    function test_grantTextRoles() external {
+    function test_revokeRoles() external {
+        uint256 roleBitmap = EACBaseRolesLib.ALL_ROLES;
+        vm.prank(owner);
+        resolver.grantNameRoles(testName, roleBitmap, friend);
+        vm.prank(owner);
+        assertTrue(
+            resolver.revokeRoles(
+                PermissionedResolverLib.resource(NameCoder.namehash(testName, 0), 0),
+                PermissionedResolverLib.ROLE_SET_TEXT,
+                friend
+            )
+        );
+    }
+
+    function test_revokeRoles_root() external {
+        uint256 roleBitmap = EACBaseRolesLib.ALL_ROLES;
+        vm.prank(owner);
+        resolver.grantNameRoles(NameCoder.encode(""), roleBitmap, friend);
+        vm.prank(owner);
+        assertTrue(resolver.revokeRootRoles(roleBitmap, friend));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // authorizeTextRoles() and authorizeAddrRoles()
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_authorizeTextRoles() external {
         uint256 resource = PermissionedResolverLib.resource(
             NameCoder.namehash(testName, 0),
             PermissionedResolverLib.textPart(testString)
@@ -274,11 +308,31 @@ contract PermissionedResolverTest is Test {
             testString
         );
         vm.prank(owner);
-        resolver.grantTextRoles(testName, testString, friend);
+        resolver.authorizeTextRoles(testName, testString, friend, true);
         assertTrue(resolver.hasRoles(resource, PermissionedResolverLib.ROLE_SET_TEXT, friend));
+
+        vm.prank(owner);
+        resolver.authorizeTextRoles(testName, testString, friend, false);
+        assertFalse(resolver.hasRoles(resource, PermissionedResolverLib.ROLE_SET_TEXT, friend));
     }
 
-    function test_grantTextRoles_notAuthorized() external {
+    function test_authorizeTextRoles_anyName() external {
+        vm.prank(owner);
+        resolver.authorizeTextRoles(NameCoder.encode(""), testString, friend, true);
+        vm.prank(owner);
+        resolver.authorizeTextRoles(NameCoder.encode(""), testString, friend, false);
+    }
+
+    function test_authorizeTextRoles_notRoot() external {
+        vm.prank(owner);
+        resolver.grantNameRoles(testName, PermissionedResolverLib.ROLE_SET_TEXT_ADMIN, actor);
+        vm.prank(actor);
+        resolver.authorizeTextRoles(testName, testString, friend, true);
+        vm.prank(actor);
+        resolver.authorizeTextRoles(testName, testString, friend, false);
+    }
+
+    function test_authorizeTextRoles_notAuthorized() external {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IEnhancedAccessControl.EACCannotGrantRoles.selector,
@@ -288,10 +342,10 @@ contract PermissionedResolverTest is Test {
             )
         );
         vm.prank(friend);
-        resolver.grantTextRoles(testName, testString, owner);
+        resolver.authorizeTextRoles(testName, testString, owner, true);
     }
 
-    function test_grantAddrRoles(uint256 coinType) external {
+    function test_authorizeAddrRoles(uint256 coinType) external {
         uint256 resource = PermissionedResolverLib.resource(
             NameCoder.namehash(testName, 0),
             PermissionedResolverLib.addrPart(coinType)
@@ -299,11 +353,33 @@ contract PermissionedResolverTest is Test {
         vm.expectEmit();
         emit PermissionedResolver.NamedAddrResource(resource, testName, coinType);
         vm.prank(owner);
-        resolver.grantAddrRoles(testName, coinType, friend);
+        resolver.authorizeAddrRoles(testName, coinType, friend, true);
         assertTrue(resolver.hasRoles(resource, PermissionedResolverLib.ROLE_SET_ADDR, friend));
+
+        vm.prank(owner);
+        resolver.authorizeAddrRoles(testName, coinType, friend, false);
+        assertFalse(resolver.hasRoles(resource, PermissionedResolverLib.ROLE_SET_ADDR, friend));
     }
 
-    function test_grantAddrRoles_notAuthorized() external {
+    function test_authorizeAddrRoles_anyName() external {
+        uint256 coinType = 0;
+        vm.prank(owner);
+        resolver.authorizeAddrRoles(NameCoder.encode(""), coinType, friend, true);
+        vm.prank(owner);
+        resolver.authorizeAddrRoles(NameCoder.encode(""), coinType, friend, false);
+    }
+
+    function test_authorizeAddrRoles_notRoot() external {
+        uint256 coinType = 0;
+        vm.prank(owner);
+        resolver.grantNameRoles(testName, PermissionedResolverLib.ROLE_SET_ADDR_ADMIN, actor);
+        vm.prank(actor);
+        resolver.authorizeAddrRoles(testName, coinType, friend, true);
+        vm.prank(actor);
+        resolver.authorizeAddrRoles(testName, coinType, friend, false);
+    }
+
+    function test_authorizeAddrRoles_notAuthorized() external {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IEnhancedAccessControl.EACCannotGrantRoles.selector,
@@ -313,58 +389,7 @@ contract PermissionedResolverTest is Test {
             )
         );
         vm.prank(friend);
-        resolver.grantAddrRoles(testName, 0, owner);
-    }
-
-    ////////////////////////////////////////////////////////////////////////
-    // revokeRoles() [corresponding to granters above]
-    ////////////////////////////////////////////////////////////////////////
-
-    function test_revokeRoles_name() external {
-        uint256 roleBitmap = EACBaseRolesLib.ALL_ROLES;
-        vm.prank(owner);
-        resolver.grantNameRoles(testName, roleBitmap, friend);
-        vm.prank(owner);
-        assertTrue(
-            resolver.revokeRoles(
-                PermissionedResolverLib.resource(NameCoder.namehash(testName, 0), 0),
-                roleBitmap,
-                friend
-            )
-        );
-    }
-
-    function test_revokeRoles_text() external {
-        vm.prank(owner);
-        resolver.grantTextRoles(testName, testString, friend);
-        vm.prank(owner);
-        assertTrue(
-            resolver.revokeRoles(
-                PermissionedResolverLib.resource(
-                    NameCoder.namehash(testName, 0),
-                    PermissionedResolverLib.textPart(testString)
-                ),
-                PermissionedResolverLib.ROLE_SET_TEXT,
-                friend
-            )
-        );
-    }
-
-    function test_revokeRoles_addr() external {
-        uint256 coinType = 0;
-        vm.prank(owner);
-        resolver.grantAddrRoles(testName, coinType, friend);
-        vm.prank(owner);
-        assertTrue(
-            resolver.revokeRoles(
-                PermissionedResolverLib.resource(
-                    NameCoder.namehash(testName, 0),
-                    PermissionedResolverLib.addrPart(coinType)
-                ),
-                PermissionedResolverLib.ROLE_SET_ADDR,
-                friend
-            )
-        );
+        resolver.authorizeAddrRoles(testName, 0, owner, true);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -800,7 +825,7 @@ contract PermissionedResolverTest is Test {
         resolver.setText(testNode, testString, "A");
 
         vm.prank(owner);
-        resolver.grantTextRoles(NameCoder.encode(""), testString, friend);
+        resolver.authorizeTextRoles(NameCoder.encode(""), testString, friend, true);
 
         vm.prank(friend);
         resolver.setText(testNode, testString, "B");
@@ -833,7 +858,7 @@ contract PermissionedResolverTest is Test {
         resolver.setText(testNode, testString, "A");
 
         vm.prank(owner);
-        resolver.grantTextRoles(testName, testString, friend);
+        resolver.authorizeTextRoles(testName, testString, friend, true);
 
         vm.prank(friend);
         resolver.setText(testNode, testString, "B");
@@ -864,7 +889,7 @@ contract PermissionedResolverTest is Test {
         resolver.setAddr(testNode, coinType, hex"01");
 
         vm.prank(owner);
-        resolver.grantAddrRoles(NameCoder.encode(""), coinType, friend);
+        resolver.authorizeAddrRoles(NameCoder.encode(""), coinType, friend, true);
 
         vm.prank(friend);
         resolver.setAddr(testNode, coinType, hex"02");
@@ -898,7 +923,7 @@ contract PermissionedResolverTest is Test {
         resolver.setAddr(testNode, coinType, hex"01");
 
         vm.prank(owner);
-        resolver.grantAddrRoles(testName, coinType, friend);
+        resolver.authorizeAddrRoles(testName, coinType, friend, true);
 
         vm.prank(friend);
         resolver.setAddr(testNode, coinType, hex"02");


### PR DESCRIPTION
- updated `PermissionedResolver`
     * changed `resource(0, 0)` to be `ROOT_RESOURCE`
     * changed `grantTextRoles(name, key, account)` to `authorizeTextRoles(name, key, account, grant)`
     * changed `grantAddrRoles(name, coinType, account)` to `authorizeAddrRoles(name, coinType, account, grant)`
     * disabled `revokeRoles()`  
     * changed `grantNameRoles(name, roles, account)` to `authorizeNameRoles(name, roles, account, grant)`
     * added `IDataResolver` support
     * added `authorizeDataRoles(name, key, account)`
- added tests
- minor simplification of `EAC._get{Settable|Revokable}Roles()`