### PR TITLE
Add Encoded Label Support to `Graveyard`

### DIFF
--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -6,6 +6,7 @@ import {
 } from "@ens/contracts/ethregistrar/BaseRegistrarImplementation.sol";
 import {IBaseRegistrar} from "@ens/contracts/ethregistrar/IBaseRegistrar.sol";
 import {ENS} from "@ens/contracts/registry/ENS.sol";
+import {HexUtils} from "@ens/contracts/utils/HexUtils.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
 import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
@@ -72,10 +73,16 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
     ////////////////////////////////////////////////////////////////////////
 
     /// @notice Clear registry for migrated names.
+    /// @dev Append non-zero byte to process encoded-labels.
     /// @param names The array of names to clear.
     function clear(bytes[] calldata names) external {
         for (uint256 i; i < names.length; ++i) {
-            _clear(names[i], 0);
+            bytes calldata name = names[i];
+            bool encoded = name.length >= 1 && uint8(name[name.length - 1]) != 0;
+            if (encoded) {
+                name = name[:name.length - 1]; // remove tail byte
+            }
+            _clear(name, 0, encoded);
         }
     }
 
@@ -84,16 +91,24 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
     ////////////////////////////////////////////////////////////////////////
 
     /// @dev Recursively clear ancestor namespace.
