### PR TITLE
fix: gate wrapper registry upgrades

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 - When running tests they should be run from the contracts/ subfolder.
 - See package.json for the test commands.
-- When testing for event emission never use vm.expectEmit, always use vm.recordLogs and actually check the logs properly.
+- When testing for event emission, always check logs properly. Use either `vm.recordLogs` with explicit log assertions, or `vm.expectEmit` paired with an `emit Event(...)` expectation before the call under test.
 - Do not use --via-ir when compiling contracts and tests. If there are Solidity stack too deep errors then fix them through code refactoring.
 - When doing vm.prank and vm.expectRevert together for a call, always place the vm.expectRevert call before the vm.prank call.
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "contracts-v2",

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -108,7 +108,7 @@ In registry contracts, EAC is used with these specific behaviors:
 | `ROLE_SET_SUBREGISTRY`   | 20  | 148       | Root or token| Change child registry                                                    |
 | `ROLE_SET_RESOLVER`      | 24  | 152       | Root or token| Change resolver address                                                  |
 | `ROLE_CAN_TRANSFER_ADMIN`| 28* | 156       | Root or token| Admin-only. Auto-granted to name owner. Revoke to make soulbound.        |
-| `ROLE_UPGRADE`           | 124 | 252       | Root-only    | UUPS proxy upgrades                                                      |
+| `ROLE_UPGRADE`           | 124 | 252       | Root-only    | UUPS proxy upgrades. WrapperRegistry targets must also be DAO-approved   |
 
 \*`ROLE_CAN_TRANSFER_ADMIN` has no base role; it is admin-only (upper 128 bits).
 
@@ -145,7 +145,7 @@ Roles granted during core deployment.
 
 Legend: A = admin only, R = regular only, AR = admin and regular
 
-*StandardRentPriceOracle uses Ownable, not EAC. Implementation contracts (PermissionedResolverImpl, UserRegistryImpl, WrapperRegistryImpl) grant no roles at deployment; proxies receive roles via `initialize()` when created.*
+*StandardRentPriceOracle and ApprovedUpgradeGate use Ownable, not EAC. Implementation contracts (PermissionedResolverImpl, UserRegistryImpl, WrapperRegistryImpl) grant no roles at deployment; proxies receive roles via `initialize()` when created.*
 
 *The tokens for .eth, .reverse and .addr.reverse are owned by the deployer.*
 

--- a/contracts/deploy/03_ApprovedUpgradeGate.ts
+++ b/contracts/deploy/03_ApprovedUpgradeGate.ts
@@ -1,0 +1,14 @@
+import { artifacts, execute } from "@rocketh";
+
+export default execute(
+  async ({ deploy, namedAccounts: { deployer, owner } }) => {
+    await deploy("ApprovedUpgradeGate", {
+      account: deployer,
+      artifact: artifacts.ApprovedUpgradeGate,
+      args: [owner],
+    });
+  },
+  {
+    tags: ["ApprovedUpgradeGate", "v2"],
+  },
+);

--- a/contracts/deploy/03_WrapperRegistryImpl.ts
+++ b/contracts/deploy/03_WrapperRegistryImpl.ts
@@ -18,6 +18,10 @@ export default execute(
     const ensV1Resolver =
       get<(typeof artifacts.ENSV1Resolver)["abi"]>("ENSV1Resolver");
 
+    const approvedUpgradeGate = get<
+      (typeof artifacts.ApprovedUpgradeGate)["abi"]
+    >("ApprovedUpgradeGate");
+
     await deploy("WrapperRegistryImpl", {
       account: deployer,
       artifact: artifacts.WrapperRegistry,
@@ -27,6 +31,7 @@ export default execute(
         ensV1Resolver.address,
         hcaFactory.address,
         registryMetadata.address,
+        approvedUpgradeGate.address,
       ],
     });
   },
@@ -38,6 +43,7 @@ export default execute(
       "SimpleRegistryMetadata",
       "VerifiableFactory",
       "ENSV1Resolver",
+      "ApprovedUpgradeGate",
     ],
   },
 );

