### PR TITLE
Fix `ResolverProfileRewriterLib` memory underflow

### DIFF
--- a/contracts/src/resolver/libraries/ResolverProfileRewriterLib.sol
+++ b/contracts/src/resolver/libraries/ResolverProfileRewriterLib.sol
@@ -36,12 +36,19 @@ library ResolverProfileRewriterLib {
                 switch shr(224, mload(sub(ptr, 4))) // read selector
                 case 0xac9650d8 {
                     // multicall(bytes[])
+                    let lower := ptr
                     ptr := add(ptr, mload(ptr)) // follow jump
+                    if lt(ptr, lower) {
+                        leave // underflow
+                    }
                     let size := shl(5, mload(ptr)) // read word count as size
                     // prettier-ignore
                     for { } size { size := sub(size, 32) } { // backwards
-                        let p := mload(add(ptr, size)) // jump[i]
-                        p := add(add(ptr, 32), p) // local ptr
+                        lower := add(ptr, 32)
+                        let p := add(lower, mload(add(ptr, size))) // local ptr
+                        if lt(p, lower) {
+                            continue // underflow
+                        }
                         let b := add(p, mload(p)) // local bound w/room for 1 word
                         if lt(bound, b) {
                             b := bound // global bound is smaller

--- a/contracts/test/unit/resolver/libraries/ResolverProfileRewriterLib.t.sol
+++ b/contracts/test/unit/resolver/libraries/ResolverProfileRewriterLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-import {Test, stdError} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
 import {IMulticallable} from "@ens/contracts/resolvers/IMulticallable.sol";
 
@@ -89,6 +89,28 @@ contract ResolverProfileRewriterLibTest is Test {
         assembly {
             mstore(add(v, offset), save) // unmangle
         }
+        assertEq(v0, v); // unchanged
+    }
+
+    function test_replaceNode_multicall_underflow(bytes32 node) external view {
+        bytes[] memory m = new bytes[](1);
+        m[0] = vMin;
+        bytes memory v0 = abi.encodeCall(IMulticallable.multicall, (m));
+        assembly {
+            mstore(add(v0, 36), not(0)) // jump backwards
+        }
+        bytes memory v = this.replaceNode(v0, node);
+        assertEq(v0, v); // unchanged
+    }
+
+    function test_replaceNode_multicall_underflow_arrayStart(bytes32 node) external view {
+        bytes[] memory m = new bytes[](1);
+        m[0] = vMin;
+        bytes memory v0 = abi.encodeCall(IMulticallable.multicall, (m));
+        assembly {
+            mstore(add(v0, 100), not(0)) // jump backwards
+        }
+        bytes memory v = this.replaceNode(v0, node);
         assertEq(v0, v); // unchanged
     }
 


### PR DESCRIPTION
* prevent underflow writes via malicious offsets