-    function _clear(bytes calldata name, uint256 offset)
+    function _clear(bytes calldata name, uint256 offset, bool encoded)
         internal
         returns (bytes32 node, State state)
     {
-        (bytes32 labelHash, uint256 nextOffset) = NameCoder.readLabel(name, offset);
-        if (labelHash == bytes32(0)) {
+        (uint8 size, uint256 nextOffset) = NameCoder.nextLabel(name, offset);
+        if (size == 0) {
             return (bytes32(0), State.ROOT);
         }
+        bytes32 labelHash;
+        bool valid;
+        if (encoded && size == 66 && name[offset + 1] == "[" && name[nextOffset - 1] == "]") {
+            (labelHash, valid) = HexUtils.hexStringToBytes32(name[offset + 2:offset + 66], 0, 64);
+        }
+        if (!valid) {
+            labelHash = keccak256(name[offset + 1:offset + 1 + size]);
+        }
         bytes32 parentNode;
-        (parentNode, state) = _clear(name, nextOffset);
+        (parentNode, state) = _clear(name, nextOffset, encoded);
         node = NameCoder.namehash(parentNode, labelHash);
         if (state == State.ROOT) {
             if (node != NameCoder.ETH_NODE) {

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -78,7 +78,7 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
     function clear(bytes[] calldata names) external {
         for (uint256 i; i < names.length; ++i) {
             bytes calldata name = names[i];
-            bool encoded = name.length >= 1 && uint8(name[name.length - 1]) != 0;
+            bool encoded = name.length > 0 && uint8(name[name.length - 1]) > 0;
             if (encoded) {
                 name = name[:name.length - 1]; // remove tail byte
             }
@@ -150,9 +150,10 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
                 // resolver is cleared by migration
                 if (LibMigration.isLocked(fuses)) {
                     return (node, State.LOCKED);
-                } else if (LibMigration.isEmancipatedChild(fuses)) {
-                    return (node, State.OWNED);
                 }
+                // } else if (LibMigration.isEmancipatedChild(fuses)) {
+                //    return (node, State.OWNED);
+                // }
             } else if (owner != address(0)) {
                 NAME_WRAPPER.setSubnodeRecord(
                     parentNode,

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -72,8 +72,6 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
     ////////////////////////////////////////////////////////////////////////
 
     /// @notice Clear registry for migrated names.
-    /// @dev Uses special encoding where each label is prefixed with a byte
-    ///      that determines if it is a label or labelhash.
     /// @param names The array of names to clear.
     function clear(bytes[] calldata names) external {
         for (uint256 i; i < names.length; ++i) {
@@ -86,18 +84,29 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
     ////////////////////////////////////////////////////////////////////////
 
     /// @dev Recursively clear ancestor namespace.
+    ///
+    /// Wrapped labels are 1-255 bytes and always have a preimage.
+    /// see: V1Fixture.t.sol: `test_nameWrapper_labelTooShort` and `test_nameWrapper_labelTooLong`
+    /// see: https://github.com/ensdomains/ens-contracts/blob/staging/contracts/wrapper/NameWrapper.sol#L865-L876
+    /// 
+    /// This function supports a modified DNS-encoding where zero-length labels 
+    /// in the middle of name must be followed with exactly 32 bytes of labelhash.
+    ///
+    /// This is safe because zero-length non-terminating labels normally revert.
+    /// 
     function _clear(bytes calldata name, uint256 offset) internal returns (bytes32 node, State) {
         bytes32 labelHash;
         uint256 nextOffset;
+        // modified DNS-encoding: interpret zero-length labels differently
         if (offset + 1 < name.length && uint8(name[offset]) == 0) {
-            ++offset;
-            nextOffset = offset + 32;
+            ++offset; // skip length byte
+            nextOffset = offset + 32; // ensure next 32 bytes exist
             if (nextOffset >= name.length) {
                 revert NameCoder.DNSDecodingFailed(name);
             }
-            labelHash = bytes32(name[offset:nextOffset]);
+            labelHash = bytes32(name[offset:nextOffset]); // cast as literal bytes32
         } else {
-            (labelHash, nextOffset) = NameCoder.readLabel(name, offset);
+            (labelHash, nextOffset) = NameCoder.readLabel(name, offset); // use standard logic
             if (labelHash == bytes32(0)) {
                 return (bytes32(0), State.ROOT);
             }
@@ -150,7 +159,7 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
             } else if (owner != address(0)) {
                 NAME_WRAPPER.setSubnodeRecord(
                     parentNode,
-                    string(name[offset + 1:nextOffset]),
+                    string(name[offset:nextOffset]),
                     address(this), // owner
                     address(0), // resolver
                     0, // ttl

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -6,7 +6,6 @@ import {
 } from "@ens/contracts/ethregistrar/BaseRegistrarImplementation.sol";
 import {IBaseRegistrar} from "@ens/contracts/ethregistrar/IBaseRegistrar.sol";
 import {ENS} from "@ens/contracts/registry/ENS.sol";
-import {HexUtils} from "@ens/contracts/utils/HexUtils.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
 import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
@@ -73,16 +72,12 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
     ////////////////////////////////////////////////////////////////////////
 
     /// @notice Clear registry for migrated names.
-    /// @dev Append non-zero byte to process encoded-labels.
+    /// @dev Uses special encoding where each label is prefixed with a byte
+    ///      that determines if it is a label or labelhash.
     /// @param names The array of names to clear.
     function clear(bytes[] calldata names) external {
         for (uint256 i; i < names.length; ++i) {
-            bytes calldata name = names[i];
-            bool encoded = name.length > 0 && uint8(name[name.length - 1]) > 0;
-            if (encoded) {
-                name = name[:name.length - 1]; // remove tail byte
-            }
-            _clear(name, 0, encoded);
+            _clear(names[i], 0);
         }
     }
 
@@ -91,25 +86,23 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
     ////////////////////////////////////////////////////////////////////////
 
     /// @dev Recursively clear ancestor namespace.
-    function _clear(bytes calldata name, uint256 offset, bool encoded)
-        internal
-        returns (bytes32 node, State state)
-    {
-        (uint8 size, uint256 nextOffset) = NameCoder.nextLabel(name, offset);
-        if (size == 0) {
-            return (bytes32(0), State.ROOT);
-        }
-        bytes32 parentNode;
-        (parentNode, state) = _clear(name, nextOffset, encoded);
+    function _clear(bytes calldata name, uint256 offset) internal returns (bytes32 node, State) {
         bytes32 labelHash;
-        if (encoded && size == 66 && name[offset + 1] == "[" && name[nextOffset - 1] == "]") {
-            (labelHash, encoded) = HexUtils.hexStringToBytes32(name[offset + 2:offset + 66], 0, 64);
+        uint256 nextOffset;
+        if (offset + 1 < name.length && uint8(name[offset]) == 0) {
+            ++offset;
+            nextOffset = offset + 32;
+            if (nextOffset >= name.length) {
+                revert NameCoder.DNSDecodingFailed(name);
+            }
+            labelHash = bytes32(name[offset:nextOffset]);
         } else {
-            encoded = false;
+            (labelHash, nextOffset) = NameCoder.readLabel(name, offset);
+            if (labelHash == bytes32(0)) {
+                return (bytes32(0), State.ROOT);
+            }
         }
-        if (!encoded) {
-            labelHash = keccak256(name[offset + 1:offset + 1 + size]);
-        }
+        (bytes32 parentNode, State state) = _clear(name, nextOffset);
         node = NameCoder.namehash(parentNode, labelHash);
         if (state == State.ROOT) {
             if (node != NameCoder.ETH_NODE) {

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -99,26 +99,25 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
         uint256 nextOffset;
         // modified DNS-encoding: interpret zero-length labels differently
         if (offset + 1 < name.length && uint8(name[offset]) == 0) {
-            ++offset; // skip length byte
-            nextOffset = offset + 32; // ensure next 32 bytes exist
+            nextOffset = offset + 33; // skip length and ensure next 32 bytes exist
             if (nextOffset >= name.length) {
                 revert NameCoder.DNSDecodingFailed(name);
             }
-            labelHash = bytes32(name[offset:nextOffset]); // cast as literal bytes32
+            labelHash = bytes32(name[offset + 1:nextOffset]); // cast as literal bytes32
         } else {
             (labelHash, nextOffset) = NameCoder.readLabel(name, offset); // use standard logic
             if (labelHash == bytes32(0)) {
                 return (bytes32(0), State.ROOT);
             }
         }
-        (bytes32 parentNode, State state) = _clear(name, nextOffset);
+        (bytes32 parentNode, State parentState) = _clear(name, nextOffset);
         node = NameCoder.namehash(parentNode, labelHash);
-        if (state == State.ROOT) {
+        if (parentState == State.ROOT) {
             if (node != NameCoder.ETH_NODE) {
                 revert NameNotClearable();
             }
             return (node, State.ETH);
-        } else if (state == State.ETH) {
+        } else if (parentState == State.ETH) {
             address owner = _REGISTRY_V1.owner(node);
             if (owner == address(this)) {
                 // resolver is cleared by migration
@@ -143,7 +142,7 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
                 _REGISTRY_V1.setResolver(node, address(0));
             }
             return (node, State.OWNED);
-        } else if (state == State.OWNED) {
+        } else if (parentState == State.OWNED) {
             _REGISTRY_V1.setSubnodeRecord(parentNode, labelHash, address(this), address(0), 0);
             return (node, State.OWNED);
         } else {
@@ -159,7 +158,7 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
             } else if (owner != address(0)) {
                 NAME_WRAPPER.setSubnodeRecord(
                     parentNode,
-                    string(name[offset:nextOffset]),
+                    string(name[offset + 1:nextOffset]),
                     address(this), // owner
                     address(0), // resolver
                     0, // ttl

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -99,16 +99,17 @@ contract Graveyard is ERC721Holder, ERC1155Holder {
         if (size == 0) {
             return (bytes32(0), State.ROOT);
         }
-        bytes32 labelHash;
-        bool valid;
-        if (encoded && size == 66 && name[offset + 1] == "[" && name[nextOffset - 1] == "]") {
-            (labelHash, valid) = HexUtils.hexStringToBytes32(name[offset + 2:offset + 66], 0, 64);
-        }
-        if (!valid) {
-            labelHash = keccak256(name[offset + 1:offset + 1 + size]);
-        }
         bytes32 parentNode;
         (parentNode, state) = _clear(name, nextOffset, encoded);
+        bytes32 labelHash;
+        if (encoded && size == 66 && name[offset + 1] == "[" && name[nextOffset - 1] == "]") {
+            (labelHash, encoded) = HexUtils.hexStringToBytes32(name[offset + 2:offset + 66], 0, 64);
+        } else {
+            encoded = false;
+        }
+        if (!encoded) {
+            labelHash = keccak256(name[offset + 1:offset + 1 + size]);
+        }
         node = NameCoder.namehash(parentNode, labelHash);
         if (state == State.ROOT) {
             if (node != NameCoder.ETH_NODE) {

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -77,7 +77,15 @@ contract GraveyardTest is MigrationControllerFixture {
         );
     }
 
-    function test_clear_encodedLabel_literal(bytes32 labelHash) external {
+    function test_clear_prehashedLabel_invalid() external {
+        bytes memory name = NameCoder.encode("eth");
+        for (uint256 i; i < 32; ++i) {
+            vm.expectRevert();
+            graveyard.clear(_oneName(abi.encodePacked(uint8(0), new bytes(i), name)));
+        }
+    }
+
+    function test_clear_prehashedLabel_literal(bytes32 labelHash) external {
         (bytes memory name, ) = registerUnwrapped(testLabel);
         bytes32 node = NameCoder.namehash(name, 0);
 
@@ -92,13 +100,13 @@ contract GraveyardTest is MigrationControllerFixture {
         node = NameCoder.namehash(node, actualLabelHash);
 
         assertEq(registryV1.resolver(node), address(1), "before");
-        graveyard.clear(_oneName(abi.encodePacked(uint8(0), labelHash, name))); // mark as encoded
+        graveyard.clear(_oneName(abi.encodePacked(uint8(0), labelHash, name))); // mark as prehashed
         assertEq(registryV1.resolver(node), address(1), "uncleared");
         graveyard.clear(_oneName(NameCoder.addLabel(name, label)));
         assertEq(registryV1.resolver(node), address(0), "after");
     }
 
-    function test_clear_encodedLabelHash(bytes32 labelHash) external {
+    function test_clear_prehashedLabel_hashed(bytes32 labelHash) external {
         (bytes memory name, ) = registerUnwrapped(testLabel);
         bytes32 node = NameCoder.namehash(name, 0);
 
@@ -112,7 +120,7 @@ contract GraveyardTest is MigrationControllerFixture {
         assertEq(registryV1.resolver(node), address(1), "before");
         graveyard.clear(_oneName(NameCoder.addLabel(name, _encodedLabelHash(labelHash))));
         assertEq(registryV1.resolver(node), address(1), "uncleared");
-        graveyard.clear(_oneName(abi.encodePacked(uint8(0), labelHash, name))); // mark as encoded
+        graveyard.clear(_oneName(abi.encodePacked(uint8(0), labelHash, name))); // mark as prehashed
         assertEq(registryV1.resolver(node), address(0), "after");
     }
 

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -82,18 +82,19 @@ contract GraveyardTest is MigrationControllerFixture {
         bytes32 node = NameCoder.namehash(name, 0);
 
         string memory label = _encodedLabelHash(labelHash);
+        bytes32 actualLabelHash = keccak256(bytes(label));
+
         vm.prank(testOwner);
-        registryV1.setSubnodeRecord(node, keccak256(bytes(label)), friend, address(1), 0);
+        registryV1.setSubnodeRecord(node, actualLabelHash, friend, address(1), 0);
 
         _simulateMigration(name);
 
-        name = NameCoder.addLabel(name, label);
-        node = NameCoder.namehash(name, 0);
+        node = NameCoder.namehash(node, actualLabelHash);
 
         assertEq(registryV1.resolver(node), address(1), "before");
-        graveyard.clear(_oneName(abi.encodePacked(name, uint8(1)))); // mark as encoded
+        graveyard.clear(_oneName(abi.encodePacked(uint8(0), labelHash, name))); // mark as encoded
         assertEq(registryV1.resolver(node), address(1), "uncleared");
-        graveyard.clear(_oneName(name));
+        graveyard.clear(_oneName(NameCoder.addLabel(name, label)));
         assertEq(registryV1.resolver(node), address(0), "after");
     }
 
@@ -106,13 +107,12 @@ contract GraveyardTest is MigrationControllerFixture {
 
         _simulateMigration(name);
 
-        name = NameCoder.addLabel(name, _encodedLabelHash(labelHash));
         node = NameCoder.namehash(node, labelHash);
 
         assertEq(registryV1.resolver(node), address(1), "before");
-        graveyard.clear(_oneName(name));
+        graveyard.clear(_oneName(NameCoder.addLabel(name, _encodedLabelHash(labelHash))));
         assertEq(registryV1.resolver(node), address(1), "uncleared");
-        graveyard.clear(_oneName(abi.encodePacked(name, uint8(1)))); // mark as encoded
+        graveyard.clear(_oneName(abi.encodePacked(uint8(0), labelHash, name))); // mark as encoded
         assertEq(registryV1.resolver(node), address(0), "after");
     }
 

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -7,8 +7,10 @@ import {
     CANNOT_UNWRAP,
     PARENT_CANNOT_CONTROL
 } from "@ens/contracts/wrapper/INameWrapper.sol";
+import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
+import {HexUtils} from "@ens/contracts/utils/HexUtils.sol";
 
-import {MigrationControllerFixture, NameCoder} from "~test/fixtures/MigrationControllerFixture.sol";
+import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixture.sol";
 
 contract GraveyardTest is MigrationControllerFixture {
     uint256 constant N = 10;
@@ -62,6 +64,56 @@ contract GraveyardTest is MigrationControllerFixture {
 
         vm.expectRevert();
         graveyard.clear(_oneName(name));
+    }
+
+    function test_encodeLabelHash() external pure {
+        assertEq(
+            _encodedLabelHash(bytes32(0)),
+            "[0000000000000000000000000000000000000000000000000000000000000000]"
+        );
+        assertEq(
+            _encodedLabelHash(0x5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da),
+            "[5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da]"
+        );
+    }
+
+    function test_clear_encodedLabel_literal(bytes32 labelHash) external {
+        (bytes memory name, ) = registerUnwrapped(testLabel);
+        bytes32 node = NameCoder.namehash(name, 0);
+
+        string memory label = _encodedLabelHash(labelHash);
+        vm.prank(testOwner);
+        registryV1.setSubnodeRecord(node, keccak256(bytes(label)), friend, address(1), 0);
+
+        _simulateMigration(name);
+
+        name = NameCoder.addLabel(name, label);
+        node = NameCoder.namehash(name, 0);
+
+        assertEq(registryV1.resolver(node), address(1), "before");
+        graveyard.clear(_oneName(abi.encodePacked(name, uint8(1)))); // mark as encoded
+        assertEq(registryV1.resolver(node), address(1), "uncleared");
+        graveyard.clear(_oneName(name));
+        assertEq(registryV1.resolver(node), address(0), "after");
+    }
+
+    function test_clear_encodedLabelHash(bytes32 labelHash) external {
+        (bytes memory name, ) = registerUnwrapped(testLabel);
+        bytes32 node = NameCoder.namehash(name, 0);
+
+        vm.prank(testOwner);
+        registryV1.setSubnodeRecord(node, labelHash, friend, address(1), 0);
+
+        _simulateMigration(name);
+
+        name = NameCoder.addLabel(name, _encodedLabelHash(labelHash));
+        node = NameCoder.namehash(node, labelHash);
+
+        assertEq(registryV1.resolver(node), address(1), "before");
+        graveyard.clear(_oneName(name));
+        assertEq(registryV1.resolver(node), address(1), "uncleared");
+        graveyard.clear(_oneName(abi.encodePacked(name, uint8(1)))); // mark as encoded
+        assertEq(registryV1.resolver(node), address(0), "after");
     }
 
     function test_clear_unregistered(uint256) external {
@@ -144,7 +196,7 @@ contract GraveyardTest is MigrationControllerFixture {
 
         // set resolvers
         vm.startPrank(testOwner);
-        nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
+        nameWrapper.setResolver(NameCoder.namehash(name2, 0), address(1));
         nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
         vm.stopPrank();
 
@@ -168,7 +220,7 @@ contract GraveyardTest is MigrationControllerFixture {
 
         // set resolvers
         vm.startPrank(testOwner);
-        nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
+        nameWrapper.setResolver(NameCoder.namehash(name2, 0), address(1));
         nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
         vm.stopPrank();
 
@@ -335,6 +387,8 @@ contract GraveyardTest is MigrationControllerFixture {
             );
             vm.prank(owner);
             baseRegistrar.safeTransferFrom(owner, address(graveyard), uint256(labelHash));
+        } else {
+            revert("migrated failed");
         }
     }
 
@@ -358,6 +412,11 @@ contract GraveyardTest is MigrationControllerFixture {
         for (uint256 n = vm.randomUint(1, 10); n > 0; --n) {
             name = NameCoder.addLabel(name, new string(vm.randomUint(1, 255)));
         }
+    }
+
+    /// @dev Convert labelhash to encoded form.
+    function _encodedLabelHash(bytes32 labelHash) internal pure returns (string memory) {
+        return string(abi.encodePacked("[", HexUtils.bytesToHex(abi.encodePacked(labelHash)), "]"));
     }
 
     function _oneName(bytes memory name) internal pure returns (bytes[] memory names) {


### PR DESCRIPTION
- updated `Graveyard.clear()` to process encoded labels using modified encoding