--- a/contracts/src/registry/ApprovedUpgradeGate.sol
+++ b/contracts/src/registry/ApprovedUpgradeGate.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @notice Allowlist for approved implementation upgrade targets.
+contract ApprovedUpgradeGate is Ownable {
+    ////////////////////////////////////////////////////////////////////////
+    // Storage
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Returns whether an implementation may be used as an upgrade target.
+    mapping(address implementation => bool approved) public approvedImplementations;
+
+    ////////////////////////////////////////////////////////////////////////
+    // Events
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Approval status changed for an implementation.
+    /// @param implementation The implementation address.
+    /// @param approved Whether upgrades to the implementation are approved.
+    event ImplementationApprovalChanged(address indexed implementation, bool indexed approved);
+
+    ////////////////////////////////////////////////////////////////////////
+    // Initialization
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Creates the upgrade gate.
+    /// @param owner_ The address that controls implementation approvals.
+    constructor(address owner_) Ownable(owner_) {}
+
+    ////////////////////////////////////////////////////////////////////////
+    // Implementation
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Set whether an implementation may be used as an upgrade target.
+    /// @param implementation The implementation address.
+    /// @param approved Whether upgrades to the implementation are approved.
+    function setImplementationApproval(address implementation, bool approved) external onlyOwner {
+        approvedImplementations[implementation] = approved;
+        emit ImplementationApprovalChanged(implementation, approved);
+    }
+}

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -13,6 +13,7 @@ import {LibMigration} from "../migration/libraries/LibMigration.sol";
 import {LockedWrapperReceiver} from "../migration/LockedWrapperReceiver.sol";
 import {IWrapperRegistry} from "../registry/interfaces/IWrapperRegistry.sol";
 
+import {ApprovedUpgradeGate} from "./ApprovedUpgradeGate.sol";
 import {IRegistry} from "./interfaces/IRegistry.sol";
 import {IRegistryMetadata} from "./interfaces/IRegistryMetadata.sol";
 import {IStandardRegistry} from "./interfaces/IStandardRegistry.sol";
@@ -35,12 +36,24 @@ contract WrapperRegistry is
     /// @notice Fallback resolver for ENSv1 resolution.
     address public immutable V1_RESOLVER;
 
+    /// @notice Gate for approved implementation upgrade targets.
+    ApprovedUpgradeGate public immutable UPGRADE_GATE;
+
     ////////////////////////////////////////////////////////////////////////
     // Storage
     ////////////////////////////////////////////////////////////////////////
 
     /// @dev The namehash of this registry.
     bytes32 internal _node;
+
+    ////////////////////////////////////////////////////////////////////////
+    // Errors
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Upgrade target is not approved for `WrapperRegistry` proxies.
+    /// @dev Error selector: `0xf74d7dd0`
+    /// @param implementation The disallowed implementation address.
+    error UpgradeTargetNotApproved(address implementation);
 
     ////////////////////////////////////////////////////////////////////////
     // Initialization
@@ -52,17 +65,20 @@ contract WrapperRegistry is
     /// @param ensV1Resolver The ENSv1 resolver.
     /// @param hcaFactory The HCA factory.
     /// @param metadataProvider The metadata provider.
+    /// @param upgradeGate The upgrade target allowlist.
     constructor(
         INameWrapper nameWrapper,
         VerifiableFactory verifiableFactory,
         address ensV1Resolver,
         IHCAFactoryBasic hcaFactory,
-        IRegistryMetadata metadataProvider
+        IRegistryMetadata metadataProvider,
+        ApprovedUpgradeGate upgradeGate
     )
         PermissionedRegistry(hcaFactory, metadataProvider, address(0), 0) // no roles are granted
         LockedWrapperReceiver(nameWrapper, verifiableFactory, address(this))
     {
         V1_RESOLVER = ensV1Resolver;
+        UPGRADE_GATE = upgradeGate;
         _disableInitializers();
     }
 
@@ -167,11 +183,13 @@ contract WrapperRegistry is
         return _register(label, owner, subregistry, resolver, roleBitmap, expiry, false);
     }
 
