### PR TITLE
feat(devnet): add mainnet-fork mode to runDevnet

### DIFF
--- a/contracts/script/forkBootstrap.ts
+++ b/contracts/script/forkBootstrap.ts
@@ -1,0 +1,126 @@
+import { readFile, writeFile, mkdir, copyFile } from "node:fs/promises";
+import { join } from "node:path";
+import { type Address, parseEther } from "viem";
+
+// v1 contracts on canonical mainnet that v2 deploys and `setup.ts` reference
+// by name through rocketh's `get()`. Pre-populated into the devnet deployments
+// dir so `get(name)` resolves to the canonical address without redeploying.
+const V1_DEPLOYMENT_NAMES = [
+  "ENSRegistry",
+  "Root",
+  "BaseRegistrarImplementation",
+  "NameWrapper",
+  "RegistrarSecurityController",
+  "ETHRegistrarController",
+  "WrappedETHRegistrarController",
+  "PublicResolver",
+  "UniversalResolver",
+  "OffchainDNSResolver",
+  "SimplePublicSuffixList",
+  "DNSSECImpl",
+  "ReverseRegistrar",
+  "DefaultReverseRegistrar",
+  "DefaultReverseResolver",
+  "BatchGatewayProvider",
+] as const;
+
+// Canonical contracts whose `.owner()` issues writes during the v2 deploy or
+// activation flow. Read live so that future ownership changes on mainnet are
+// picked up without code changes.
+const V1_OWNABLE_NAMES = [
+  "BaseRegistrarImplementation",
+  "NameWrapper",
+  "ReverseRegistrar",
+  "DefaultReverseRegistrar",
+  "RegistrarSecurityController",
+] as const;
+
+// ENS DAO multisig — mapped to the `owner` named account on chainId 1 via
+// `rocketh.ts`. Included unconditionally so that even if a future ownership
+// transfer hasn't fully propagated, the DAO address is still funded.
+export const ENS_DAO_MULTISIG: Address =
+  "0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7";
+
+const OWNER_ABI = [
+  {
+    type: "function",
+    name: "owner",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "address" }],
+  },
+] as const;
+
+type ClientLike = {
+  readContract: (args: {
+    address: Address;
+    abi: typeof OWNER_ABI;
+    functionName: "owner";
+  }) => Promise<unknown>;
+  setBalance: (args: { address: Address; value: bigint }) => Promise<void>;
+};
+
+export async function bootstrapForkDeployments({
+  client,
+  deploymentsDir,
+  canonicalDir,
+  chainId,
+}: {
+  client: ClientLike;
+  deploymentsDir: string;
+  canonicalDir: string;
+  chainId: number;
+}) {
+  await mkdir(deploymentsDir, { recursive: true });
+
+  for (const name of V1_DEPLOYMENT_NAMES) {
+    const src = JSON.parse(
+      await readFile(join(canonicalDir, `${name}.json`), "utf8"),
+    );
+    const dst = { address: src.address, abi: src.abi };
+    await writeFile(
+      join(deploymentsDir, `${name}.json`),
+      JSON.stringify(dst, null, 2),
+    );
+  }
+
+  // Mirror the canonical `.chain` so rocketh's chainId/genesisHash checks pass
+  // against the live forked node (which exposes the upstream genesis at block
+  // 0). rocketh stores chainId as a string and compares it strictly.
+  await copyFile(
+    join(canonicalDir, ".chain"),
+    join(deploymentsDir, ".chain"),
+  );
+
+  // sanity: bail loudly if the canonical chainId disagrees with the live one
+  const liveChainHeader = JSON.parse(
+    await readFile(join(deploymentsDir, ".chain"), "utf8"),
+  );
+  if (String(liveChainHeader.chainId) !== String(chainId)) {
+    throw new Error(
+      `canonical .chain chainId=${liveChainHeader.chainId} does not match live chainId=${chainId}`,
+    );
+  }
+
+  const ownerAddrs = new Set<Address>([ENS_DAO_MULTISIG]);
+  for (const name of V1_OWNABLE_NAMES) {
+    const src = JSON.parse(
+      await readFile(join(canonicalDir, `${name}.json`), "utf8"),
+    );
+    try {
+      const addr = (await client.readContract({
+        address: src.address as Address,
+        abi: OWNER_ABI,
+        functionName: "owner",
+      })) as Address;
+      ownerAddrs.add(addr);
+    } catch {
+      // contract doesn't expose owner(); skip
+    }
+  }
+
+  const fundWei = parseEther("10000");
+  for (const addr of ownerAddrs) {
+    await client.setBalance({ address: addr, value: fundWei });
+  }
+}

