### PR TITLE
Fix refactor `PermissionedRegistry.register()` permission avoidance

### DIFF
--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -84,8 +84,10 @@ contract PermissionedRegistry is
 
     /// @dev The parent registry of this registry.
     IRegistry internal _parentRegistry;
+
     /// @dev The child label of this registry.
     string internal _childLabel;
+
     /// @dev The entries of this registry.
     mapping(uint256 storageId => Entry entry) internal _entries;
 
@@ -152,17 +154,13 @@ contract PermissionedRegistry is
     function setParent(
         IRegistry parent,
         string memory label
-    ) public virtual onlyRootRoles(RegistryRolesLib.ROLE_SET_PARENT) {
+    ) public onlyRootRoles(RegistryRolesLib.ROLE_SET_PARENT) {
         _parentRegistry = parent;
         _childLabel = label;
         emit ParentUpdated(parent, label, _msgSender());
     }
 
     /// @inheritdoc IStandardRegistry
-    /// @dev If `AVAILABLE`, requires `ROLE_REGISTRAR` on root.
-    ///         * If `owner` is null (`roleBitmap` must be 0), status becomes `RESERVED` instead of `REGISTERED`.
-    ///      If `RESERVED`, requires `ROLE_REGISTER_RESERVED` on root.
-    ///         * If `expiry` is 0, uses current expiry.
     function register(
         string memory label,
         address owner,
@@ -170,66 +168,13 @@ contract PermissionedRegistry is
         address resolver,
         uint256 roleBitmap,
         uint64 expiry
-    ) public virtual override returns (uint256 tokenId) {
-        NameCoder.assertLabelSize(label);
-        uint256 labelId = LibLabel.id(label);
-        Entry storage entry = _entry(labelId);
-        tokenId = _constructTokenId(labelId, entry);
-        address prevOwner = super.ownerOf(tokenId);
-        address sender = _msgSender(); // the registrar, not the registrant
-        if (_isExpired(entry.expiry)) {
-            if (sender != address(this)) {
-                _checkRoles(ROOT_RESOURCE, RegistryRolesLib.ROLE_REGISTRAR, sender);
-            }
-            if (owner == address(0) && roleBitmap != 0) {
-                revert EACCannotGrantRoles(ROOT_RESOURCE, roleBitmap, sender); // strict
-            }
-        } else {
-            if (prevOwner != address(0)) {
-                revert LabelAlreadyRegistered(label); // cannot overwrite REGISTERED
-            } else if (owner == address(0)) {
-                revert LabelAlreadyReserved(label); // cannot reserve/register RESERVED
-            }
-            if (sender != address(this)) {
-                _checkRoles(ROOT_RESOURCE, RegistryRolesLib.ROLE_REGISTER_RESERVED, sender);
-            }
-            if (expiry == 0) {
-                expiry = entry.expiry; // use current expiry
-            }
-        }
-        if (_isExpired(expiry)) {
-            revert CannotSetPastExpiry(expiry);
-        }
-        if (prevOwner != address(0)) {
-            _burn(prevOwner, tokenId, 1);
-            ++entry.eacVersionId;
-            ++entry.tokenVersionId;
-            tokenId = _constructTokenId(tokenId, entry);
-        }
-        entry.expiry = expiry;
-        entry.subregistry = registry;
-        entry.resolver = resolver;
-        // emit LabelRegistered before mint so we can determine this is a registry (in an indexer)
-        if (owner == address(0)) {
-            emit LabelReserved(tokenId, bytes32(labelId), label, expiry, sender);
-        } else {
-            emit LabelRegistered(tokenId, bytes32(labelId), label, owner, expiry, sender);
-            _mint(owner, tokenId, 1, "");
-            uint256 resource = _constructResource(tokenId, entry);
-            emit TokenResource(tokenId, resource);
-            _grantRoles(resource, roleBitmap, owner, false);
-        }
-        if (address(registry) != address(0)) {
-            emit SubregistryUpdated(tokenId, registry, sender);
-        }
-        if (address(resolver) != address(0)) {
-            emit ResolverUpdated(tokenId, resolver, sender);
-        }
+    ) public virtual returns (uint256) {
+        return _register(label, owner, registry, resolver, roleBitmap, expiry, true);
     }
 
     /// @inheritdoc IStandardRegistry
     /// @dev Requires `REGISTERED | RESERVED` and `ROLE_UNREGISTER`.