-    /// @dev Requires `ROLE_UPGRADE` to upgrade.
+    /// @dev Requires `ROLE_UPGRADE` and approval for the target implementation.
     function _authorizeUpgrade(
-        address
-    ) internal override onlyRootRoles(RegistryRolesLib.ROLE_UPGRADE) {
-        //
+        address newImplementation
+    ) internal view override onlyRootRoles(RegistryRolesLib.ROLE_UPGRADE) {
+        if (!UPGRADE_GATE.approvedImplementations(newImplementation)) {
+            revert UpgradeTargetNotApproved(newImplementation);
+        }
     }
 
     /// @inheritdoc LockedWrapperReceiver

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -34,6 +34,7 @@ import {
     IEnhancedAccessControl,
     EACBaseRolesLib
 } from "~src/access-control/EnhancedAccessControl.sol";
+import {IHCAFactoryBasic} from "~src/hca/interfaces/IHCAFactoryBasic.sol";
 import {
     WrapperRegistry,
     IWrapperRegistry,
@@ -44,6 +45,8 @@ import {
     LibMigration
 } from "~src/registry/WrapperRegistry.sol";
 import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
+import {IRegistryMetadata} from "~src/registry/interfaces/IRegistryMetadata.sol";
+import {ApprovedUpgradeGate} from "~src/registry/ApprovedUpgradeGate.sol";
 import {
     MigrationControllerFixture,
     ERC165Checker,
@@ -54,16 +57,19 @@ import {V2Fixture, VerifiableFactory} from "~test/fixtures/V2Fixture.sol";
 
 contract LockedMigrationControllerTest is MigrationControllerFixture {
     LockedMigrationController migrationController;
+    ApprovedUpgradeGate approvedUpgradeGate;
     WrapperRegistry wrapperRegistryImpl;
 
     function setUp() public override {
         super.setUp();
+        approvedUpgradeGate = new ApprovedUpgradeGate(address(this));
         wrapperRegistryImpl = new WrapperRegistry(
             nameWrapper,
             verifiableFactory,
             address(ensV1Resolver),
             hcaFactory,
-            metadata
+            metadata,
+            approvedUpgradeGate
         );
         migrationController = new LockedMigrationController(
             nameWrapper,
@@ -104,6 +110,47 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             ),
             "IERC1155Receiver"
         );
+    }
+
+    function test_wrapperRegistryUpgrade_revertsForUnapprovedTarget() external {
+        WrapperRegistry registry = _deployWrapperRegistryProxy(address(this));
+        WrapperRegistryV2Mock newImplementation = _newWrapperRegistryV2Mock();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                WrapperRegistry.UpgradeTargetNotApproved.selector,
+                address(newImplementation)
+            )
+        );
+        registry.upgradeToAndCall(address(newImplementation), "");
+    }
+
+    function test_wrapperRegistryUpgrade_allowsApprovedTarget() external {
+        WrapperRegistry registry = _deployWrapperRegistryProxy(address(this));
+        WrapperRegistryV2Mock newImplementation = _newWrapperRegistryV2Mock();
+
+        approvedUpgradeGate.setImplementationApproval(address(newImplementation), true);
+        registry.upgradeToAndCall(address(newImplementation), "");
+
+        assertEq(WrapperRegistryV2Mock(address(registry)).version(), 2, "version");
+    }
+
+    function test_wrapperRegistryUpgrade_requiresUpgradeRole() external {
+        WrapperRegistry registry = _deployWrapperRegistryProxy(address(this));
+        WrapperRegistryV2Mock newImplementation = _newWrapperRegistryV2Mock();
+
+        approvedUpgradeGate.setImplementationApproval(address(newImplementation), true);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                registry.ROOT_RESOURCE(),
+                RegistryRolesLib.ROLE_UPGRADE,
+                user
+            )
+        );
+        vm.prank(user);
+        registry.upgradeToAndCall(address(newImplementation), "");
     }
 
     function test_MIN_DATA_SIZE() external pure {
@@ -814,5 +861,56 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
                 subregistry: IRegistry(address(0)), // ignored by LockedMigrationController
                 resolver: testResolver
             });