--- a/contracts/script/runDevnet.ts
+++ b/contracts/script/runDevnet.ts
@@ -24,31 +24,33 @@ const args = parseArgs({
     forkBlock: {
       type: "string",
     },
+    quiet: {
+      type: "boolean",
+    },
   },
   strict: true,
 });
 
-if (args.values.forkUrl && args.values.testNames) {
+// Env-var fallbacks: CLI wins, then FORK_URL / FORK_BLOCK / DEVNET_QUIET.
+// Lets callers (e.g. morticia's mainnet-fork e2e runner) configure once via
+// env and avoid duplicating the same flags across every script invocation.
+const forkUrl = args.values.forkUrl ?? process.env.FORK_URL;
+const forkBlock = args.values.forkBlock ?? process.env.FORK_BLOCK;
+const quiet = args.values.quiet ?? process.env.DEVNET_QUIET === "1";
+
+if (forkUrl && args.values.testNames) {
   console.error("--testNames is incompatible with --forkUrl");
   process.exit(2);
 }
 
 const env = await setupDevnet({
   port: 8545,
-  chainId: args.values.forkUrl
-    ? undefined
-    : Number(args.values.chainId) || undefined,
+  chainId: forkUrl ? undefined : Number(args.values.chainId) || undefined,
   saveDeployments: true,
   procLog: args.values.procLog,
-  extraTime: args.values.forkUrl
-    ? 0
-    : args.values.testNames
-      ? 86_401
-      : 60,
-  forkUrl: args.values.forkUrl,
-  forkBlockNumber: args.values.forkBlock
-    ? BigInt(args.values.forkBlock)
-    : undefined,
+  extraTime: forkUrl ? 0 : args.values.testNames ? 86_401 : 60,
+  forkUrl,
+  forkBlockNumber: forkBlock ? BigInt(forkBlock) : undefined,
 });
 
 // handler for shell
@@ -68,27 +70,29 @@ process.once("uncaughtException", async (err) => {
   throw err;
 });
 
-console.log();
-console.log("Available Named Accounts:");
-console.table(
-  Object.values(env.namedAccounts).map((x) => ({
-    Name: x.name,
-    Address: x.address,
-    Resolver: x.resolver.address,
-  })),
-);
+if (!quiet) {
+  console.log();
+  console.log("Available Named Accounts:");
+  console.table(
+    Object.values(env.namedAccounts).map((x) => ({
+      Name: x.name,
+      Address: x.address,
+      Resolver: x.resolver.address,
+    })),
+  );
 
-console.table(
-  Object.entries(env.rocketh.deployments).map(([name, { address }]) => ({
-    "Contract Name": name,
-    "Contract Address": getAddress(address),
-  })),
-);
+  console.table(
+    Object.entries(env.rocketh.deployments).map(([name, { address }]) => ({
+      "Contract Name": name,
+      "Contract Address": getAddress(address),
+    })),
+  );
 
-console.log({
-  Chain: env.client.chain.id,
-  Endpoint: `{http,ws}://${env.hostPort}`,
-});
+  console.log({
+    Chain: env.client.chain.id,
+    Endpoint: `{http,ws}://${env.hostPort}`,
+  });
+}
 
 if (args.values.testNames) {
   await testNames(env);
@@ -96,9 +100,33 @@ if (args.values.testNames) {
 
 await env.sync({ warpSec: "local" });
 
+// Fork-mode finalisation: activateV2 grants the v2 Graveyard + ETHRenewerV1
+// the RegistrarSecurityController controller role, retires the v1 ETH
+// controllers, and transfers registrar ownership to ETHRenewerV1 — all via
+// anvil autoImpersonate as the ENS DAO multisig. Without this every
+// graveyard clear() reverts with ONLY_CONTROLLER on a fresh fork.
+// Greenfield (non-fork) devnets retain the previous behaviour: callers are
+// expected to grant controller roles themselves via test-side setup.
+if (forkUrl) {
+  await env.activateV2();
+}
+
 console.log(new Date(), `Ready! <${Date.now() - t0}ms>`);
 
-const server = createServer((_req, res) => {
+const server = createServer((req, res) => {
+  // Surface every rocketh-tracked deployment as JSON so consumers don't
+  // have to know about the deployments/devnet-{chainId}/*.json layout.
+  if (req.url === "/deployments") {
+    const body: Record<string, string> = {
+      chainId: String(env.client.chain.id),
+    };
+    for (const [name, dep] of Object.entries(env.rocketh.deployments)) {
+      body[name] = getAddress(dep.address);
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+    return;
+  }
   res.writeHead(200, { "Content-Type": "text/plain" });
   res.end("healthy\n");
 });

--- a/contracts/script/runDevnet.ts
+++ b/contracts/script/runDevnet.ts
@@ -18,16 +18,37 @@ const args = parseArgs({
     chainId: {
       type: "string",
     },
+    forkUrl: {
+      type: "string",
+    },
+    forkBlock: {
+      type: "string",
+    },
   },
   strict: true,
 });
 
+if (args.values.forkUrl && args.values.testNames) {
+  console.error("--testNames is incompatible with --forkUrl");
+  process.exit(2);
+}
+
 const env = await setupDevnet({
   port: 8545,
-  chainId: Number(args.values.chainId) || undefined,
+  chainId: args.values.forkUrl
+    ? undefined
+    : Number(args.values.chainId) || undefined,
   saveDeployments: true,
   procLog: args.values.procLog,
-  extraTime: args.values.testNames ? 86_401 : 60,
+  extraTime: args.values.forkUrl
+    ? 0
+    : args.values.testNames
+      ? 86_401
+      : 60,
+  forkUrl: args.values.forkUrl,
+  forkBlockNumber: args.values.forkBlock
+    ? BigInt(args.values.forkBlock)
+    : undefined,
 });
 
 // handler for shell

--- a/contracts/script/setup.ts
+++ b/contracts/script/setup.ts
@@ -1,5 +1,6 @@
 import { artifacts } from "@rocketh";
 import { rm } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { anvil as createAnvil } from "prool/instances";
 import { executeDeployScripts, resolveConfig } from "rocketh";
 import {
@@ -7,6 +8,7 @@ import {
   type Address,
   ContractFunctionExecutionError,
   ContractFunctionRevertedError,
+  createPublicClient,
   createWalletClient,
   decodeAbiParameters,
   encodeAbiParameters,
@@ -38,6 +40,10 @@ import {
 } from "./deploy-constants.js";
 import { deployArtifact } from "../test/integration/fixtures/deployArtifact.js";
 import { patchArtifactsV1 } from "./patchArtifactsV1.js";
+import {
+  bootstrapForkDeployments,
+  ENS_DAO_MULTISIG,
+} from "./forkBootstrap.js";
 
 const NAMED_ACCOUNTS = ["deployer", "owner", "user", "user2"] as const;
 
@@ -58,6 +64,8 @@ export async function setupDevnet({
   quiet = !saveDeployments,
   procLog = false,
   extraTime = 0,
+  forkUrl,
+  forkBlockNumber,
 }: {
   port?: number;
   chainId?: number;
@@ -66,7 +74,10 @@ export async function setupDevnet({
   quiet?: boolean;
   procLog?: boolean; // show anvil process logs
   extraTime?: number; // extra time to subtract from genesis timestamp
+  forkUrl?: string; // when set, anvil forks from this RPC URL
+  forkBlockNumber?: bigint; // optional fork block; defaults to latest
 } = {}) {
+  const isFork = !!forkUrl;
   // shutdown functions for partial initialization
   const finalizers: (() => unknown | Promise<unknown>)[] = [];
   async function shutdown() {
@@ -90,9 +101,18 @@ export async function setupDevnet({
     const anvilInstance = createAnvil({
       accounts: NAMED_ACCOUNTS.length,
       mnemonic,
-      chainId,
+      // when forking, anvil derives chainId from the upstream RPC; the bare
+      // `chainId` flag is omitted so anvil takes the upstream value
+      ...(isFork ? {} : { chainId }),
       port,
-      ...(extraTime
+      // autoImpersonate lets the deploy flow sign as any address (e.g. the DAO
+      // multisig mapped to `owner` on chainId 1) without explicit unlocking.
+      // omitted in non-fork mode — prool encodes `false` as a positional arg
+      // rather than dropping the flag, which trips anvil's subcommand parser.
+      ...(isFork
+        ? { autoImpersonate: true, forkUrl, forkBlockNumber }
+        : {}),
+      ...(extraTime && !isFork
         ? { timestamp: Math.floor(Date.now() / 1000) - extraTime }
         : {}),
     });
@@ -148,8 +168,15 @@ export async function setupDevnet({
     })();
 
     const httpURL = `http://${hostPort}`;
+
+    // when forking, anvil reports the upstream chainId — pull it from the live
+    // node so downstream chain definition + deployments dir name reflect reality
+    const activeChainId = isFork
+      ? await createPublicClient({ transport: http(httpURL) }).getChainId()
+      : chainId;
+
     const chain = defineChain({
-      id: chainId,
+      id: activeChainId,
       name: "ENSv2",
       nativeCurrency: {
         decimals: 18,
@@ -198,11 +225,28 @@ export async function setupDevnet({
     });
 
     console.log("Deploying contracts");
-    const deploymentName = `devnet-${chainId}`;
+    const deploymentName = `devnet-${activeChainId}`;
+    const deploymentsDirURL = new URL(
+      `../deployments/${deploymentName}`,
+      import.meta.url,
+    );
     if (saveDeployments) {
-      await rm(new URL(`../deployments/${deploymentName}`, import.meta.url), {
+      await rm(deploymentsDirURL, {
         recursive: true,
         force: true,
+      });
+    }
+    if (isFork) {
+      await bootstrapForkDeployments({
+        client,
+        deploymentsDir: fileURLToPath(deploymentsDirURL),
+        canonicalDir: fileURLToPath(
+          new URL(
+            "../lib/ens-contracts/deployments/mainnet",
+            import.meta.url,
+          ),
+        ),
+        chainId: activeChainId,
       });
     }
     process.env.BATCH_GATEWAY_URLS = JSON.stringify([LOCAL_BATCH_GATEWAY_URL]);
@@ -219,7 +263,9 @@ export async function setupDevnet({
             "legacy", // legacy registry
           ],
           fork: false,
-          scripts: ["lib/ens-contracts/deploy", "deploy"],
+          // on fork, v1 contracts come from the live mainnet state we just
+          // pre-populated; only the v2 deploy scripts run on top
+          scripts: isFork ? ["deploy"] : ["lib/ens-contracts/deploy", "deploy"],
           pollingInterval: 0.001, // cannot be zero
         },
         askBeforeProceeding: false,
@@ -470,8 +516,12 @@ export async function setupDevnet({
     >;
     console.log("Created PermissionedResolver for each account");
 
-    await setupEnsDotEth();
-    console.log("Setup ens.eth");
+    // on fork, ens.eth already exists on canonical v1 with real subdomains;
+    // skip the synthetic register-and-seed step to avoid colliding with state
+    if (!isFork) {
+      await setupEnsDotEth();
+      console.log("Setup ens.eth");
+    }
 
     console.log("Deployed ENSv2");
     return {
@@ -741,22 +791,32 @@ export async function setupDevnet({
     }
 
     async function activateV2() {
-      const account = namedAccounts.owner;
-      // lock NameWrapper
-      await v1.NameWrapper.write.renounceOwnership({ account });
-      // disable v1 eth controllers
-      await v1.RegistrarSecurityController.write.removeRegistrarController(
-        [rocketh.get("ETHRegistrarController").address],
-        { account },
-      );
-      await v1.RegistrarSecurityController.write.removeRegistrarController(
-        [rocketh.get("WrappedETHRegistrarController").address],
-        { account },
-      );
-      await v1.RegistrarSecurityController.write.removeRegistrarController(
-        [rocketh.get("LegacyETHRegistrarController").address],
-        { account },
-      );
+      // on fork the canonical v1 contracts are owned by the DAO multisig, not
+      // by the mnemonic-derived `owner` account — anvil autoImpersonate lets us
+      // call onlyOwner functions by passing the DAO address as a JSON-RPC
+      // account directly.
+      const account: Account | Address = isFork
+        ? ENS_DAO_MULTISIG
+        : namedAccounts.owner;
+      // lock NameWrapper if still owned (idempotent across fork + synthetic)
+      if ((await v1.NameWrapper.read.owner()) !== zeroAddress) {
+        await v1.NameWrapper.write.renounceOwnership({ account });
+      }
+      // disable v1 eth controllers — LegacyETHRegistrarController only exists
+      // when the v1 deploy scripts were executed (i.e. non-fork devnet)
+      const v1ControllerNames = isFork
+        ? (["ETHRegistrarController", "WrappedETHRegistrarController"] as const)
+        : ([
+            "ETHRegistrarController",
+            "WrappedETHRegistrarController",
+            "LegacyETHRegistrarController",
+          ] as const);
+      for (const name of v1ControllerNames) {
+        await v1.RegistrarSecurityController.write.removeRegistrarController(
+          [rocketh.get(name).address],
+          { account },
+        );
+      }
       // add v2 eth controllers
       await v1.RegistrarSecurityController.write.addRegistrarController(
         [v2.Graveyard.address],
@@ -766,6 +826,15 @@ export async function setupDevnet({
         [v2.ETHRenewerV1.address],
         { account },
       );
+      // on fork, also grant deployer registrar-controller rights so morticia's
+      // e2e harness can call into v1.BaseRegistrar from the test mnemonic
+      // (matches the synthetic devnet's implicit "deployer can register" stance)
+      if (isFork) {
+        await v1.RegistrarSecurityController.write.addRegistrarController(
+          [namedAccounts.deployer.address],
+          { account },
+        );
+      }
       // transfer to syncer for juggling
       await v1.RegistrarSecurityController.write.transferRegistrarOwnership(
         [v2.ETHRenewerV1.address],


### PR DESCRIPTION
Introduces `--forkUrl` (and optional `--forkBlock`) so the devnet can boot against a forked mainnet with canonical v1 contracts preserved and v2 contracts deployed fresh on top.

- Pre-populate `deployments/devnet-<chainId>/` with canonical v1 `{address, abi}` entries from `lib/ens-contracts/deployments/mainnet/` so `rocketh.get(name)` resolves to mainnet addresses without redeploys.
- Mirror the canonical `.chain` header so rocketh's chainId/genesisHash validation passes against the forked node.
- Enable anvil `autoImpersonate` and fund the DAO multisig plus every live `.owner()` of the relevant Ownable v1 contracts via `anvil_setBalance`, letting deploy scripts that issue `account: owner` writes succeed.
- Skip the `lib/ens-contracts/deploy` scripts list on fork; v2 scripts still run.
- Branch `activateV2` to (a) sign as the DAO via autoImpersonate, (b) skip `LegacyETHRegistrarController` removal (doesn't exist on canonical mainnet), (c) grant `accounts.deployer` registrar-controller rights so test harnesses can drive v1.BaseRegistrar from the mnemonic, and (d) renounce NameWrapper ownership only when still non-zero.
- Skip `setupEnsDotEth` on fork to avoid colliding with real subdomains.
- Omit anvil `--auto-impersonate false` in non-fork mode (prool encodes `false` as a positional arg that trips anvil's subcommand parser).