### PR TITLE
Tag migrations onchain

### DIFF
--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -391,6 +391,7 @@ contract PermissionedRegistry is
             if (expiry == 0) {
                 expiry = entry.expiry; // use current expiry
             }
+            roleBitmap |= RegistryRolesLib.ROLE_REGISTER_RESERVED;
         }
         if (_isExpired(expiry)) {
             revert CannotSetPastExpiry(expiry);

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -383,15 +383,15 @@ contract PermissionedRegistry is
             if (prevOwner != address(0)) {
                 revert LabelAlreadyRegistered(label); // cannot overwrite REGISTERED
             } else if (owner == address(0)) {
-                revert LabelAlreadyReserved(label); // cannot reserve/register RESERVED
+                revert LabelAlreadyReserved(label); // cannot overwrite RESERVED
             }
             if (checkRoles) {
                 _checkRoles(ROOT_RESOURCE, RegistryRolesLib.ROLE_REGISTER_RESERVED, sender);
             }
             if (expiry == 0) {
-                expiry = entry.expiry; // use current expiry
+                expiry = entry.expiry; // use RESERVED expiry
             }
-            roleBitmap |= RegistryRolesLib.ROLE_REGISTER_RESERVED;
+            roleBitmap |= RegistryRolesLib.ROLE_WAS_RESERVED; // remember
         }
         if (_isExpired(expiry)) {
             revert CannotSetPastExpiry(expiry);

--- a/contracts/src/registry/libraries/RegistryRolesLib.sol
+++ b/contracts/src/registry/libraries/RegistryRolesLib.sol
@@ -5,47 +5,50 @@ pragma solidity >=0.8.13;
 ///      `EnhancedAccessControl` nybble-packed bitmap system. Each role occupies one nybble (4 bits)
 ///      at a specific index, with its admin counterpart shifted 128 bits higher.
 library RegistryRolesLib {
-    /// @dev Nybble 0 — authorizes registering and reserving new names. Root only.
+    /// @dev Nybble 0: authorizes registering and reserving new names. Root only.
     uint256 internal constant ROLE_REGISTRAR = 1 << 0;
-    /// @dev Nybble 32 — authorizes setting ROLE_REGISTRAR.
+    /// @dev Nybble 32: authorizes setting ROLE_REGISTRAR.
     uint256 internal constant ROLE_REGISTRAR_ADMIN = ROLE_REGISTRAR << 128;
 
-    /// @dev Nybble 1 — authorizes registering a reserved name (promoting it from RESERVED to REGISTERED). Root-only.
+    /// @dev Nybble 1: authorizes registering a reserved name (promoting it from RESERVED to REGISTERED). Root-only.
     uint256 internal constant ROLE_REGISTER_RESERVED = 1 << 4;
-    /// @dev Nybble 33 - authorizes setting ROLE_REGISTER_RESERVED.
+    /// @dev Nybble 33: authorizes setting ROLE_REGISTER_RESERVED.
     uint256 internal constant ROLE_REGISTER_RESERVED_ADMIN = ROLE_REGISTER_RESERVED << 128;
 
-    /// @dev Nybble 2 — authorizes setting the parent registry. Root-only.
+    /// @dev Nybble 2: authorizes setting the parent registry. Root-only.
     uint256 internal constant ROLE_SET_PARENT = 1 << 8;
-    /// @dev Nybble 34 - authorizes setting ROLE_SET_PARENT.
+    /// @dev Nybble 34: authorizes setting ROLE_SET_PARENT.
     uint256 internal constant ROLE_SET_PARENT_ADMIN = ROLE_SET_PARENT << 128;
 
-    /// @dev Nybble 3 — authorizes unregistering names. Root or token.
+    /// @dev Nybble 3: authorizes unregistering names. Root or token.
     uint256 internal constant ROLE_UNREGISTER = 1 << 12;
-    /// @dev Nybble 35 - authorizes setting ROLE_UNREGISTER.
+    /// @dev Nybble 35: authorizes setting ROLE_UNREGISTER.
     uint256 internal constant ROLE_UNREGISTER_ADMIN = ROLE_UNREGISTER << 128;
 
-    /// @dev Nybble 4 — authorizes extending name expiry. Root or token.
+    /// @dev Nybble 4: authorizes extending name expiry. Root or token.
     uint256 internal constant ROLE_RENEW = 1 << 16;
-    /// @dev Nybble 36 - authorizes setting ROLE_RENEW.
+    /// @dev Nybble 36: authorizes setting ROLE_RENEW.
     uint256 internal constant ROLE_RENEW_ADMIN = ROLE_RENEW << 128;
 
-    /// @dev Nybble 5 — authorizes changing a name's child registry. Root or token.
+    /// @dev Nybble 5: authorizes changing a name's child registry. Root or token.
     uint256 internal constant ROLE_SET_SUBREGISTRY = 1 << 20;
-    /// @dev Nybble 37 - authorizes setting ROLE_SET_SUBREGISTRY.
+    /// @dev Nybble 37: authorizes setting ROLE_SET_SUBREGISTRY.
     uint256 internal constant ROLE_SET_SUBREGISTRY_ADMIN = ROLE_SET_SUBREGISTRY << 128;
 
-    /// @dev Nybble 6 — authorizes changing a name's resolver. Root or token.
+    /// @dev Nybble 6: authorizes changing a name's resolver. Root or token.
     uint256 internal constant ROLE_SET_RESOLVER = 1 << 24;
-    /// @dev Nybble 38 - authorizes setting ROLE_SET_RESOLVER.
+    /// @dev Nybble 38: authorizes setting ROLE_SET_RESOLVER.
     uint256 internal constant ROLE_SET_RESOLVER_ADMIN = ROLE_SET_RESOLVER << 128;
 
-    /// @dev Nybble 7 — authorizes ERC1155 token transfers. Root or token.
+    /// @dev Nybble 7: authorizes ERC1155 token transfers. Root or token.
     ///      This role is only checked on the token owner, not the operator.
     uint256 internal constant ROLE_CAN_TRANSFER_ADMIN = (1 << 28) << 128;
 
-    /// @dev Nybble 31 — authorizes UUPS proxy upgrades. Root-only.
+    /// @dev Nybble 8: tags a name that was registered via ROLE_REGISTER_RESERVED. Token only. Not revokable.
+    uint256 internal constant ROLE_WAS_RESERVED = (1 << 32);
+
+    /// @dev Nybble 31: authorizes UUPS proxy upgrades. Root-only.
     uint256 internal constant ROLE_UPGRADE = 1 << 124;
-    /// @dev Nybble 63 - authorizes setting ROLE_UPGRADE.
+    /// @dev Nybble 63: authorizes setting ROLE_UPGRADE.
     uint256 internal constant ROLE_UPGRADE_ADMIN = ROLE_UPGRADE << 128;
 }

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -315,7 +315,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         LibMigration.Data memory md = _makeData(name);
         uint256 tokenIdV1 = LibLabel.id(md.label);
 
-        assertFalse(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_REGISTER_RESERVED, user));
+        assertFalse(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, user));
 
         vm.prank(user);
         nameWrapper.safeTransferFrom(
@@ -326,7 +326,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             abi.encode(md)
         );
 
