### PR TITLE
Add `UniversalResolver.findOwner(name)`

### DIFF
--- a/contracts/src/resolver/PublicResolverV2.sol
+++ b/contracts/src/resolver/PublicResolverV2.sol
@@ -11,8 +11,8 @@ import {InterfaceResolver} from "@ens/contracts/resolvers/profiles/InterfaceReso
 import {NameResolver} from "@ens/contracts/resolvers/profiles/NameResolver.sol";
 import {PubkeyResolver} from "@ens/contracts/resolvers/profiles/PubkeyResolver.sol";
 import {TextResolver} from "@ens/contracts/resolvers/profiles/TextResolver.sol";
-import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
 import {HCAContext} from "../hca/HCAContext.sol";
 import {HCAEquivalence} from "../hca/HCAEquivalence.sol";
@@ -175,20 +175,7 @@ contract PublicResolverV2 is
         if (name.length == 0) {
             return false;
         }
-        (bytes32 labelHash, uint256 offset) = NameCoder.readLabel(name, 0);
-        if (labelHash == bytes32(0)) {
-            return false;
-        }
-        address parent = address(LibRegistry.findExactRegistry(ROOT_REGISTRY, name, offset));
-        if (parent == address(0)) {
-            return false;
-        }
-        IPermissionedRegistry.State memory state =
-            IPermissionedRegistry(parent).getState(uint256(labelHash));
-        if (state.status != IPermissionedRegistry.Status.REGISTERED) {
-            return false;
-        }
-        address owner = state.latestOwner;
+        address owner = LibRegistry.findOwner(ROOT_REGISTRY, name, 0);
         return
             owner == operator ||
             isApprovedForAll(owner, operator) ||

--- a/contracts/src/resolver/PublicResolverV2.sol
+++ b/contracts/src/resolver/PublicResolverV2.sol
@@ -12,7 +12,6 @@ import {NameResolver} from "@ens/contracts/resolvers/profiles/NameResolver.sol";
 import {PubkeyResolver} from "@ens/contracts/resolvers/profiles/PubkeyResolver.sol";
 import {TextResolver} from "@ens/contracts/resolvers/profiles/TextResolver.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
-import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
 import {HCAContext} from "../hca/HCAContext.sol";
 import {HCAEquivalence} from "../hca/HCAEquivalence.sol";

--- a/contracts/src/universalResolver/UniversalResolverV2.sol
+++ b/contracts/src/universalResolver/UniversalResolverV2.sol
@@ -45,6 +45,11 @@ contract UniversalResolverV2 is AbstractUniversalResolver, IUniversalResolverV2 
     ////////////////////////////////////////////////////////////////////////
 
     /// @inheritdoc IUniversalResolverV2
+    function findOwner(bytes calldata name) external view returns (address) {
+        return LibRegistry.findOwner(ROOT_REGISTRY, name, 0);
+    }
+
+    /// @inheritdoc IUniversalResolverV2
     function findCanonicalName(IRegistry registry) external view returns (bytes memory) {
         return LibRegistry.findCanonicalName(ROOT_REGISTRY, registry);
     }

