### PR TITLE
fix: advance reverse registrar inception on direct writes

### DIFF
--- a/contracts/src/reverse-registrar/L2ReverseRegistrar.sol
+++ b/contracts/src/reverse-registrar/L2ReverseRegistrar.sol
@@ -116,11 +116,13 @@ contract L2ReverseRegistrar is IL2ReverseRegistrar, ERC165, StandaloneReverseReg
     /// @inheritdoc IL2ReverseRegistrar
     function setName(string calldata name) external {
         _setName(msg.sender, name);
+        _advanceInception(msg.sender);
     }
 
     /// @inheritdoc IL2ReverseRegistrar
     function setNameForAddr(address addr, string calldata name) external authorized(addr) {
         _setName(addr, name);
+        _advanceInception(addr);
     }
 
     /// @inheritdoc IL2ReverseRegistrar
@@ -203,6 +205,15 @@ contract L2ReverseRegistrar is IL2ReverseRegistrar, ERC165, StandaloneReverseReg
 
         // Update the inception to the new signedAt
         inceptionOf[addr] = signedAt;
+    }
+
+    /// @notice Advances the inception timestamp after an authorized direct name update.
+    /// @dev The replay fence never moves backward.
+    /// @param addr The address whose inception should be advanced.
+    function _advanceInception(address addr) internal {
+        if (block.timestamp > inceptionOf[addr]) {
+            inceptionOf[addr] = block.timestamp;
+        }
     }
 
     /// @notice Checks if the provided address owns the contract via the Ownable interface.

--- a/contracts/src/reverse-registrar/README.md
+++ b/contracts/src/reverse-registrar/README.md
@@ -21,7 +21,7 @@ Signature-based methods use an **inception timestamp** system for replay protect
 1. The signature's `signedAt` timestamp must be **strictly greater than** the current inception for that address
 2. The `signedAt` timestamp must not be in the future (i.e., `signedAt <= block.timestamp`)
 
-When a valid signature is used, the inception is updated to the `signedAt` value. This ensures:
+When a valid signature is used, the inception is updated to the `signedAt` value. Authorized direct updates via `setName()` or `setNameForAddr()` advance the inception to the current block timestamp. This ensures:
 - Each signature can only be used once per chain
 - Newer signatures always supersede older ones
 - Ordering is guaranteed (signatures with older `signedAt` values become invalid once a newer one is used)

--- a/contracts/test/unit/reverse-registrar/L2ReverseRegistrar.t.sol
+++ b/contracts/test/unit/reverse-registrar/L2ReverseRegistrar.t.sol
@@ -320,6 +320,49 @@ contract L2ReverseRegistrarTest is Test {
         vm.stopPrank();
     }
 
+    function test_setName_updatesInception() public {
+        uint256 timestamp = 1_700_000_000;
+        vm.warp(timestamp);
+
+        vm.prank(user1);
+        registrar.setName("myname.eth");
+
+        assertEq(registrar.inceptionOf(user1), timestamp, "Inception should track direct write");
+    }
+
+    function test_setName_invalidatesPriorUnusedSignature() public {
+        string memory signedName = "signed.eth";
+        uint256 signedAt = block.timestamp;
+        uint256[] memory chainIds = _singleChainIdArray();
+
+        bytes32 message = _createNameForAddrMessage(signedName, user1, chainIds, signedAt);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(user1Pk, message);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        IL2ReverseRegistrar.NameClaim memory claim = IL2ReverseRegistrar.NameClaim({
+            name: signedName,
+            addr: user1,
+            chainIds: chainIds,
+            signedAt: signedAt
+        });
+
+        vm.warp(block.timestamp + 1);
+        uint256 directSetAt = block.timestamp;
+
+        vm.prank(user1);
+        registrar.setName("direct.eth");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                L2ReverseRegistrar.StaleSignature.selector,
+                signedAt,
+                directSetAt
+            )
+        );
+        vm.prank(relayer);
+        registrar.setNameForAddrWithSignature(claim, signature);
+    }
+
     function test_setName_canSetToEmptyString() public {
         string memory name_ = "myname.eth";
 
@@ -376,6 +419,59 @@ contract L2ReverseRegistrarTest is Test {
 
         bytes32 node = _getNode(user1);
         assertEq(registrar.name(node), name_, "Name should be set for caller");
+    }
+
+    function test_setNameForAddr_updatesInceptionForTarget() public {
+        uint256 timestamp = 1_700_000_000;
+        vm.warp(timestamp);
+
+        vm.prank(user1);
+        registrar.setNameForAddr(address(mockOwnableEoa), "myname.eth");
+
+        assertEq(
+            registrar.inceptionOf(address(mockOwnableEoa)),
+            timestamp,
+            "Inception should track target direct write"
+        );
+    }
+
+    function test_setNameForAddr_invalidatesPriorUnusedOwnableSignature() public {
+        string memory signedName = "signed.eth";
+        uint256 signedAt = block.timestamp;
+        uint256[] memory chainIds = _singleChainIdArray();
+
+        bytes32 message = _createNameForOwnableMessage(
+            signedName,
+            address(mockOwnableEoa),
+            user1,
+            chainIds,
+            signedAt
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(user1Pk, message);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        IL2ReverseRegistrar.NameClaim memory claim = IL2ReverseRegistrar.NameClaim({
+            name: signedName,
+            addr: address(mockOwnableEoa),
+            chainIds: chainIds,
+            signedAt: signedAt
+        });
+
+        vm.warp(block.timestamp + 1);
+        uint256 directSetAt = block.timestamp;
+
+        vm.prank(user1);
+        registrar.setNameForAddr(address(mockOwnableEoa), "direct.eth");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                L2ReverseRegistrar.StaleSignature.selector,
+                signedAt,
+                directSetAt
+            )
+        );
+        vm.prank(relayer);
+        registrar.setNameForOwnableWithSignature(claim, user1, signature);
     }
 
     function test_setNameForAddr_revert_callerNotOwnerOfTargetAddress() public {


### PR DESCRIPTION
`inceptionOf` now gets updated on direct `setName` or `setNameForAddr` calls so that older signatures can't be used to overwrite newer values.

Fixes BET-609
