### PR TITLE
Fix/bet 601 fix unused code

### DIFF
--- a/contracts/src/access-control/EnhancedAccessControl.sol
+++ b/contracts/src/access-control/EnhancedAccessControl.sol
@@ -298,15 +298,6 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         }
     }
 
-    /// @dev Revoke all roles for account within resource.
-    function _revokeAllRoles(
-        uint256 resource,
-        address account,
-        bool executeCallbacks
-    ) internal virtual returns (bool) {
-        return _revokeRoles(resource, EACBaseRolesLib.ALL_ROLES, account, executeCallbacks);
-    }
-
     /// @dev Updates role counts when roles are granted/revoked
     /// @param resource The resource to update counts for
     /// @param roleBitmap The roles being modified

--- a/contracts/src/erc1155/ERC1155Singleton.sol
+++ b/contracts/src/erc1155/ERC1155Singleton.sol
@@ -324,27 +324,6 @@ abstract contract ERC1155Singleton is
         _updateWithAcceptanceCheck(address(0), to, ids, values, data, false);
     }
 
-    /// @notice Mint multiple token IDs to `to`.
-    /// @param to Address receiving the minted tokens.
-    /// @param ids Token IDs to mint.
-    /// @param values Amounts to mint for each token ID.
-    /// @param data Additional calldata passed to receiver hooks.
-    /// @dev Reverts with `ERC1155InvalidReceiver` if `to` is the zero address.
-    /// @dev Reverts with `ERC1155InvalidArrayLength` if `ids.length != values.length`.
-    /// @dev If `to` is a contract, it must return the ERC-1155 acceptance magic value.
-    /// @dev Emits `TransferBatch`.
-    function _mintBatch(
-        address to,
-        uint256[] memory ids,
-        uint256[] memory values,
-        bytes memory data
-    ) internal {
-        if (to == address(0)) {
-            revert ERC1155InvalidReceiver(address(0));
-        }
-        _updateWithAcceptanceCheck(address(0), to, ids, values, data, true);
-    }
-
     /// @notice Burn `value` tokens of token ID `id` from `from`.
     /// @param from Address to burn from.
     /// @param id Token ID to burn.
@@ -358,21 +337,6 @@ abstract contract ERC1155Singleton is
         }
         (uint256[] memory ids, uint256[] memory values) = _asSingletonArrays(id, value);
         _updateWithAcceptanceCheck(from, address(0), ids, values, "", false);
-    }
-
-    /// @notice Burn multiple token IDs from `from`.
-    /// @param from Address to burn from.
-    /// @param ids Token IDs to burn.
-    /// @param values Amounts to burn for each token ID.
-    /// @dev Reverts with `ERC1155InvalidSender` if `from` is the zero address.
-    /// @dev Reverts with `ERC1155InvalidArrayLength` if `ids.length != values.length`.
-    /// @dev Reverts with `ERC1155InsufficientBalance` if `from` is not current owner or `value > 1`.
-    /// @dev Emits `TransferBatch`.
-    function _burnBatch(address from, uint256[] memory ids, uint256[] memory values) internal {
-        if (from == address(0)) {
-            revert ERC1155InvalidSender(address(0));
-        }
-        _updateWithAcceptanceCheck(from, address(0), ids, values, "", true);
     }
 
     /// @notice Set or clear approval for `operator` to manage all tokens owned by `owner`.

--- a/contracts/src/erc1155/ERC1155Singleton.sol
+++ b/contracts/src/erc1155/ERC1155Singleton.sol
@@ -50,16 +50,6 @@ abstract contract ERC1155Singleton is
     mapping(address account => mapping(address operator => bool)) private _operatorApprovals;
 
     ////////////////////////////////////////////////////////////////////////
-    // Events
-    ////////////////////////////////////////////////////////////////////////
-
-    /// @notice An approval for all operator was set.
-    /// @param owner The owner of the token.
-    /// @param approved The approved address.
-    /// @param tokenId The token ID.
-    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
-
-    ////////////////////////////////////////////////////////////////////////
     // Initialization
     ////////////////////////////////////////////////////////////////////////
 