+    }
+
+    function _deployWrapperRegistryProxy(address admin) internal returns (WrapperRegistry) {
+        bytes memory name = NameCoder.encode(string.concat(testLabel, ".eth"));
+        bytes32 node = NameCoder.namehash(name, 0);
+        uint256 salt = uint256(node);
+        address proxyAddress = verifiableFactory.deployProxy(
+            address(wrapperRegistryImpl),
+            salt,
+            abi.encodeCall(
+                IWrapperRegistry.initialize,
+                (node, ethRegistry, testLabel, admin, RegistryRolesLib.ROLE_RENEW)
+            )
+        );
+        return WrapperRegistry(proxyAddress);
+    }
+
+    function _newWrapperRegistryV2Mock() internal returns (WrapperRegistryV2Mock) {
+        return
+            new WrapperRegistryV2Mock(
+                nameWrapper,
+                verifiableFactory,
+                address(ensV1Resolver),
+                hcaFactory,
+                metadata,
+                approvedUpgradeGate
+            );
+    }
+}
+
+contract WrapperRegistryV2Mock is WrapperRegistry {
+    constructor(
+        INameWrapper nameWrapper,
+        VerifiableFactory verifiableFactory,
+        address ensV1Resolver,
+        IHCAFactoryBasic hcaFactory,
+        IRegistryMetadata metadataProvider,
+        ApprovedUpgradeGate upgradeGate
+    )
+        WrapperRegistry(
+            nameWrapper,
+            verifiableFactory,
+            ensV1Resolver,
+            hcaFactory,
+            metadataProvider,
+            upgradeGate
+        )
+    {}
+
+    function version() public pure returns (uint256) {
+        return 2;
     }
 }

--- a/contracts/test/unit/registry/ApprovedUpgradeGate.t.sol
+++ b/contracts/test/unit/registry/ApprovedUpgradeGate.t.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+import {ApprovedUpgradeGate} from "~src/registry/ApprovedUpgradeGate.sol";
+
+contract ApprovedUpgradeGateTest is Test {
+    ApprovedUpgradeGate gate;
+
+    address owner = makeAddr("owner");
+    address nonOwner = makeAddr("nonOwner");
+    address implementation = makeAddr("implementation");
+
+    function setUp() public {
+        gate = new ApprovedUpgradeGate(owner);
+    }
+
+    function test_constructor_setsOwner() external view {
+        assertEq(gate.owner(), owner, "owner");
+        assertFalse(gate.approvedImplementations(implementation), "implementation");
+    }
+
+    function test_setImplementationApproval_approvesImplementation() external {
+        vm.expectEmit(true, true, false, true, address(gate));
+        emit ApprovedUpgradeGate.ImplementationApprovalChanged(implementation, true);
+
+        vm.prank(owner);
+        gate.setImplementationApproval(implementation, true);
+
+        assertTrue(gate.approvedImplementations(implementation), "implementation");
+    }
+
+    function test_setImplementationApproval_revokesImplementation() external {
+        vm.prank(owner);
+        gate.setImplementationApproval(implementation, true);
+
+        vm.expectEmit(true, true, false, true, address(gate));
+        emit ApprovedUpgradeGate.ImplementationApprovalChanged(implementation, false);
+
+        vm.prank(owner);
+        gate.setImplementationApproval(implementation, false);
+
+        assertFalse(gate.approvedImplementations(implementation), "implementation");
+    }
+
+    function test_setImplementationApproval_revertsWhenNotOwner() external {
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, nonOwner)
+        );
+        vm.prank(nonOwner);
+        gate.setImplementationApproval(implementation, true);
+
+        assertFalse(gate.approvedImplementations(implementation), "implementation");
+    }
+}


### PR DESCRIPTION
changes:
- added `ApprovedUpgradeGate` contract, simple allowlist for approved implementations, expectedly DAO-managed.
- added gate check in `WrapperRegistry` upgrade authorisation

note:
`ROLE_UPGRADE` is still used to determine if the user can initiate the upgrade, but the implementation can only be upgraded to implementations specified in the gate contract.

Fixes BET-606