### PR TITLE
chore: update verifiable factory

### DIFF
--- a/contracts/foundry.lock
+++ b/contracts/foundry.lock
@@ -18,7 +18,7 @@
     "rev": "c4fbe97cf5e8c1b8d607001588fd23abb5bfb923"
   },
   "contracts/lib/verifiable-factory": {
-    "rev": "c47c0e61ce03b3ab5891a3b743287b54aee9f021"
+    "rev": "04ec76f4c211bff795235feae90ad01882477ca1"
   },
   "lib/buffer": {
     "rev": "82cc81935de1d1a82e021cf1030d902c5248982b"
@@ -48,6 +48,6 @@
     }
   },
   "lib/verifiable-factory": {
-    "rev": "c47c0e61ce03b3ab5891a3b743287b54aee9f021"
+    "rev": "04ec76f4c211bff795235feae90ad01882477ca1"
   }
 }

--- a/contracts/script/setup.ts
+++ b/contracts/script/setup.ts
@@ -415,6 +415,8 @@ export async function setupDevnet({
       }),
     };
 
+    const verifiableProxyLogic = await v2.VerifiableFactory.read.proxyLogic();
+
     [shared, v1, v2, erc20]
       .flatMap((x) => Object.values(x))
       .forEach(patchContractWrite);