--- a/contracts/src/registry/BaseUriRegistryMetadata.sol
+++ b/contracts/src/registry/BaseUriRegistryMetadata.sol
@@ -20,9 +20,6 @@ contract BaseUriRegistryMetadata is EnhancedAccessControl, IRegistryMetadata {
     /// @dev Role bit allowing an account to update the token base URI.
     uint256 private constant _ROLE_UPDATE_METADATA = 1 << 0;
 
-    /// @dev Admin-tier counterpart of the metadata update role, shifted into the upper half of the bitmap.
-    uint256 private constant _ROLE_UPDATE_METADATA_ADMIN = _ROLE_UPDATE_METADATA << 128;
-
     ////////////////////////////////////////////////////////////////////////
     // Storage
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/src/registry/SimpleRegistryMetadata.sol
+++ b/contracts/src/registry/SimpleRegistryMetadata.sol
@@ -20,9 +20,6 @@ contract SimpleRegistryMetadata is EnhancedAccessControl, IRegistryMetadata {
     /// @dev Role bit allowing an account to update individual token URIs.
     uint256 private constant _ROLE_UPDATE_METADATA = 1 << 0;
 
-    /// @dev Admin-tier counterpart of the metadata update role, shifted into the upper half of the bitmap.
-    uint256 private constant _ROLE_UPDATE_METADATA_ADMIN = _ROLE_UPDATE_METADATA << 128;
-
     ////////////////////////////////////////////////////////////////////////
     // Storage
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/src/reverse-registrar/L2ReverseRegistrar.sol
+++ b/contracts/src/reverse-registrar/L2ReverseRegistrar.sol
@@ -66,14 +66,6 @@ contract L2ReverseRegistrar is IL2ReverseRegistrar, ERC165, StandaloneReverseReg
     /// @dev Error selector: `0x8baa579f`
     error InvalidSignature();
 
-    /// @notice Thrown when the chain ID array is not in strictly ascending order.
-    /// @dev Error selector: `0xea0b14e2`
-    error ChainIdsNotAscending();
-
-    /// @notice Thrown when the current chain ID is not included in the claim's chain ID array.
-    /// @dev Error selector: `0x756925c8`
-    error CurrentChainNotFound(uint256 chainId);
-
     ////////////////////////////////////////////////////////////////////////
     // Modifiers
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/src/reverse-registrar/L2ReverseRegistrar.sol
+++ b/contracts/src/reverse-registrar/L2ReverseRegistrar.sol
@@ -66,6 +66,15 @@ contract L2ReverseRegistrar is IL2ReverseRegistrar, ERC165, StandaloneReverseReg
     /// @dev Error selector: `0x8baa579f`
     error InvalidSignature();
 
+    /// @notice Thrown when the chain ID array is not in strictly ascending order.
+    /// @dev Error selector: `0xea0b14e2`. Re-declared here (despite living in
+    ///      `ChainIdsBuilderLib`) because the library reverts via assembly literal
+    ///      and Solidity has no source-level reference to propagate the type into
+    ///      this contract's ABI. `CurrentChainNotFound` doesn't need this anchor —
+    ///      the library reverts it via `revert CurrentChainNotFound(...)` so its
+    ///      type propagates automatically.
+    error ChainIdsNotAscending();
+
     ////////////////////////////////////////////////////////////////////////
     // Modifiers
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/src/universalResolver/libraries/LibRegistry.sol
+++ b/contracts/src/universalResolver/libraries/LibRegistry.sol
@@ -111,21 +111,6 @@ library LibRegistry {
         }
     }
 
-    /// @dev Find the parent registry for `name[offset:]`.
-    /// @param rootRegistry The root ENS registry.
-    /// @param name The DNS-encoded name to search.
-    /// @return parentRegistry The parent registry or null if not found.
-    function findParentRegistry(
-        IRegistry rootRegistry,
-        bytes memory name,
-        uint256 offset
-    ) internal view returns (IRegistry parentRegistry) {
-        (bytes32 labelHash, uint256 next) = NameCoder.readLabel(name, offset);
-        if (labelHash != bytes32(0)) {
-            parentRegistry = findExactRegistry(rootRegistry, name, next);
-        }
-    }
-
     /// @dev Find all registries in the ancestry of `name`.
     /// @param rootRegistry The root ENS registry.
     /// @param name The DNS-encoded name.

--- a/contracts/test/unit/access-control/EnhancedAccessControl.t.sol
+++ b/contracts/test/unit/access-control/EnhancedAccessControl.t.sol
@@ -69,7 +69,14 @@ contract MockEnhancedAccessControl is EnhancedAccessControl {
     }
 
     function revokeAllRoles(uint256 resource, address account) external returns (bool) {
-        return _revokeAllRoles(resource, account, true);
+        return _revokeRoles(resource, EACBaseRolesLib.ALL_ROLES, account, true);
+    }
+
+    function revokeAllRolesWithoutCallback(
+        uint256 resource,
+        address account
+    ) external returns (bool) {
+        return _revokeRoles(resource, EACBaseRolesLib.ALL_ROLES, account, false);
     }
 
     function _onRolesGranted(
@@ -134,12 +141,6 @@ contract MockEnhancedAccessControl is EnhancedAccessControl {
         _transferRoles(resource, srcAccount, dstAccount, false);
     }
 
-    function revokeAllRolesWithoutCallback(
-        uint256 resource,
-        address account
-    ) external returns (bool) {
-        return _revokeAllRoles(resource, account, false);
-    }
 }
 
 contract EnhancedAccessControlTest is Test {
@@ -533,32 +534,6 @@ contract EnhancedAccessControlTest is Test {
 
         // Verify user2 no longer has ROLE_A in root resource
         assertFalse(access.hasRootRoles(ROLE_A, user2));
-    }
-
-    function test_revoke_all_roles() external {
-        // Setup: Grant multiple roles to user1
-        _grant(RESOURCE_1, ROLE_A | ROLE_B, user1);
-        _grant(RESOURCE_2, ROLE_A, user1);
-
-        // Revoke all roles for RESOURCE_1
-        // Verify the operation was successful
-        vm.expectEmit(true, true, false, true);
-        emit IEnhancedAccessControl.EACRolesChanged(RESOURCE_1, user1, ROLE_A | ROLE_B, 0);
-        assertTrue(access.revokeAllRoles(RESOURCE_1, user1), "revoke");
-
-        // Verify all roles for RESOURCE_1 were revoked
-        assertFalse(access.hasRoles(RESOURCE_1, ROLE_A, user1));
-        assertFalse(access.hasRoles(RESOURCE_1, ROLE_B, user1));
-
-        // Verify roles for RESOURCE_2 were not affected
-        assertTrue(access.hasRoles(RESOURCE_2, ROLE_A, user1));
-
-        // Test revoking all roles when there are no roles to revoke
-        // Verify the operation was not successful (no roles to revoke)
-        // Verify no event was emitted
-        vm.recordLogs();
-        assertFalse(access.revokeAllRoles(RESOURCE_1, user1), "noop");
-        assertEq(vm.getRecordedLogs().length, 0, "silent");
     }
 
     function test_supports_interface() external view {

--- a/contracts/test/unit/registry/SimpleRegistryMetadata.t.sol
+++ b/contracts/test/unit/registry/SimpleRegistryMetadata.t.sol
@@ -26,7 +26,6 @@ contract SimpleRegistryMetadataTest is Test, ERC1155Holder {
 
     // Hardcoded role constants
     uint256 constant ROLE_UPDATE_METADATA = 1 << 0;
-    uint256 constant ROLE_UPDATE_METADATA_ADMIN = ROLE_UPDATE_METADATA << 128;
 
     uint256 constant DEFAULT_ROLE_BITMAP =
         RegistryRolesLib.ROLE_SET_SUBREGISTRY | RegistryRolesLib.ROLE_SET_RESOLVER;

--- a/contracts/test/unit/reverse-registrar/L2ReverseRegistrar.t.sol
+++ b/contracts/test/unit/reverse-registrar/L2ReverseRegistrar.t.sol
@@ -22,6 +22,7 @@ import {
     LibISO8601,
     LibString
 } from "~src/reverse-registrar/L2ReverseRegistrar.sol";
+import {ChainIdsBuilderLib} from "~src/reverse-registrar/libraries/ChainIdsBuilderLib.sol";
 
 contract L2ReverseRegistrarTest is Test {
     using MessageHashUtils for bytes;
@@ -746,7 +747,7 @@ contract L2ReverseRegistrarTest is Test {
         vm.prank(relayer);
         vm.expectRevert(
             abi.encodeWithSelector(
-                L2ReverseRegistrar.CurrentChainNotFound.selector,
+                ChainIdsBuilderLib.CurrentChainNotFound.selector,
                 OPTIMISM_CHAIN_ID
             )
         );
@@ -772,7 +773,7 @@ contract L2ReverseRegistrarTest is Test {
         vm.prank(relayer);
         vm.expectRevert(
             abi.encodeWithSelector(
-                L2ReverseRegistrar.CurrentChainNotFound.selector,
+                ChainIdsBuilderLib.CurrentChainNotFound.selector,
                 OPTIMISM_CHAIN_ID
             )
         );
@@ -796,7 +797,7 @@ contract L2ReverseRegistrarTest is Test {
         });
 
         vm.prank(relayer);
-        vm.expectRevert(L2ReverseRegistrar.ChainIdsNotAscending.selector);
+        vm.expectRevert(ChainIdsBuilderLib.ChainIdsNotAscending.selector);
         registrar.setNameForAddrWithSignature(claim, signature);
     }
 
@@ -817,7 +818,7 @@ contract L2ReverseRegistrarTest is Test {
         });
 
         vm.prank(relayer);
-        vm.expectRevert(L2ReverseRegistrar.ChainIdsNotAscending.selector);
+        vm.expectRevert(ChainIdsBuilderLib.ChainIdsNotAscending.selector);
         registrar.setNameForAddrWithSignature(claim, signature);
     }
 
@@ -1327,7 +1328,7 @@ contract L2ReverseRegistrarTest is Test {
         vm.prank(relayer);
         vm.expectRevert(
             abi.encodeWithSelector(
-                L2ReverseRegistrar.CurrentChainNotFound.selector,
+                ChainIdsBuilderLib.CurrentChainNotFound.selector,
                 OPTIMISM_CHAIN_ID
             )
         );
@@ -1359,7 +1360,7 @@ contract L2ReverseRegistrarTest is Test {
         vm.prank(relayer);
         vm.expectRevert(
             abi.encodeWithSelector(
-                L2ReverseRegistrar.CurrentChainNotFound.selector,
+                ChainIdsBuilderLib.CurrentChainNotFound.selector,
                 OPTIMISM_CHAIN_ID
             )
         );
@@ -1389,7 +1390,7 @@ contract L2ReverseRegistrarTest is Test {
         });
 
         vm.prank(relayer);
-        vm.expectRevert(L2ReverseRegistrar.ChainIdsNotAscending.selector);
+        vm.expectRevert(ChainIdsBuilderLib.ChainIdsNotAscending.selector);
         registrar.setNameForOwnableWithSignature(claim, user1, signature);
     }
 
@@ -1416,7 +1417,7 @@ contract L2ReverseRegistrarTest is Test {
         });
 
         vm.prank(relayer);
-        vm.expectRevert(L2ReverseRegistrar.ChainIdsNotAscending.selector);
+        vm.expectRevert(ChainIdsBuilderLib.ChainIdsNotAscending.selector);
         registrar.setNameForOwnableWithSignature(claim, user1, signature);
     }
 

--- a/contracts/test/unit/universalResolver/libraries/LibRegistry.t.sol
+++ b/contracts/test/unit/universalResolver/libraries/LibRegistry.t.sol
@@ -59,7 +59,6 @@ contract LibRegistryTest is Test, ERC1155Holder {
     function _expectFind(
         bytes memory name,
         uint256 resolverOffset,
-        address parentRegistry,
         IRegistry[] memory registries,
         bytes memory canonicalName
     ) internal view {
@@ -73,11 +72,6 @@ contract LibRegistryTest is Test, ERC1155Holder {
         assertEq(resolver, resolverAddress, "resolver");
         assertEq(node, NameCoder.namehash(name, 0), "node");
         assertEq(resolverOffset_, resolverOffset, "offset");
-        assertEq(
-            address(LibRegistry.findParentRegistry(rootRegistry, name, 0)),
-            parentRegistry,
-            "parent"
-        );
         {
             IRegistry[] memory regs = LibRegistry.findRegistries(rootRegistry, name, 0);
             assertEq(registries.length, regs.length, "count");
@@ -126,7 +120,7 @@ contract LibRegistryTest is Test, ERC1155Holder {
         IRegistry[] memory v = new IRegistry[](2);
         v[0] = ethRegistry;
         v[1] = rootRegistry;
-        _expectFind(name, 0, address(rootRegistry), v, name);
+        _expectFind(name, 0, v, name);
     }
 
     function test_findResolver_resolverOnParent() external {
@@ -145,7 +139,7 @@ contract LibRegistryTest is Test, ERC1155Holder {
         v[0] = testRegistry;
         v[1] = ethRegistry;
         v[2] = rootRegistry;
-        _expectFind(name, 0, address(ethRegistry), v, name);
+        _expectFind(name, 0, v, name);
     }
 
     function test_findResolver_resolverOnRoot() external {
@@ -164,7 +158,7 @@ contract LibRegistryTest is Test, ERC1155Holder {
         v[1] = testRegistry;
         v[2] = ethRegistry;
         v[3] = rootRegistry;
-        _expectFind(name, 9, address(testRegistry), v, ""); // 3sub4test
+        _expectFind(name, 9, v, ""); // 3sub4test
     }
 
     function test_findResolver_virtual() external {
@@ -183,7 +177,7 @@ contract LibRegistryTest is Test, ERC1155Holder {
         v[2] = testRegistry;
         v[3] = ethRegistry;
         v[4] = rootRegistry;
-        _expectFind(name, 10, address(0), v, ""); // 1a2bb4test
+        _expectFind(name, 10, v, ""); // 1a2bb4test
     }
 
     function test_findCanonicalName() external {


### PR DESCRIPTION
                                                                                       
  - `event Approval` in `ERC1155Singleton` — removed                                                                                                                                       
  - `_mintBatch` / `_burnBatch` in `ERC1155Singleton` — removed                                                                                                                            
  - `_ROLE_UPDATE_METADATA_ADMIN` in `SimpleRegistryMetadata` + `BaseUriRegistryMetadata` — removed
  - `error CurrentChainNotFound` in `L2ReverseRegistrar` — removed; `error ChainIdsNotAscending` kept as ABI anchor (documented)                                                           
  - `findParentRegistry` in `LibRegistry` — removed                                                                                                                                        
  - `_revokeAllRoles` in `EnhancedAccessControl` — removed (helper relocated to test mock)           