### PR TITLE
Change `PermissionedRegistry.renew()` to allow revive

### DIFF
--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -192,15 +192,25 @@ contract PermissionedRegistry is
     }
 
     /// @inheritdoc IStandardRegistry
-    /// @dev Requires `REGISTERED | RESERVED` and `ROLE_RENEW`.
-    function renew(uint256 anyId, uint64 newExpiry) public {
-        (uint256 tokenId, Entry storage entry) =
-            _checkExpiryAndTokenRoles(anyId, RegistryRolesLib.ROLE_RENEW);
-        if (newExpiry < entry.expiry) {
-            revert CannotReduceExpiry(entry.expiry, newExpiry);
+    /// @dev If `REGISTERED | RESERVED`, requires `ROLE_RENEW`.
+    ///      If `AVAILABLE`, requires expiry > 0 and `ROLE_RENEW` on root.
+    function renew(uint256 anyId, uint64 newExpiry) public override {
+        Entry storage entry = _entry(anyId);
+        uint256 tokenId = _constructTokenId(anyId, entry);
+        address sender = _msgSender();
+        uint64 expiry = entry.expiry;
+        if (_isExpired(expiry)) {
+            if (expiry == 0 || !hasRootRoles(RegistryRolesLib.ROLE_RENEW, sender)) {
+                revert LabelExpired(tokenId); // never registered OR cannot revive
+            }
+        } else {
+            _checkRoles(_constructResource(anyId, entry), RegistryRolesLib.ROLE_RENEW, sender);
+        }
+        if (newExpiry < expiry) {
+            revert CannotReduceExpiry(expiry, newExpiry);
         }
         entry.expiry = newExpiry;
-        emit ExpiryUpdated(tokenId, newExpiry, _msgSender());
+        emit ExpiryUpdated(tokenId, newExpiry, sender);
     }
 
     /// @inheritdoc IEnhancedAccessControl

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -304,11 +304,29 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         registry.renew(tokenId, testExpiry);
     }
 
-    function test_renew_expired() external {
+    function test_renew_expiredReservation_asRoot() external {
+        uint256 tokenId = this._reserve();
+        vm.warp(testExpiry);
+        testExpiry += testExpiry;
+        registry.renew(tokenId, testExpiry);
+        assertEq(registry.getExpiry(tokenId), testExpiry);
+    }
+
+    function test_renew_expiredRegistration_asRoot() external {
+        uint256 tokenId = this._register();
+        vm.warp(testExpiry);
+        testExpiry += testExpiry;
+        registry.renew(tokenId, testExpiry);
+        assertEq(registry.getExpiry(tokenId), testExpiry);
+    }
+
+    function test_renew_expiredRegistration_asOwner() external {
+        testRoles = RegistryRolesLib.ROLE_RENEW;
         uint256 tokenId = this._register();
         vm.warp(testExpiry);
         testExpiry += testExpiry;
         vm.expectRevert(abi.encodeWithSelector(IStandardRegistry.LabelExpired.selector, tokenId));
+        vm.prank(testOwner);
         registry.renew(tokenId, testExpiry);
     }
 
@@ -1008,7 +1026,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
     // EAC Override: grantRoles() and revokeRoles()
     ////////////////////////////////////////////////////////////////////////
 
-    function test_grantRolesAsOwner(uint256) external {
+    function test_grantRoles_asOwner(uint256) external {
         uint256 roleBitmap = _randomRoleBitmap(false, true);
 
         testRoles = roleBitmap << 128; // admin
@@ -1020,7 +1038,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         assertTrue(registry.grantRoles(tokenId, roleBitmap, user2));
     }
 
-    function test_grantRolesAsRoot(uint256) external {
+    function test_grantRoles_asRoot(uint256) external {
         uint256 roleBitmap = _randomRoleBitmap(false, true);
 
         uint256 tokenId = this._register();
@@ -1028,7 +1046,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         assertTrue(registry.grantRoles(tokenId, roleBitmap, testOwner));
     }
 
-    function test_grantRolesWithAdminAsOwner(uint256) external {
+    function test_grantRoles_withAdminAsOwner(uint256) external {
         uint256 roleBitmap = _randomRoleBitmap(true, false);
 
         uint256 tokenId = this._register();
@@ -1045,7 +1063,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         registry.grantRoles(tokenId, roleBitmap, user2);
     }
 
-    function test_grantRolesWithAdminAsOwnerAndRoot(uint256) external {
+    function test_grantRoles_withAdminAsOwnerAndRoot(uint256) external {
         uint256 roleBitmap = _randomRoleBitmap(true, false);
 
         testOwner = address(this); // mint to account with root
@@ -1062,7 +1080,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         registry.grantRoles(tokenId, roleBitmap, user2);
     }
 
-    function test_grantRolesWhileExpired(uint256) external {
+    function test_grantRoles_whileExpired(uint256) external {
         uint256 roleBitmap = _randomRoleBitmap(true, true);
 
         uint256 tokenId = this._register();
@@ -1079,7 +1097,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         registry.grantRoles(tokenId, roleBitmap, user2);
     }
 
-    function test_grantRolesWhileReserved(uint256) external {
+    function test_grantRoles_whileReserved(uint256) external {
         uint256 roleBitmap = _randomRoleBitmap(true, true);
 
         uint256 tokenId = this._reserve();
@@ -1095,7 +1113,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         registry.grantRoles(tokenId, roleBitmap, user2);
     }
 
-    function test_revokeRolesAsOwnerHavingAdmin(uint256) external {
+    function test_revokeRoles_asOwnerHavingAdmin(uint256) external {
         uint256 roleBitmap = _randomRoleBitmap(false, true);
         uint256 adminRoleBitmap = roleBitmap << 128;
 
@@ -1113,7 +1131,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         assertTrue(registry.revokeRoles(tokenId, adminRoleBitmap, testOwner));
     }
 
-    function test_revokeRolesAsOwnerLackingAdmin(uint256) external {
+    function test_revokeRoles_asOwnerLackingAdmin(uint256) external {
         testRoles = _randomRoleBitmap(false, true);
 
         uint256 tokenId = this._register();
@@ -1130,7 +1148,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         registry.revokeRoles(tokenId, testRoles, testOwner);
     }
 
-    function test_revokeRolesAsRoot(uint256) external {
+    function test_revokeRoles_asRoot(uint256) external {
         testRoles = _randomRoleBitmap(true, true);
 
         uint256 tokenId = this._register();
@@ -1138,7 +1156,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         assertTrue(registry.revokeRoles(tokenId, testRoles, testOwner));
     }
 
-    function test_revokeRolesWhileExpired(uint256) external {
+    function test_revokeRoles_whileExpired(uint256) external {
         testRoles = _randomRoleBitmap(true, true);
 
         uint256 tokenId = this._register();
@@ -1155,7 +1173,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         registry.revokeRoles(tokenId, testRoles, testOwner);
     }
 
-    function test_revokeRolesWhileReserved(uint256) external {
+    function test_revokeRoles_whileReserved(uint256) external {
         uint256 roleBitmap = _randomRoleBitmap(true, true);
 
         uint256 tokenId = this._reserve();


### PR DESCRIPTION
- changed `PermissionedRegistry.renew()` to allow "revive" (expired renew) from `ROOT_RESOURCE`
- added tests