--- a/contracts/src/universalResolver/interfaces/IUniversalResolverV2.sol
+++ b/contracts/src/universalResolver/interfaces/IUniversalResolverV2.sol
@@ -6,6 +6,11 @@ import {IRegistry} from "../../registry/interfaces/IRegistry.sol";
 /// @notice Interface for ENSv2-specific UniversalResolver helper functions.
 /// @dev Interface selector: `0x6e37653d`
 interface IUniversalResolverV2 {
+    /// @notice Find the owner for `name`.
+    /// @param name The DNS-encoded name.
+    /// @return The owner address or null if unowned or not found.
+    function findOwner(bytes calldata name) external view returns (address);
+
     /// @notice Construct the canonical name for `registry`.
     /// @param registry The registry to name.
     /// @return The DNS-encoded name or empty if not canonical.

--- a/contracts/src/universalResolver/interfaces/IUniversalResolverV2.sol
+++ b/contracts/src/universalResolver/interfaces/IUniversalResolverV2.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.13;
 import {IRegistry} from "../../registry/interfaces/IRegistry.sol";
 
 /// @notice Interface for ENSv2-specific UniversalResolver helper functions.
-/// @dev Interface selector: `0x6e37653d`
+/// @dev Interface selector: `0xf99a5e06`
 interface IUniversalResolverV2 {
     /// @notice Find the owner for `name`.
     /// @param name The DNS-encoded name.

--- a/contracts/src/universalResolver/libraries/LibRegistry.sol
+++ b/contracts/src/universalResolver/libraries/LibRegistry.sol
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
 
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 
 import {IRegistry} from "../../registry/interfaces/IRegistry.sol";
+import {IOwnedRegistry} from "../../registry/interfaces/IOwnedRegistry.sol";
 
 /// @dev Recursive traversal helpers for the namechain registry tree — resolver lookup, registry
 ///      discovery, canonical name construction, and ancestry enumeration.
@@ -40,6 +42,25 @@ library LibRegistry {
             exactRegistry = exactRegistry.getSubregistry(label);
         }
         node = NameCoder.namehash(node, labelHash); // update namehash
+    }
+
+    /// @dev Find the owner for `name[offset:]`.
+    /// @param rootRegistry The root ENS registry.
+    /// @param name The DNS-encoded name to search.
+    /// @return owner The owner address or null if unowned or not found.
+    function findOwner(IRegistry rootRegistry, bytes memory name, uint256 offset)
+        internal
+        view
+        returns (address owner)
+    {
+        IRegistry registry = findParentRegistry(rootRegistry, name, offset);
+        if (
+            address(registry) != address(0) &&
+            ERC165Checker.supportsInterface(address(registry), type(IOwnedRegistry).interfaceId)
+        ) {
+            (string memory label, ) = NameCoder.extractLabel(name, offset);
+            owner = IOwnedRegistry(address(registry)).findOwner(label);
+        }
     }
 
     /// @dev Construct the canonical name for `registry`.

--- a/contracts/src/universalResolver/libraries/LibRegistry.sol
+++ b/contracts/src/universalResolver/libraries/LibRegistry.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
 
-import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
-import {IRegistry} from "../../registry/interfaces/IRegistry.sol";
 import {IOwnedRegistry} from "../../registry/interfaces/IOwnedRegistry.sol";
+import {IRegistry} from "../../registry/interfaces/IRegistry.sol";
 
 /// @dev Recursive traversal helpers for the namechain registry tree — resolver lookup, registry
 ///      discovery, canonical name construction, and ancestry enumeration.

--- a/contracts/test/unit/resolver/PublicResolverV2.t.sol
+++ b/contracts/test/unit/resolver/PublicResolverV2.t.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {PublicResolverV2, NameCoder} from "~src/resolver/PublicResolverV2.sol";
+import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
+import {PublicResolverV2} from "~src/resolver/PublicResolverV2.sol";
 import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
 import {V1Fixture} from "~test/fixtures/V1Fixture.sol";
 import {V2Fixture} from "~test/fixtures/V2Fixture.sol";
@@ -64,7 +65,7 @@ contract PublicResolverV2Test is V1Fixture, V2Fixture {
 
     function _register(string memory label) internal returns (bytes32 node) {
         // register wrapped name in v1
-        bytes memory name = this.registerWrappedETH2LD(label, 0);
+        bytes memory name = registerWrappedETH2LD(label, 0);
         node = NameCoder.namehash(name, 0);
 
         assertFalse(publicResolver.canModifyName(node, testOwner), "before");

--- a/contracts/test/unit/resolver/PublicResolverV2.t.sol
+++ b/contracts/test/unit/resolver/PublicResolverV2.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
+
 import {PublicResolverV2} from "~src/resolver/PublicResolverV2.sol";
 import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
 import {V1Fixture} from "~test/fixtures/V1Fixture.sol";

--- a/contracts/test/unit/universalResolver/UniversalResolverV2.t.sol
+++ b/contracts/test/unit/universalResolver/UniversalResolverV2.t.sol
@@ -33,6 +33,21 @@ contract UniversalResolverV2Test is V2Fixture {
         );
     }
 
+    function test_findOwner() external {
+        assertEq(universalResolver.findOwner(NameCoder.encode("")), address(0));
+        assertEq(universalResolver.findOwner(NameCoder.encode("eth")), address(this));
+
+        ethRegistry.register(
+            "test",
+            address(1),
+            IRegistry(address(0)),
+            address(0),
+            0,
+            type(uint64).max
+        );
+        assertEq(universalResolver.findOwner(NameCoder.encode("test.eth")), address(1));
+    }
+
     function test_findCanonicalName() external view {
         assertEq(universalResolver.findCanonicalName(rootRegistry), NameCoder.encode(""));
         assertEq(universalResolver.findCanonicalName(ethRegistry), NameCoder.encode("eth"));

--- a/contracts/test/unit/universalResolver/libraries/LibRegistry.t.sol
+++ b/contracts/test/unit/universalResolver/libraries/LibRegistry.t.sol
@@ -302,6 +302,17 @@ contract LibRegistryTest is Test, ERC1155Holder {
         );
     }
 
+    function test_findOwner() external {
+        PermissionedRegistry ethRegistry = _createRegistry();
+        PermissionedRegistry testRegistry = _createRegistry();
+        _register(rootRegistry, "eth", ethRegistry, address(0));
+        _register(ethRegistry, "test", testRegistry, address(0));
+
+        assertEq(LibRegistry.findOwner(rootRegistry, NameCoder.encode(""), 0), address(0));
+        assertEq(LibRegistry.findOwner(rootRegistry, NameCoder.encode("eth"), 0), address(this));
+        assertEq(LibRegistry.findOwner(rootRegistry, NameCoder.encode("test.eth"), 0), address(this));
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // Helpers
     ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- added `LibRegistry.findOwner(root, name offset): owner`
- added `UniversalResolver.findOwner(name): owner`
- updated `PublicResolverV2.authorize()` to use `findOwner()`