-        assertTrue(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_REGISTER_RESERVED, user));
+        assertTrue(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, user));
     }
 
     function test_migrate() external {
@@ -387,7 +387,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             RegistryRolesLib.ROLE_SET_RESOLVER |
                 RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
                 RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
-                RegistryRolesLib.ROLE_REGISTER_RESERVED
+                RegistryRolesLib.ROLE_WAS_RESERVED
         );
         vm.expectEmit();
         emit IRegistryEvents.SubregistryUpdated(

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -385,9 +385,9 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             md.owner,
             0 /*old roles*/,
             RegistryRolesLib.ROLE_SET_RESOLVER |
-                RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
-                RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
-                RegistryRolesLib.ROLE_WAS_RESERVED
+            RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
+            RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
+            RegistryRolesLib.ROLE_WAS_RESERVED
         );
         vm.expectEmit();
         emit IRegistryEvents.SubregistryUpdated(

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -310,6 +310,25 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
+    function test_checkIfMigrated() external {
+        bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        LibMigration.Data memory md = _makeData(name);
+        uint256 tokenIdV1 = LibLabel.id(md.label);
+
+        assertFalse(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_REGISTER_RESERVED, user));
+
+        vm.prank(user);
+        nameWrapper.safeTransferFrom(
+            user,
+            address(migrationController),
+            uint256(NameCoder.namehash(name, 0)),
+            1,
+            abi.encode(md)
+        );
+
+        assertTrue(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_REGISTER_RESERVED, user));
+    }
+
     function test_migrate() external {
         bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         checkResolution(name, address(ensV2Resolver), address(ensV1Resolver));
@@ -366,8 +385,9 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             md.owner,
             0 /*old roles*/,
             RegistryRolesLib.ROLE_SET_RESOLVER |
-            RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
-            RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN
+                RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
+                RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
+                RegistryRolesLib.ROLE_REGISTER_RESERVED
         );
         vm.expectEmit();
         emit IRegistryEvents.SubregistryUpdated(
@@ -382,7 +402,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         nameWrapper.safeTransferFrom(
             user,
             address(migrationController),
-            uint256(NameCoder.namehash(name, 0)),
+            uint256(node),
             1,
             abi.encode(md)
         );

--- a/contracts/test/unit/migration/UnlockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/UnlockedMigrationController.t.sol
@@ -5,7 +5,9 @@ pragma solidity >=0.8.13;
 
 import {console} from "forge-std/console.sol";
 
+import {ENS} from "@ens/contracts/registry/ENS.sol";
 import {CAN_DO_EVERYTHING, CANNOT_UNWRAP} from "@ens/contracts/wrapper/INameWrapper.sol";
+import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import {IERC1155Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
@@ -13,28 +15,23 @@ import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Recei
 import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
+import {InvalidOwner, UnauthorizedCaller} from "~src/CommonErrors.sol";
 import {WrappedErrorLib} from "~src/utils/WrappedErrorLib.sol";
+import {LibLabel} from "~src/utils/LibLabel.sol";
+import {LibMigration} from "~src/migration/libraries/LibMigration.sol";
 import {IEnhancedAccessControl} from "~src/access-control/EnhancedAccessControl.sol";
-import {
-    IPermissionedRegistry,
-    RegistryRolesLib,
-    IRegistry,
-    LibLabel
-} from "~src/registry/PermissionedRegistry.sol";
+import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
 import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
+import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
+import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
+import {REGISTRATION_ROLE_BITMAP} from "~src/registrar/ETHRegistrar.sol";
 import {
-    UnlockedMigrationController,
-    LibMigration,
-    InvalidOwner,
-    UnauthorizedCaller
+    UnlockedMigrationController
 } from "~src/migration/UnlockedMigrationController.sol";
 import {
-    MigrationControllerFixture,
-    ERC165Checker,
-    NameCoder
-} from "./MigrationControllerFixture.sol";
-import {REGISTRATION_ROLE_BITMAP} from "~src/registrar/ETHRegistrar.sol";
-import {V1Fixture, ENS} from "~test/fixtures/V1Fixture.sol";
+    MigrationControllerFixture
+} from "~test/unit/migration/MigrationControllerFixture.sol";
+import {V1Fixture} from "~test/fixtures/V1Fixture.sol";
 import {V2Fixture} from "~test/fixtures/V2Fixture.sol";
 
 contract UnlockedMigrationControllerTest is MigrationControllerFixture {

--- a/contracts/test/unit/migration/UnlockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/UnlockedMigrationController.t.sol
@@ -24,12 +24,8 @@ import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
 import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
 import {REGISTRATION_ROLE_BITMAP} from "~src/registrar/ETHRegistrar.sol";
-import {
-    UnlockedMigrationController
-} from "~src/migration/UnlockedMigrationController.sol";
-import {
-    MigrationControllerFixture
-} from "~test/unit/migration/MigrationControllerFixture.sol";
+import {UnlockedMigrationController} from "~src/migration/UnlockedMigrationController.sol";
+import {MigrationControllerFixture} from "~test/unit/migration/MigrationControllerFixture.sol";
 
 contract UnlockedMigrationControllerTest is MigrationControllerFixture {
     UnlockedMigrationController migrationController;

--- a/contracts/test/unit/migration/UnlockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/UnlockedMigrationController.t.sol
@@ -314,7 +314,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         (bytes memory name, uint256 tokenIdV1) = registerUnwrapped(testLabel);
         LibMigration.Data memory md = _makeData(name);
 
-        assertFalse(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_REGISTER_RESERVED, user));
+        assertFalse(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, user));
 
         vm.prank(user);
         ethRegistrarV1.safeTransferFrom(
@@ -324,7 +324,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             abi.encode(md)
         );
 
-        assertTrue(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_REGISTER_RESERVED, user));
+        assertTrue(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, user));
     }
 
     function test_unwrapped_migrate() external {
@@ -351,7 +351,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             tokenId,
             md.owner,
             0 /*old roles*/,
-            REGISTRATION_ROLE_BITMAP | RegistryRolesLib.ROLE_REGISTER_RESERVED
+            REGISTRATION_ROLE_BITMAP | RegistryRolesLib.ROLE_WAS_RESERVED
         );
         vm.expectEmit();
         emit IRegistryEvents.SubregistryUpdated(
@@ -410,7 +410,7 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
             tokenId,
             md.owner,
             0 /*old roles*/,
-            REGISTRATION_ROLE_BITMAP | RegistryRolesLib.ROLE_REGISTER_RESERVED
+            REGISTRATION_ROLE_BITMAP | RegistryRolesLib.ROLE_WAS_RESERVED
         );
         vm.expectEmit();
         emit IRegistryEvents.SubregistryUpdated(

--- a/contracts/test/unit/migration/UnlockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/UnlockedMigrationController.t.sol
@@ -5,7 +5,6 @@ pragma solidity >=0.8.13;
 
 import {console} from "forge-std/console.sol";
 
-import {ENS} from "@ens/contracts/registry/ENS.sol";
 import {CAN_DO_EVERYTHING, CANNOT_UNWRAP} from "@ens/contracts/wrapper/INameWrapper.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
@@ -31,8 +30,6 @@ import {
 import {
     MigrationControllerFixture
 } from "~test/unit/migration/MigrationControllerFixture.sol";
-import {V1Fixture} from "~test/fixtures/V1Fixture.sol";
-import {V2Fixture} from "~test/fixtures/V2Fixture.sol";
 
 contract UnlockedMigrationControllerTest is MigrationControllerFixture {
     UnlockedMigrationController migrationController;

--- a/contracts/test/unit/migration/UnlockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/UnlockedMigrationController.t.sol
@@ -28,8 +28,14 @@ import {
     InvalidOwner,
     UnauthorizedCaller
 } from "~src/migration/UnlockedMigrationController.sol";
-
-import {MigrationControllerFixture, NameCoder} from "./MigrationControllerFixture.sol";
+import {
+    MigrationControllerFixture,
+    ERC165Checker,
+    NameCoder
+} from "./MigrationControllerFixture.sol";
+import {REGISTRATION_ROLE_BITMAP} from "~src/registrar/ETHRegistrar.sol";
+import {V1Fixture, ENS} from "~test/fixtures/V1Fixture.sol";
+import {V2Fixture} from "~test/fixtures/V2Fixture.sol";
 
 contract UnlockedMigrationControllerTest is MigrationControllerFixture {
     UnlockedMigrationController migrationController;
@@ -304,6 +310,23 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
+    function test_checkIfMigrated() external {
+        (bytes memory name, uint256 tokenIdV1) = registerUnwrapped(testLabel);
+        LibMigration.Data memory md = _makeData(name);
+
+        assertFalse(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_REGISTER_RESERVED, user));
+
+        vm.prank(user);
+        ethRegistrarV1.safeTransferFrom(
+            user,
+            address(migrationController),
+            tokenIdV1,
+            abi.encode(md)
+        );
+
+        assertTrue(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_REGISTER_RESERVED, user));
+    }
+
     function test_unwrapped_migrate() external {
         (bytes memory name, uint256 tokenIdV1) = registerUnwrapped(testLabel);
         LibMigration.Data memory md = _makeData(name);
@@ -323,6 +346,13 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         emit IERC1155.TransferSingle(address(migrationController), address(0), md.owner, tokenId, 1);
         vm.expectEmit();
         emit IPermissionedRegistry.TokenResource(tokenId, tokenId);
+        vm.expectEmit();
+        emit IEnhancedAccessControl.EACRolesChanged(
+            tokenId,
+            md.owner,
+            0 /*old roles*/,
+            REGISTRATION_ROLE_BITMAP | RegistryRolesLib.ROLE_REGISTER_RESERVED
+        );
         vm.expectEmit();
         emit IRegistryEvents.SubregistryUpdated(
             tokenId,
@@ -375,6 +405,13 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         emit IERC1155.TransferSingle(address(migrationController), address(0), md.owner, tokenId, 1);
         vm.expectEmit();
         emit IPermissionedRegistry.TokenResource(tokenId, tokenId);
+        vm.expectEmit();
+        emit IEnhancedAccessControl.EACRolesChanged(
+            tokenId,
+            md.owner,
+            0 /*old roles*/,
+            REGISTRATION_ROLE_BITMAP | RegistryRolesLib.ROLE_REGISTER_RESERVED
+        );
         vm.expectEmit();
         emit IRegistryEvents.SubregistryUpdated(
             tokenId,


### PR DESCRIPTION
- changed `PermissionedRegistry` to assign token `ROLE_WAS_RESERVED` when registered via reservation
- added tests