### PR TITLE
Fix `PermissionedRegistry` Batch Transfer Behavior

### DIFF
--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -425,17 +425,12 @@ contract PermissionedRegistry is
                 // only check ROLE_CAN_TRANSFER_ADMIN on token owner (from)
                 if (!hasRoles(tokenId, RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, from)) {
                     revert TransferDisallowed(tokenId, from);
-                }
-            }
-        }
-        super._update(from, to, tokenIds, amounts); // ensures amounts[i] is 0 or 1
-        if (externalTransfer) {
-            for (uint256 i; i < tokenIds.length; ++i) {
-                if (amounts[i] > 0) {
+                } else if (amounts[i] > 0) {
                     _transferRoles(getResource(tokenIds[i]), from, to, false);
                 }
             }
         }
+        super._update(from, to, tokenIds, amounts); // ensures amounts[i] is 0 or 1
     }
 
     /// @dev Override the base registry _onRolesGranted function to regenerate the token when the roles are granted.

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -418,19 +418,20 @@ contract PermissionedRegistry is
         uint256[] memory tokenIds,
         uint256[] memory amounts
     ) internal override {
-        bool externalTransfer = to != address(0) && from != address(0); // skip mint and burn
-        if (externalTransfer) {
+        super._update(from, to, tokenIds, amounts); // ensures amounts[i] is 0 or 1
+        if (to != address(0) && from != address(0)) {
+            // only transfers (skip mint and burn)
             for (uint256 i; i < tokenIds.length; ++i) {
                 uint256 tokenId = tokenIds[i];
-                // only check ROLE_CAN_TRANSFER_ADMIN on token owner (from)
+                // only check ROLE_CAN_TRANSFER_ADMIN on original owner (from)
+                // ROLE_CAN_TRANSFER_ADMIN is technically a property of the token
                 if (!hasRoles(tokenId, RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, from)) {
                     revert TransferDisallowed(tokenId, from);
                 } else if (amounts[i] > 0) {
-                    _transferRoles(getResource(tokenIds[i]), from, to, false);
+                    _transferRoles(getResource(tokenId), from, to, false);
                 }
             }
         }
-        super._update(from, to, tokenIds, amounts); // ensures amounts[i] is 0 or 1
     }
 
     /// @dev Override the base registry _onRolesGranted function to regenerate the token when the roles are granted.

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -597,11 +597,11 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         uint256 tokenId = this._register();
         StrictERC1155Holder r = new StrictERC1155Holder(false);
         vm.expectEmit();
+        emit IERC1155.TransferSingle(user1, user1, address(r), tokenId, 1);
+        vm.expectEmit();
         emit IEnhancedAccessControl.EACRolesChanged(tokenId, user1, testRoles, 0); // revoke (transfer 1/2)
         vm.expectEmit();
         emit IEnhancedAccessControl.EACRolesChanged(tokenId, address(r), 0, testRoles); // grant (transfer 2/2)
-        vm.expectEmit();
-        emit IERC1155.TransferSingle(user1, user1, address(r), tokenId, 1);
         vm.prank(user1);
         registry.safeTransferFrom(user1, address(r), tokenId, 1, "");
     }
@@ -688,6 +688,8 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         amounts[1] = 1;
         StrictERC1155Holder r = new StrictERC1155Holder(true);
         vm.expectEmit();
+        emit IERC1155.TransferBatch(user1, user1, address(r), tokenIds, amounts);
+        vm.expectEmit();
         emit IEnhancedAccessControl.EACRolesChanged(tokenIds[0], user1, testRoles, 0);
         vm.expectEmit();
         emit IEnhancedAccessControl.EACRolesChanged(tokenIds[0], address(r), 0, testRoles);
@@ -695,8 +697,6 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         emit IEnhancedAccessControl.EACRolesChanged(tokenIds[1], user1, testRoles, 0);
         vm.expectEmit();
         emit IEnhancedAccessControl.EACRolesChanged(tokenIds[1], address(r), 0, testRoles);