@@ -541,7 +543,7 @@ export async function setupDevnet({
     function computeVerifiableProxyAddress(deployer: Address, salt: bigint) {
       return computeVerifiableProxyAddress_({
         factoryAddress: v2.VerifiableFactory.address,
-        bytecode: artifacts["UUPSProxy"].bytecode,
+        proxyLogic: verifiableProxyLogic,
         deployer,
         salt,
       });

--- a/contracts/src/registry/UserRegistry.sol
+++ b/contracts/src/registry/UserRegistry.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
+import {IProxyAuthorization} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
@@ -17,7 +18,7 @@ import {PermissionedRegistry} from "./PermissionedRegistry.sol";
 ///         `VerifiableFactory` for user-owned subdomain registries. The constructor disables
 ///         initializers on the implementation contract; proxies call `initialize()` to set up the
 ///         admin and initial roles. Upgrade authorization requires the upgrade role in the root resource.
-contract UserRegistry is Initializable, PermissionedRegistry, UUPSUpgradeable {
+contract UserRegistry is Initializable, PermissionedRegistry, UUPSUpgradeable, IProxyAuthorization {
     ////////////////////////////////////////////////////////////////////////
     // Initialization
     ////////////////////////////////////////////////////////////////////////
@@ -49,12 +50,24 @@ contract UserRegistry is Initializable, PermissionedRegistry, UUPSUpgradeable {
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return
             interfaceId == type(UUPSUpgradeable).interfaceId ||
+            interfaceId == type(IProxyAuthorization).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 
     ////////////////////////////////////////////////////////////////////////
     // Implementation
     ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Declares this implementation as an eligible verifiable proxy upgrade target.
+    /// @dev Upgrade authorization is still enforced by the current implementation during the UUPS
+    ///      upgrade call.
+    /// @param {previousImplementation} Ignored.
+    /// @return allowed Always `true` for implementations in this registry family.
+    function canUpgradeFrom(
+        address /* previousImplementation */
+    ) external pure virtual override returns (bool allowed) {
+        return true;
+    }
 
     /// @dev Restricts UUPS upgrades to accounts holding the upgrade role on the root resource.
     /// @param newImplementation The address of the new implementation contract.

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.13;
 
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
+import {IProxyAuthorization} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
 import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
@@ -27,7 +28,8 @@ contract WrapperRegistry is
     PermissionedRegistry,
     LockedWrapperReceiver,
     Initializable,
-    UUPSUpgradeable
+    UUPSUpgradeable,
+    IProxyAuthorization
 {
     ////////////////////////////////////////////////////////////////////////
     // Constants
@@ -95,6 +97,7 @@ contract WrapperRegistry is
         return
             type(IWrapperRegistry).interfaceId == interfaceId ||
             type(UUPSUpgradeable).interfaceId == interfaceId ||
+            type(IProxyAuthorization).interfaceId == interfaceId ||
             super.supportsInterface(interfaceId);
     }
 
@@ -121,6 +124,17 @@ contract WrapperRegistry is
     ////////////////////////////////////////////////////////////////////////
     // Implementation
     ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Declares this implementation as an eligible verifiable proxy upgrade target.
+    /// @dev Upgrade authorization is still enforced by the current implementation during the UUPS
+    ///      upgrade call, including the wrapper upgrade target allowlist.
+    /// @param {previousImplementation} Ignored.
+    /// @return allowed Always `true` for implementations in this wrapper registry family.
+    function canUpgradeFrom(
+        address /* previousImplementation */
+    ) external pure virtual override returns (bool allowed) {
+        return true;
+    }
 
     /// @inheritdoc PermissionedRegistry
     /// @dev Blocks registration of emancipated children.

--- a/contracts/src/resolver/PermissionedResolver.sol
+++ b/contracts/src/resolver/PermissionedResolver.sol
@@ -18,6 +18,7 @@ import {ResolverFeatures} from "@ens/contracts/resolvers/ResolverFeatures.sol";
 import {ENSIP19, COIN_TYPE_ETH, COIN_TYPE_DEFAULT} from "@ens/contracts/utils/ENSIP19.sol";
 import {IERC7996} from "@ens/contracts/utils/IERC7996.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
+import {IProxyAuthorization} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
 import {Context} from "@openzeppelin/contracts/utils/Context.sol";
@@ -107,7 +108,8 @@ contract PermissionedResolver is
     INameResolver,
     IPubkeyResolver,
     ITextResolver,
-    IVersionableResolver
+    IVersionableResolver,
+    IProxyAuthorization
 {
     ////////////////////////////////////////////////////////////////////////
     // Types
@@ -221,6 +223,7 @@ contract PermissionedResolver is
             type(ITextResolver).interfaceId == interfaceId ||
             type(IVersionableResolver).interfaceId == interfaceId ||
             type(UUPSUpgradeable).interfaceId == interfaceId ||
+            type(IProxyAuthorization).interfaceId == interfaceId ||
             super.supportsInterface(interfaceId);
     }
 
@@ -615,6 +618,17 @@ contract PermissionedResolver is
     /// @inheritdoc ITextResolver
     function text(bytes32 node, string calldata key) external view returns (string memory) {
         return _record(node).texts[key];
+    }
+
+    /// @notice Declares this implementation as an eligible verifiable proxy upgrade target.
+    /// @dev Upgrade authorization is still enforced by the current implementation during the UUPS
+    ///      upgrade call.
+    /// @param {previousImplementation} Ignored.
+    /// @return allowed Always `true` for implementations in this resolver family.
+    function canUpgradeFrom(
+        address /* previousImplementation */
+    ) external pure virtual override returns (bool allowed) {
+        return true;
     }
 
     /// @notice Perform multiple write operations.

--- a/contracts/test/fixtures/V2Fixture.sol
+++ b/contracts/test/fixtures/V2Fixture.sol
@@ -6,7 +6,8 @@ import {Test} from "forge-std/Test.sol";
 import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
 
 import {GatewayProvider} from "@ens/contracts/ccipRead/GatewayProvider.sol";
-import {VerifiableFactory, UUPSProxy} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
+import {CloneProxyBytecode} from "@ensdomains/verifiable-factory/CloneProxyBytecode.sol";
+import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 
 import {BaseUriRegistryMetadata} from "~src/registry/BaseUriRegistryMetadata.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
@@ -111,15 +112,14 @@ contract V2Fixture is Test, ERC1155Holder {
         uint256 salt
     ) internal view returns (address) {
         bytes32 outerSalt = keccak256(abi.encode(deployer, salt));
+        bytes memory bytecode = CloneProxyBytecode.creationCode(
+            verifiableFactory.proxyLogic(),
+            outerSalt
+        );
         return
             vm.computeCreate2Address(
                 outerSalt,
-                keccak256(
-                    abi.encodePacked(
-                        type(UUPSProxy).creationCode,
-                        abi.encode(verifiableFactory, outerSalt)
-                    )
-                ),
+                keccak256(bytecode),
                 address(verifiableFactory)
             );
     }

--- a/contracts/test/integration/fixtures/deployVerifiableProxy.ts
+++ b/contracts/test/integration/fixtures/deployVerifiableProxy.ts
@@ -8,7 +8,6 @@ import {
   encodeFunctionData,
   getContract,
   getContractAddress,
-  type Hex,
   keccak256,
   parseAbi,
   parseEventLogs,
@@ -77,12 +76,12 @@ export async function deployVerifiableProxy<
 
 export function computeVerifiableProxyAddress({
   factoryAddress,
-  bytecode,
+  proxyLogic,
   deployer,
   salt,
 }: {
   factoryAddress: Address;
-  bytecode: Hex;
+  proxyLogic: Address;
   deployer: Address;
   salt: bigint;
 }) {
@@ -92,14 +91,14 @@ export function computeVerifiableProxyAddress({
       [deployer, salt],
     ),
   );
+  const bytecode = concat([
+    "0x3d604d80600a3d3981f3363d3d373d3d3d363d73",
+    proxyLogic,
+    "0x5af43d82803e903d91602b57fd5bf3",
+    outerSalt,
+  ]);
   return getContractAddress({
-    bytecode: concat([
-      bytecode,
-      encodeAbiParameters(
-        [{ type: "address" }, { type: "bytes32" }],
-        [factoryAddress, outerSalt],
-      ),
-    ]),
+    bytecode,
     from: factoryAddress,
     opcode: "CREATE2",
     salt: outerSalt,

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -20,6 +20,7 @@ import {
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import {IERC1155Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
 
 import {InvalidOwner, UnauthorizedCaller} from "~src/CommonErrors.sol";
 import {ENSV1Resolver} from "~src/resolver/ENSV1Resolver.sol";
@@ -349,7 +350,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
         // emit Initializable.Initialized()
         vm.expectEmit();
-        emit VerifiableFactory.ProxyDeployed(
+        emit IVerifiableFactory.ProxyDeployed(
             address(migrationController),
             expectedRegistry,
             salt,

--- a/contracts/test/unit/registry/UserRegistry.t.sol
+++ b/contracts/test/unit/registry/UserRegistry.t.sol
@@ -63,7 +63,10 @@ contract UserRegistryTest is Test, ERC1155Holder {
 
     function test_initialization() public view {
         // Verify the proxy was deployed correctly
-        assertTrue(factory.verifyContract(address(proxy)), "Proxy should be verified");
+        assertTrue(
+            factory.verifyContract(address(proxy), address(implementation)),
+            "Proxy should be verified"
+        );
 
         // Verify admin has the expected roles
         assertTrue(

--- a/contracts/test/unit/resolver/PermissionedResolver.t.sol
+++ b/contracts/test/unit/resolver/PermissionedResolver.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import {Test} from "forge-std/Test.sol";
 
+import {IProxyAuthorization} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
 import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
@@ -1018,9 +1019,12 @@ contract PermissionedResolverTest is Test {
     }
 }
 
-contract MockUpgrade is UUPSUpgradeable {
+contract MockUpgrade is UUPSUpgradeable, IProxyAuthorization {
     function addr(bytes32) external pure returns (address) {
         return address(1);
+    }
+    function canUpgradeFrom(address) external pure returns (bool) {
+        return true;
     }
     function _authorizeUpgrade(address) internal override {}
 }


### PR DESCRIPTION
changes:
- updated `verifiable-factory` to latest commit
- added explicit `canUpgradeFrom` functions in upgradable implementations. even though this is technically unnecessary (this is the first set of contracts), it doesn't cost anything and helps with visibility
- updated helpers to use new proxy bytecode

Fixes BET-614