-    function unregister(uint256 anyId) public virtual {
+    function unregister(uint256 anyId) public {
         (uint256 tokenId, Entry storage entry) = _checkExpiryAndTokenRoles(
             anyId,
             RegistryRolesLib.ROLE_UNREGISTER
@@ -246,7 +191,7 @@ contract PermissionedRegistry is
 
     /// @inheritdoc IStandardRegistry
     /// @dev Requires `REGISTERED | RESERVED` and `ROLE_RENEW`.
-    function renew(uint256 anyId, uint64 newExpiry) public override {
+    function renew(uint256 anyId, uint64 newExpiry) public {
         (uint256 tokenId, Entry storage entry) = _checkExpiryAndTokenRoles(
             anyId,
             RegistryRolesLib.ROLE_RENEW
@@ -289,7 +234,7 @@ contract PermissionedRegistry is
     }
 
     /// @inheritdoc IRegistry
-    function getParent() public view virtual returns (IRegistry parent, string memory label) {
+    function getParent() public view returns (IRegistry parent, string memory label) {
         return (_parentRegistry, _childLabel);
     }
 
@@ -333,23 +278,20 @@ contract PermissionedRegistry is
     }
 
     /// @inheritdoc IPermissionedRegistry
-    function latestOwnerOf(uint256 tokenId) public view virtual returns (address) {
+    function latestOwnerOf(uint256 tokenId) public view returns (address) {
         return super.ownerOf(tokenId);
     }
 
     /// @inheritdoc IERC1155Singleton
     function ownerOf(
         uint256 tokenId
-    ) public view virtual override(ERC1155Singleton, IERC1155Singleton) returns (address) {
+    ) public view override(ERC1155Singleton, IERC1155Singleton) returns (address) {
         Entry storage entry = _entry(tokenId);
         return
             tokenId != _constructTokenId(tokenId, entry) || _isExpired(entry.expiry)
                 ? address(0)
                 : super.ownerOf(tokenId);
     }
-
-    /// @dev EAC view overrides — each translates `anyId` to the canonical EAC resource
-    ///      (via `getResource`) before delegating to the base `EnhancedAccessControl` implementation.
 
     /// @inheritdoc IEnhancedAccessControl
     function roles(
@@ -400,13 +342,82 @@ contract PermissionedRegistry is
     // Internal Functions
     ////////////////////////////////////////////////////////////////////////
 
+    /// @dev If `AVAILABLE`, requires `ROLE_REGISTRAR` on root and status becomes `REGISTERED`.
+    ///         * If `owner` is null (`roleBitmap` must be 0), status becomes `RESERVED`.
+    ///      If `RESERVED`, requires `ROLE_REGISTER_RESERVED` on root and status becomes `REGISTERED`.
+    ///         * If `expiry` is 0, uses current expiry.
+    function _register(
+        string memory label,
+        address owner,
+        IRegistry registry,
+        address resolver,
+        uint256 roleBitmap,
+        uint64 expiry,
+        bool checkRoles
+    ) internal returns (uint256 tokenId) {
+        NameCoder.assertLabelSize(label);
+        uint256 labelId = LibLabel.id(label);
+        Entry storage entry = _entry(labelId);
+        tokenId = _constructTokenId(labelId, entry);
+        address prevOwner = super.ownerOf(tokenId);
+        address sender = _msgSender(); // the registrar, not the registrant
+        if (_isExpired(entry.expiry)) {
+            if (checkRoles) {
+                _checkRoles(ROOT_RESOURCE, RegistryRolesLib.ROLE_REGISTRAR, sender);
+            }
+            if (owner == address(0) && roleBitmap != 0) {
+                revert EACCannotGrantRoles(ROOT_RESOURCE, roleBitmap, sender); // strict
+            }
+        } else {
+            if (prevOwner != address(0)) {
+                revert LabelAlreadyRegistered(label); // cannot overwrite REGISTERED
+            } else if (owner == address(0)) {
+                revert LabelAlreadyReserved(label); // cannot reserve/register RESERVED
+            }
+            if (checkRoles) {
+                _checkRoles(ROOT_RESOURCE, RegistryRolesLib.ROLE_REGISTER_RESERVED, sender);
+            }
+            if (expiry == 0) {
+                expiry = entry.expiry; // use current expiry
+            }
+        }
+        if (_isExpired(expiry)) {
+            revert CannotSetPastExpiry(expiry);
+        }
+        if (prevOwner != address(0)) {
+            _burn(prevOwner, tokenId, 1);
+            ++entry.eacVersionId;
+            ++entry.tokenVersionId;
+            tokenId = _constructTokenId(tokenId, entry);
+        }
+        entry.expiry = expiry;
+        entry.subregistry = registry;
+        entry.resolver = resolver;
+        // emit LabelRegistered before mint so we can determine this is a registry (in an indexer)
+        if (owner == address(0)) {
+            emit LabelReserved(tokenId, bytes32(labelId), label, expiry, sender);
+        } else {
+            emit LabelRegistered(tokenId, bytes32(labelId), label, owner, expiry, sender);
+            _mint(owner, tokenId, 1, "");
+            uint256 resource = _constructResource(tokenId, entry);
+            emit TokenResource(tokenId, resource);
+            _grantRoles(resource, roleBitmap, owner, false);
+        }
+        if (address(registry) != address(0)) {
+            emit SubregistryUpdated(tokenId, registry, sender);
+        }
+        if (address(resolver) != address(0)) {
+            emit ResolverUpdated(tokenId, resolver, sender);
+        }
+    }
+
     /// @dev Override `ERC1155Singleton._update()` to transfer the roles to the new owner if the token is transferred.
     function _update(
         address from,
         address to,
         uint256[] memory tokenIds,
         uint256[] memory amounts
-    ) internal virtual override {
+    ) internal override {
         bool externalTransfer = to != address(0) && from != address(0); // skip mint and burn
         if (externalTransfer) {
             // only check ROLE_CAN_TRANSFER_ADMIN on token owner (from)
@@ -433,7 +444,7 @@ contract PermissionedRegistry is
         uint256 /*oldRoles*/,
         uint256 /*newRoles*/,
         uint256 /*roleBitmap*/
-    ) internal virtual override {
+    ) internal override {
         _regenerate(resource);
     }
 
@@ -444,7 +455,7 @@ contract PermissionedRegistry is
         uint256 /*oldRoles*/,
         uint256 /*newRoles*/,
         uint256 /*roleBitmap*/
-    ) internal virtual override {
+    ) internal override {
         _regenerate(resource);
     }
 
@@ -480,7 +491,7 @@ contract PermissionedRegistry is
     function _getSettableRoles(
         uint256 resource,
         address account
-    ) internal view virtual override returns (uint256) {
+    ) internal view override returns (uint256) {
         uint256 roleBitmap = super._getSettableRoles(resource, account);
         if (resource == ROOT_RESOURCE) {
             return roleBitmap;
@@ -500,7 +511,7 @@ contract PermissionedRegistry is
     function _getRevokableRoles(
         uint256 resource,
         address account
-    ) internal view virtual override returns (uint256) {
+    ) internal view override returns (uint256) {
         if (
             resource != ROOT_RESOURCE &&
             ownerOf(_constructTokenId(resource, _entry(resource))) == address(0)

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -164,7 +164,7 @@ contract WrapperRegistry is
         uint256 roleBitmap,
         uint64 expiry
     ) internal override returns (uint256 tokenId) {
-        return super.register(label, owner, subregistry, resolver, roleBitmap, expiry);
+        return _register(label, owner, subregistry, resolver, roleBitmap, expiry, false);
     }
 
     /// @dev Requires `ROLE_UPGRADE` to upgrade.


### PR DESCRIPTION
- added `PermissionedRegistry._register(..., bool checkRoles)`
- changed `PermissionedRegistry.register()` to call `_register(..., true)`
- changed `WrapperRegistry._inject()` to call `_register(..., false)`
- removed questionable function specifiers