-        vm.expectEmit();
-        emit IERC1155.TransferBatch(user1, user1, address(r), tokenIds, amounts);
         vm.prank(user1);
         registry.safeBatchTransferFrom(user1, address(r), tokenIds, amounts, "");
     }

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -597,11 +597,11 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         uint256 tokenId = this._register();
         StrictERC1155Holder r = new StrictERC1155Holder(false);
         vm.expectEmit();
-        emit IERC1155.TransferSingle(user1, user1, address(r), tokenId, 1);
-        vm.expectEmit();
         emit IEnhancedAccessControl.EACRolesChanged(tokenId, user1, testRoles, 0); // revoke (transfer 1/2)
         vm.expectEmit();
         emit IEnhancedAccessControl.EACRolesChanged(tokenId, address(r), 0, testRoles); // grant (transfer 2/2)
+        vm.expectEmit();
+        emit IERC1155.TransferSingle(user1, user1, address(r), tokenId, 1);
         vm.prank(user1);
         registry.safeTransferFrom(user1, address(r), tokenId, 1, "");
     }
@@ -681,12 +681,22 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         testRoles = RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
         uint256[] memory tokenIds = new uint256[](2);
         tokenIds[0] = this._register();
-        testLabel = "abc";
+        testLabel = string.concat(testLabel, testLabel);
         tokenIds[1] = this._register();
         uint256[] memory amounts = new uint256[](2);
         amounts[0] = 1;
         amounts[1] = 1;
         StrictERC1155Holder r = new StrictERC1155Holder(true);
+        vm.expectEmit();
+        emit IEnhancedAccessControl.EACRolesChanged(tokenIds[0], user1, testRoles, 0);
+        vm.expectEmit();
+        emit IEnhancedAccessControl.EACRolesChanged(tokenIds[0], address(r), 0, testRoles);
+        vm.expectEmit();
+        emit IEnhancedAccessControl.EACRolesChanged(tokenIds[1], user1, testRoles, 0);
+        vm.expectEmit();
+        emit IEnhancedAccessControl.EACRolesChanged(tokenIds[1], address(r), 0, testRoles);
+        vm.expectEmit();
+        emit IERC1155.TransferBatch(user1, user1, address(r), tokenIds, amounts);
         vm.prank(user1);
         registry.safeBatchTransferFrom(user1, address(r), tokenIds, amounts, "");
     }
@@ -695,14 +705,31 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
         testRoles = RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
         uint256[] memory tokenIds = new uint256[](2);
         tokenIds[0] = this._register();
-        testLabel = "abc";
+        testLabel = string.concat(testLabel, testLabel);
         tokenIds[1] = this._register();
         uint256[] memory amounts = new uint256[](2);
         vm.prank(user1);
         registry.safeBatchTransferFrom(user1, user2, tokenIds, amounts, "");
     }
 
-    function test_safeBatchTransferFrom_twice() external {
+    function test_safeBatchTransferFrom_noopAfterTransfer() external {
+        testRoles = RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
+        uint256[] memory tokenIds = new uint256[](2);
+        tokenIds[0] = tokenIds[1] = this._register();
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 1;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IStandardRegistry.TransferDisallowed.selector,
+                tokenIds[1],
+                user1
+            )
+        );
+        vm.prank(user1);
+        registry.safeBatchTransferFrom(user1, user2, tokenIds, amounts, "");
+    }
+
+    function test_safeBatchTransferFrom_twiceToSelf() external {
         testRoles = RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
         uint256[] memory tokenIds = new uint256[](2);
         tokenIds[0] = tokenIds[1] = this._register();
@@ -715,7 +742,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder {
     function test_safeBatchTransferFrom_oneError() external {
         uint256[] memory tokenIds = new uint256[](2);
         tokenIds[0] = this._register(); // no transfer role
-        testLabel = "abc";
+        testLabel = string.concat(testLabel, testLabel);
         testRoles = RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
         tokenIds[1] = this._register();
         uint256[] memory amounts = new uint256[](2);


### PR DESCRIPTION
Desired property:  `stateChange(batch[a,b]) == stateChange(a+b)`

---

- changed `PermissionedRegistry._update()` to check roles <ins>after</ins> `super._update()`
    * transfers roles immediately after each `ROLE_CAN_TRANSFER_ADMIN` check
    * added tests