### PR TITLE
[Idea 2] Use `WrapperRegistry` as token owner

### DIFF
--- a/contracts/src/migration/AbstractWrapperReceiver.sol
+++ b/contracts/src/migration/AbstractWrapperReceiver.sol
@@ -93,37 +93,6 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
     ////////////////////////////////////////////////////////////////////////
 
     /// @inheritdoc IERC1155Receiver
-    /// @notice Migrate one NameWrapper token via `safeTransferFrom()`.
-    /// @dev Only callable by NameWrapper.
-    ///      Reverts require `WrappedErrorLib.unwrap()` before processing.
-    /// @param id The NameWrapper token ID (namehash) of the name being migrated.
-    /// @param data ABI-encoded `LibMigration.Data` struct containing migration parameters.
-    function onERC1155Received(
-        address /*operator*/,
-        address /*from*/,
-        uint256 id,
-        uint256 /*amount*/,
-        bytes calldata data
-    )
-        external
-        onlyWrapper
-        withData(data, LibMigration.MIN_DATA_SIZE)
-        returns (bytes4)
-    {
-        // if (amount != 1) { ... } => never happens :: caught by ERC1155Fuse
-        // https://github.com/ensdomains/ens-contracts/blob/staging/contracts/wrapper/ERC1155Fuse.sol#L293
-        uint256[] memory ids = new uint256[](1);
-        LibMigration.Data[] memory mds = new LibMigration.Data[](1);
-        ids[0] = id;
-        mds[0] = abi.decode(data, (LibMigration.Data)); // reverts if invalid
-        try this.finishERC1155Migration(ids, mds) {
-            return this.onERC1155Received.selector;
-        } catch (bytes memory reason) {
-            WrappedErrorLib.wrapAndRevert(reason); // convert all errors to wrapped
-        }
-    }
-
-    /// @inheritdoc IERC1155Receiver
     /// @notice Migrate multiple NameWrapper tokens via `safeBatchTransferFrom()`.
     /// @dev Only callable by NameWrapper.
     ///      Reverts require `WrappedErrorLib.unwrap()` before processing.
@@ -171,6 +140,38 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
             revert IERC1155Errors.ERC1155InvalidArrayLength(ids.length, mds.length);
         }
         _migrateWrapped(ids, mds);
+    }
+
+    /// @inheritdoc IERC1155Receiver
+    /// @notice Migrate one NameWrapper token via `safeTransferFrom()`.
+    /// @dev Only callable by NameWrapper.
+    ///      Reverts require `WrappedErrorLib.unwrap()` before processing.
+    /// @param id The NameWrapper token ID (namehash) of the name being migrated.
+    /// @param data ABI-encoded `LibMigration.Data` struct containing migration parameters.
+    function onERC1155Received(
+        address /*operator*/,
+        address /*from*/,
+        uint256 id,
+        uint256 /*amount*/,
+        bytes calldata data
+    )
+        public
+        virtual
+        onlyWrapper
+        withData(data, LibMigration.MIN_DATA_SIZE)
+        returns (bytes4)
+    {
+        // if (amount != 1) { ... } => never happens :: caught by ERC1155Fuse
+        // https://github.com/ensdomains/ens-contracts/blob/staging/contracts/wrapper/ERC1155Fuse.sol#L293
+        uint256[] memory ids = new uint256[](1);
+        LibMigration.Data[] memory mds = new LibMigration.Data[](1);
+        ids[0] = id;
+        mds[0] = abi.decode(data, (LibMigration.Data)); // reverts if invalid
+        try this.finishERC1155Migration(ids, mds) {
+            return this.onERC1155Received.selector;
+        } catch (bytes memory reason) {
+            WrappedErrorLib.wrapAndRevert(reason); // convert all errors to wrapped
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/src/migration/AbstractWrapperReceiver.sol
+++ b/contracts/src/migration/AbstractWrapperReceiver.sol
@@ -92,6 +92,26 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
     // Implementation
     ////////////////////////////////////////////////////////////////////////
 
+    /// @notice Convert NameWrapper tokens to their equivalent ENSv2 form.
+    /// @dev Only callable by ourself and invoked by our `IERC1155Receiver` handlers.
+    ///
+    /// TODO: gas analysis and optimization
+    /// NOTE: converting this to an internal call requires catching many reverts
+    ///
+    /// @param ids The NameWrapper token IDs (namehashes) of the names being migrated.
+    /// @param mds The migration parameters for each name, indexed in parallel with `ids`.
+    function finishERC1155Migration(uint256[] calldata ids, LibMigration.Data[] calldata mds)
+        external
+    {
+        if (msg.sender != address(this)) {
+            revert UnauthorizedCaller(msg.sender);
+        }
+        if (ids.length != mds.length) {
+            revert IERC1155Errors.ERC1155InvalidArrayLength(ids.length, mds.length);
+        }
+        _migrateWrapped(ids, mds);
+    }
+
     /// @inheritdoc IERC1155Receiver
     /// @notice Migrate multiple NameWrapper tokens via `safeBatchTransferFrom()`.
     /// @dev Only callable by NameWrapper.
@@ -120,26 +140,6 @@ abstract contract AbstractWrapperReceiver is ERC165, IERC1155Receiver {
         } catch (bytes memory reason) {
             WrappedErrorLib.wrapAndRevert(reason); // convert all errors to wrapped
         }
-    }
-
-    /// @notice Convert NameWrapper tokens to their equivalent ENSv2 form.
-    /// @dev Only callable by ourself and invoked by our `IERC1155Receiver` handlers.
-    ///
-    /// TODO: gas analysis and optimization
-    /// NOTE: converting this to an internal call requires catching many reverts
-    ///
-    /// @param ids The NameWrapper token IDs (namehashes) of the names being migrated.
-    /// @param mds The migration parameters for each name, indexed in parallel with `ids`.
-    function finishERC1155Migration(uint256[] calldata ids, LibMigration.Data[] calldata mds)
-        external
-    {
-        if (msg.sender != address(this)) {
-            revert UnauthorizedCaller(msg.sender);
-        }
-        if (ids.length != mds.length) {
-            revert IERC1155Errors.ERC1155InvalidArrayLength(ids.length, mds.length);
-        }
-        _migrateWrapped(ids, mds);
     }
 
     /// @inheritdoc IERC1155Receiver

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -62,7 +62,6 @@ contract Graveyard is ERC721Holder, ERC1155Holder, DelegatedContractNamer {
     // Initialization
     ////////////////////////////////////////////////////////////////////////
 
-    /// @notice Create a graveyard.
     /// @param nameWrapper The ENSv1 `NameWrapper` contract.
     /// @param contractNamer Delegated contract namer.
     constructor(INameWrapper nameWrapper, IContractNamer contractNamer)

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -168,7 +168,7 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
                 // ERC1155._safeTransferFrom() => ERC1155InvalidReceiver :: see owner check
                 _inject(
                     md.label,
-                    md.owner,
+                    address(subregistry),
                     subregistry,
                     resolver,
                     _tokenRoleBitmapFromFuses(fuses),
@@ -227,7 +227,11 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
             RegistryRolesLib.ROLE_UPGRADE |
             RegistryRolesLib.ROLE_UPGRADE_ADMIN |
             RegistryRolesLib.ROLE_CAN_NAME |
-            RegistryRolesLib.ROLE_CAN_NAME_ADMIN;
+            RegistryRolesLib.ROLE_CAN_NAME_ADMIN |
+            RegistryRolesLib.ROLE_SET_PARENT_RESOLVER |
+            RegistryRolesLib.ROLE_SET_PARENT_RESOLVER_ADMIN |
+            RegistryRolesLib.ROLE_RENEW_PARENT |
+            RegistryRolesLib.ROLE_RENEW_PARENT_ADMIN;
     }
 
     /// @dev Convert fuses to equivalent token roles.

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -7,8 +7,7 @@ import {
     CAN_EXTEND_EXPIRY,
     CANNOT_APPROVE,
     CANNOT_CREATE_SUBDOMAIN,
-    CANNOT_SET_RESOLVER,
-    CANNOT_TRANSFER
+    CANNOT_SET_RESOLVER
 } from "@ens/contracts/wrapper/INameWrapper.sol";
 import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
 
@@ -218,6 +217,12 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
         if ((fuses & CANNOT_CREATE_SUBDOMAIN) == 0) {
             roleBitmap |= RegistryRolesLib.ROLE_REGISTRAR;
         }
+        if ((fuses & CANNOT_SET_RESOLVER) == 0) {
+            roleBitmap |= RegistryRolesLib.ROLE_SET_PARENT_RESOLVER;
+        }
+        if ((fuses & CAN_EXTEND_EXPIRY) != 0) {
+            roleBitmap |= RegistryRolesLib.ROLE_RENEW_PARENT;
+        }
         if (LibMigration.notFrozen(fuses)) {
             roleBitmap |= roleBitmap << 128; // give admin
         }
@@ -228,10 +233,8 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
             RegistryRolesLib.ROLE_UPGRADE_ADMIN |
             RegistryRolesLib.ROLE_CAN_NAME |
             RegistryRolesLib.ROLE_CAN_NAME_ADMIN |
-            RegistryRolesLib.ROLE_SET_PARENT_RESOLVER |
-            RegistryRolesLib.ROLE_SET_PARENT_RESOLVER_ADMIN |
-            RegistryRolesLib.ROLE_RENEW_PARENT |
-            RegistryRolesLib.ROLE_RENEW_PARENT_ADMIN;
+            RegistryRolesLib.ROLE_EDIT_PUBLIC_RESOLVER |
+            RegistryRolesLib.ROLE_EDIT_PUBLIC_RESOLVER_ADMIN;
     }
 
     /// @dev Convert fuses to equivalent token roles.
@@ -241,12 +244,6 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
         }
         if ((fuses & CANNOT_SET_RESOLVER) == 0) {
             roleBitmap |= RegistryRolesLib.ROLE_SET_RESOLVER;
-        }
-        if (LibMigration.notFrozen(fuses)) {
-            roleBitmap |= roleBitmap << 128; // give admin
-        }
-        if ((fuses & CANNOT_TRANSFER) == 0) {
-            roleBitmap |= RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
         }
     }
 }

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -37,8 +37,6 @@ import {RegistryRolesLib} from "./libraries/RegistryRolesLib.sol";
 ///
 /// Names are treated as `AVAILABLE` once `block.timestamp >= expiry`.
 ///
-/// URI renderer address is embedded into URI data as `abi.encodePacked(uint8(1), address)`.
-///
 /// State diagram:
 ///
 ///                      register()

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -60,6 +60,10 @@ contract WrapperRegistry is
     /// @param implementation The disallowed implementation address.
     error UpgradeTargetNotApproved(address implementation);
 
+    /// @notice Registry only accepts the canonical token.
+    /// @dev Error selector: `0xc7569e47`
+    error TokenNotCanonical();
+
     ////////////////////////////////////////////////////////////////////////
     // Initialization
     ////////////////////////////////////////////////////////////////////////
@@ -196,7 +200,7 @@ contract WrapperRegistry is
     {
         if (msg.sender == address(_parentRegistry)) {
             if (LibLabel.withVersion(id, 0) != LibLabel.withVersion(LibLabel.id(_childLabel), 0)) {
-                revert("wtf"); // TODO
+                revert TokenNotCanonical();
             }
             return this.onERC1155Received.selector;
         } else {

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -181,7 +181,7 @@ contract WrapperRegistry is
         return super.register(label, owner, registry, resolver, roleBitmap, expiry);
     }
 
-    /// @inheritdoc PermissionedRegistry
+    /// @inheritdoc AbstractWrapperReceiver
     /// @dev Support canonical token ownership.
     function onERC1155Received(
         address operator,

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -182,6 +182,45 @@ contract WrapperRegistry is
     }
 
     /// @inheritdoc PermissionedRegistry
+    /// @dev Support canonical token ownership.
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 amount,
+        bytes calldata data
+    )
+        public
+        override
+        returns (bytes4)
+    {
+        if (msg.sender == address(_parentRegistry)) {
+            if (LibLabel.withVersion(id, 0) != LibLabel.withVersion(LibLabel.id(_childLabel), 0)) {
+                revert("wtf"); // TODO
+            }
+            return this.onERC1155Received.selector;
+        } else {
+            return super.onERC1155Received(operator, from, id, amount, data);
+        }
+    }
+
+    /// @inheritdoc IWrapperRegistry
+    function setParentResolver(address resolver)
+        public
+        onlyRootRoles(RegistryRolesLib.ROLE_SET_PARENT_RESOLVER)
+    {
+        PermissionedRegistry(address(_parentRegistry)).setResolver(
+            LibLabel.id(_childLabel),
+            resolver
+        );
+    }
+
+    /// @inheritdoc IWrapperRegistry
+    function renewParent(uint64 expiry) public onlyRootRoles(RegistryRolesLib.ROLE_RENEW_PARENT) {
+        PermissionedRegistry(address(_parentRegistry)).renew(LibLabel.id(_childLabel), expiry);
+    }
+
+    /// @inheritdoc PermissionedRegistry
     /// @dev Return `V1_RESOLVER` upon visiting migratable children.
     function getResolver(string calldata label)
         public

--- a/contracts/src/registry/interfaces/IWrapperRegistry.sol
+++ b/contracts/src/registry/interfaces/IWrapperRegistry.sol
@@ -5,7 +5,7 @@ import {IPermissionedRegistry} from "./IPermissionedRegistry.sol";
 import {IRegistry} from "./IRegistry.sol";
 
 /// @notice Interface for a registry that manages a locked NameWrapper name.
-/// @dev Interface selector: `0x6b2f7339`
+/// @dev Interface selector: `0x8cdebff4`
 interface IWrapperRegistry is IPermissionedRegistry {
     /// @notice Initializes WrapperRegistry.
     /// @param node Namehash of this registry.
@@ -21,6 +21,14 @@ interface IWrapperRegistry is IPermissionedRegistry {
         uint256 roleBitmap
     )
         external;
+
+    /// @notice Call `setResolver()` on the parent registry.
+    /// @param resolver The new parent resolver.
+    function setParentResolver(address resolver) external;
+
+    /// @notice Call `renew()` on the parent registry.
+    /// @param expiry The new parent expiry.
+    function renewParent(uint64 expiry) external;
 
     /// @notice Returns the DNS-encoded name for this registry.
     function getWrappedName() external view returns (bytes memory);

--- a/contracts/src/registry/libraries/RegistryRolesLib.sol
+++ b/contracts/src/registry/libraries/RegistryRolesLib.sol
@@ -57,9 +57,14 @@ library RegistryRolesLib {
     /// @dev Nybble 42: authorizes setting `ROLE_SET_PARENT_RESOLVER`.
     uint256 internal constant ROLE_SET_PARENT_RESOLVER_ADMIN = ROLE_SET_PARENT_RESOLVER << 128;
 
-    /// @dev Nybble 11: authorizes setting the parent resolver. WrapperRegistry and Root-only.
-    uint256 internal constant ROLE_RENEW_PARENT = 1 << 44;
-    /// @dev Nybble 43: authorizes setting `ROLE_RENEW_PARENT`.
+    /// @dev Nybble 11: authorizes editing PublicResolverV2. WrapperRegistry and Root-only.
+    uint256 internal constant ROLE_EDIT_PUBLIC_RESOLVER = 1 << 44;
+    /// @dev Nybble 43: authorizes setting `ROLE_EDIT_PUBLIC_RESOLVER`.
+    uint256 internal constant ROLE_EDIT_PUBLIC_RESOLVER_ADMIN = ROLE_EDIT_PUBLIC_RESOLVER << 128;
+
+    /// @dev Nybble 12: authorizes setting the parent resolver. WrapperRegistry and Root-only.
+    uint256 internal constant ROLE_RENEW_PARENT = 1 << 48;
+    /// @dev Nybble 44: authorizes setting `ROLE_RENEW_PARENT`.
     uint256 internal constant ROLE_RENEW_PARENT_ADMIN = ROLE_RENEW_PARENT << 128;
 
     /// @dev Nybble 30: authorizes contract naming. Root-only.

--- a/contracts/src/registry/libraries/RegistryRolesLib.sol
+++ b/contracts/src/registry/libraries/RegistryRolesLib.sol
@@ -44,13 +44,23 @@ library RegistryRolesLib {
     ///      This role is only checked on the token owner, not the operator.
     uint256 internal constant ROLE_CAN_TRANSFER_ADMIN = (1 << 28) << 128;
 
-    /// @dev Nybble 8: tags a name that was registered via `ROLE_REGISTER_RESERVED`. Token only. Not revokable.
+    /// @dev Nybble 8: tags a name that was registered via `ROLE_REGISTER_RESERVED`. Token-only. Not revokable.
     uint256 internal constant ROLE_WAS_RESERVED = (1 << 32);
 
     /// @dev Nybble 9: authorizes setting the URI. Root-only.
     uint256 internal constant ROLE_SET_URI = 1 << 36;
     /// @dev Nybble 41: authorizes setting `ROLE_SET_URI`.
     uint256 internal constant ROLE_SET_URI_ADMIN = ROLE_SET_URI << 128;
+
+    /// @dev Nybble 10: authorizes setting the parent resolver. WrapperRegistry and Root-only.
+    uint256 internal constant ROLE_SET_PARENT_RESOLVER = 1 << 40;
+    /// @dev Nybble 42: authorizes setting `ROLE_SET_PARENT_RESOLVER`.
+    uint256 internal constant ROLE_SET_PARENT_RESOLVER_ADMIN = ROLE_SET_PARENT_RESOLVER << 128;
+
+    /// @dev Nybble 11: authorizes setting the parent resolver. WrapperRegistry and Root-only.
+    uint256 internal constant ROLE_RENEW_PARENT = 1 << 44;
+    /// @dev Nybble 43: authorizes setting `ROLE_RENEW_PARENT`.
+    uint256 internal constant ROLE_RENEW_PARENT_ADMIN = ROLE_RENEW_PARENT << 128;
 
     /// @dev Nybble 30: authorizes contract naming. Root-only.
     uint256 internal constant ROLE_CAN_NAME = 1 << 120;

--- a/contracts/src/resolver/PublicResolverV2.sol
+++ b/contracts/src/resolver/PublicResolverV2.sol
@@ -187,7 +187,7 @@ contract PublicResolverV2 is
         if (ERC165Checker.supportsInterface(owner, type(IPermissionedRegistry).interfaceId)) {
             return
                 IPermissionedRegistry(owner).hasRootRoles(
-                    RegistryRolesLib.ROLE_SET_PARENT_RESOLVER,
+                    RegistryRolesLib.ROLE_EDIT_PUBLIC_RESOLVER,
                     operator
                 );
         }

--- a/contracts/src/resolver/PublicResolverV2.sol
+++ b/contracts/src/resolver/PublicResolverV2.sol
@@ -12,11 +12,13 @@ import {NameResolver} from "@ens/contracts/resolvers/profiles/NameResolver.sol";
 import {PubkeyResolver} from "@ens/contracts/resolvers/profiles/PubkeyResolver.sol";
 import {TextResolver} from "@ens/contracts/resolvers/profiles/TextResolver.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
 import {HCAContext} from "../hca/HCAContext.sol";
 import {HCAEquivalence} from "../hca/HCAEquivalence.sol";
 import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
 import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
+import {RegistryRolesLib} from "../registry/libraries/RegistryRolesLib.sol";
 import {IContractNamer} from "../reverse-registrar/interfaces/IContractNamer.sol";
 import {LibRegistry} from "../universalResolver/libraries/LibRegistry.sol";
 import {DelegatedContractNamer} from "../utils/DelegatedContractNamer.sol";
@@ -182,6 +184,13 @@ contract PublicResolverV2 is
             return false;
         }
         address owner = LibRegistry.findOwner(ROOT_REGISTRY, name, 0);
+        if (ERC165Checker.supportsInterface(owner, type(IPermissionedRegistry).interfaceId)) {
+            return
+                IPermissionedRegistry(owner).hasRootRoles(
+                    RegistryRolesLib.ROLE_SET_PARENT_RESOLVER,
+                    operator
+                );
+        }
         return
             owner == operator ||
             isApprovedForAll(owner, operator) ||

--- a/contracts/test/e2e/migration.test.ts
+++ b/contracts/test/e2e/migration.test.ts
@@ -607,7 +607,7 @@ describe("Migration", () => {
       await locked.migrate({
         target: env.v2.LockedMigrationController.address,
       });
-      await locked.checkMigrated();
+      await locked.checkMigrated({ owner: locked.wrapperRegistry().address });
       await locked.checkResolution();
     });
 
@@ -619,7 +619,7 @@ describe("Migration", () => {
         target: env.v2.LockedMigrationController.address,
         data: { resolver: anotherAddress },
       });
-      await locked.checkMigrated();
+      await locked.checkMigrated({ owner: locked.wrapperRegistry().address });
       const resolver = await env.v2.ETHRegistry.read.getResolver([
         locked.label,
       ]);
@@ -660,7 +660,7 @@ describe("Migration", () => {
       await locked.migrate({
         target: env.v2.LockedMigrationController.address,
       });
-      await locked.checkMigrated();
+      await locked.checkMigrated({ owner: locked.wrapperRegistry().address });
     });
 
     it("migrate locked child", async () => {
@@ -677,7 +677,9 @@ describe("Migration", () => {
       await lockedChild.migrate({
         target: lockedRegistry.address,
       });
-      await lockedChild.checkMigrated();
+      await lockedChild.checkMigrated({
+        owner: lockedChild.wrapperRegistry().address,
+      });
       await lockedChild.checkResolution();
     });
 
@@ -807,7 +809,8 @@ describe("Migration", () => {
       const state = await lockedRegistry.read.getState([
         idFromLabel(lockedChild.label),
       ]);
-      await lockedRegistry.write.renew([state.tokenId, state.expiry + 1n], {
+      const lockedChildRegistry = lockedChild.wrapperRegistry();
+      await lockedChildRegistry.write.renewParent([state.expiry + 1n], {
         account: lockedChild.account,
       });
     });
@@ -820,16 +823,6 @@ describe("Migration", () => {
           data: { owner: zeroAddress }, // wrong
         }),
       ).rejects.toThrow("InvalidOwner");
-    });
-
-    it("invalid receiver", async () => {
-      const locked = await registerWrapped({ fuses: FUSES.CANNOT_UNWRAP });
-      expect(
-        locked.migrate({
-          target: env.v2.LockedMigrationController.address,
-          data: { owner: env.v2.ETHRegistry.address }, // not IERC1155Receiver
-        }),
-      ).rejects.toThrow("ERC1155InvalidReceiver");
     });
 
     it("wrong controller", async () => {

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -284,25 +284,6 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
-    function test_migrate_invalidReceiver() external {
-        bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
-        LibMigration.Data memory md = _lockedData(name);
-        md.owner = address(ethRegistry); // not a IERC1155Receiver
-        vm.expectRevert(
-            WrappedErrorLib.wrap(
-                abi.encodeWithSelector(IERC1155Errors.ERC1155InvalidReceiver.selector, md.owner)
-            )
-        );
-        vm.prank(testOwner);
-        nameWrapper.safeTransferFrom(
-            testOwner,
-            address(migrationController),
-            uint256(NameCoder.namehash(name, 0)),
-            1,
-            abi.encode(md)
-        );
-    }
-
     function test_migrate_nameDataMismatch() external {
         bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         bytes32 node = NameCoder.namehash(name, 0);
@@ -367,20 +348,31 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
     function test_checkIfMigrated() external {
         bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         LibMigration.Data memory md = _lockedData(name);
+        bytes32 node = NameCoder.namehash(name, 0);
         uint256 tokenIdV1 = LibLabel.id(md.label);
 
-        assertFalse(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, testOwner));
+        address expectedRegistry =
+            _computeVerifiableFactoryAddress(address(migrationController), uint256(node));
+
+        assertFalse(
+            ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, expectedRegistry)
+        );
 
         vm.prank(testOwner);
         nameWrapper.safeTransferFrom(
             testOwner,
             address(migrationController),
-            uint256(NameCoder.namehash(name, 0)),
+            uint256(node),
             1,
             abi.encode(md)
         );
 
-        assertTrue(ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, testOwner));
+        assertTrue(
+            ethRegistry.hasRoles(tokenIdV1, RegistryRolesLib.ROLE_WAS_RESERVED, expectedRegistry),
+            "hasRoles"
+        );
+        assertEq(ethRegistry.findOwner(md.label), expectedRegistry, "owner");
+        assertEq(address(ethRegistry.getSubregistry(md.label)), expectedRegistry, "subregistry");
     }
 
     function test_migrate() external {
@@ -420,7 +412,11 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             RegistryRolesLib.ROLE_RENEW |
             RegistryRolesLib.ROLE_RENEW_ADMIN |
             RegistryRolesLib.ROLE_CAN_NAME |
-            RegistryRolesLib.ROLE_CAN_NAME_ADMIN
+            RegistryRolesLib.ROLE_CAN_NAME_ADMIN |
+            RegistryRolesLib.ROLE_SET_PARENT_RESOLVER |
+            RegistryRolesLib.ROLE_SET_PARENT_RESOLVER_ADMIN |
+            RegistryRolesLib.ROLE_RENEW_PARENT |
+            RegistryRolesLib.ROLE_RENEW_PARENT_ADMIN
         );
         // emit Initializable.Initialized()
         vm.expectEmit();
@@ -435,18 +431,24 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             tokenId,
             bytes32(tokenIdV1),
             md.label,
-            md.owner,
+            expectedRegistry, // owner
             expectedExpiry,
             address(migrationController)
         );
         vm.expectEmit();
-        emit IERC1155.TransferSingle(address(migrationController), address(0), md.owner, tokenId, 1);
+        emit IERC1155.TransferSingle(
+            address(migrationController),
+            address(0),
+            expectedRegistry,
+            tokenId,
+            1
+        );
         vm.expectEmit();
         emit IPermissionedRegistry.TokenResource(tokenId, tokenId);
         vm.expectEmit();
         emit IEnhancedAccessControl.EACRolesChanged(
             tokenId,
-            md.owner,
+            expectedRegistry,
             0 /*old roles*/,
             RegistryRolesLib.ROLE_SET_RESOLVER |
             RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
@@ -473,7 +475,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         console.log("Gas: %s", g - gasleft());
 
         assertEq(ethRegistry.getTokenId(tokenIdV1), tokenId, "tokenId");
-        assertEq(ethRegistry.ownerOf(tokenId), md.owner, "owner");
+        assertEq(ethRegistry.ownerOf(tokenId), expectedRegistry, "owner");
         assertEq(ethRegistry.getExpiry(tokenId), expectedExpiry, "expiry");
         assertEq(ethRegistry.getResolver(md.label), md.resolver, "resolver");
         checkResolution(name, address(ensV2Resolver), md.resolver);
@@ -522,13 +524,13 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         for (uint256 i; i < count; ++i) {
             string memory label = _label(i);
             uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(label));
-            assertEq(ethRegistry.ownerOf(tokenId), testOwner, "owner");
+            address expectedRegistry =
+                _computeVerifiableFactoryAddress(address(migrationController), ids[i]);
+            assertEq(ethRegistry.ownerOf(tokenId), expectedRegistry, "owner");
             assertEq(ethRegistry.getResolver(label), address(uint160(i)), "resolver");
+            assertEq(address(ethRegistry.getSubregistry(label)), expectedRegistry, "subregistry");
             assertTrue(
-                ERC165Checker.supportsInterface(
-                    address(ethRegistry.getSubregistry(label)),
-                    type(IWrapperRegistry).interfaceId
-                ),
+                ERC165Checker.supportsInterface(expectedRegistry, type(IWrapperRegistry).interfaceId),
                 "IWrapperRegistry"
             );
         }
@@ -661,17 +663,19 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
 
         uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(md.label));
+        IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
         assertEq(
-            ethRegistry.roles(tokenId, testOwner) & EACBaseRolesLib.ADMIN_ROLES,
+            ethRegistry.roles(tokenId, address(registry)) & EACBaseRolesLib.ADMIN_ROLES,
             RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN,
             "token"
         );
-        IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
         assertEq(
             registry.roles(registry.ROOT_RESOURCE(), testOwner) & EACBaseRolesLib.ADMIN_ROLES,
             RegistryRolesLib.ROLE_UPGRADE_ADMIN |
             RegistryRolesLib.ROLE_RENEW_ADMIN |
-            RegistryRolesLib.ROLE_CAN_NAME_ADMIN,
+            RegistryRolesLib.ROLE_CAN_NAME_ADMIN |
+            RegistryRolesLib.ROLE_SET_PARENT_RESOLVER_ADMIN |
+            RegistryRolesLib.ROLE_RENEW_PARENT_ADMIN,
             "registry"
         );
     }
@@ -745,13 +749,21 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             1,
             abi.encode(data3)
         );
+        IWrapperRegistry registry3 =
+            IWrapperRegistry(address(registry2.getSubregistry(data3.label)));
 
-        uint256 tokenId = registry2.getTokenId(LibLabel.id(data3.label));
-        assertTrue(registry2.hasRoles(tokenId, RegistryRolesLib.ROLE_RENEW, friend), "ROLE_RENEW");
+        assertTrue(
+            registry2.hasRoles(
+                LibLabel.id(data3.label),
+                RegistryRolesLib.ROLE_RENEW,
+                address(registry3)
+            ),
+            "ROLE_RENEW"
+        );
 
-        uint64 expiry = registry2.getExpiry(tokenId);
+        uint64 expiry = registry2.getExpiry(LibLabel.id(data3.label));
         vm.prank(friend);
-        registry2.renew(tokenId, expiry + 1);
+        registry3.renewParent(expiry + 1);
     }
 
     function test_migrate_lockedChildren() external {
@@ -773,13 +785,14 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             1,
             abi.encode(data2)
         );
-        assertEq(
-            ethRegistry.ownerOf(ethRegistry.getTokenId(LibLabel.id(data2.label))),
-            data2.owner,
-            "owner2"
-        );
         IWrapperRegistry registry2 =
             IWrapperRegistry(address(ethRegistry.getSubregistry(data2.label)));
+
+        assertEq(
+            ethRegistry.ownerOf(ethRegistry.getTokenId(LibLabel.id(data2.label))),
+            address(registry2),
+            "owner2"
+        );
         assertTrue(
             ERC165Checker.supportsInterface(address(registry2), type(IWrapperRegistry).interfaceId),
             "registry2"
@@ -797,12 +810,12 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
         assertEq(registry2.getResolver(data3.label), data3.resolver, "resolver3");
         checkResolution(name3, address(ensV2Resolver), data3.resolver);
+        IRegistry registry3 = registry2.getSubregistry(data3.label);
         assertEq(
             registry2.ownerOf(registry2.getTokenId(LibLabel.id(data3.label))),
-            data3.owner,
+            address(registry3),
             "owner3"
         );
-        IRegistry registry3 = registry2.getSubregistry(data3.label);
         assertTrue(
             ERC165Checker.supportsInterface(address(registry3), type(IWrapperRegistry).interfaceId),
             "registry3"
@@ -850,13 +863,13 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             1,
             abi.encode(data2)
         );
-        assertEq(
-            ethRegistry.ownerOf(ethRegistry.getTokenId(LibLabel.id(data2.label))),
-            data2.owner,
-            "owner2"
-        );
         IWrapperRegistry registry2 =
             IWrapperRegistry(address(ethRegistry.getSubregistry(data2.label)));
+        assertEq(
+            ethRegistry.ownerOf(ethRegistry.getTokenId(LibLabel.id(data2.label))),
+            address(registry2),
+            "owner2"
+        );
         assertTrue(
             ERC165Checker.supportsInterface(address(registry2), type(IWrapperRegistry).interfaceId),
             "registry2"

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -415,8 +415,8 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             RegistryRolesLib.ROLE_CAN_NAME_ADMIN |
             RegistryRolesLib.ROLE_SET_PARENT_RESOLVER |
             RegistryRolesLib.ROLE_SET_PARENT_RESOLVER_ADMIN |
-            RegistryRolesLib.ROLE_RENEW_PARENT |
-            RegistryRolesLib.ROLE_RENEW_PARENT_ADMIN
+            RegistryRolesLib.ROLE_EDIT_PUBLIC_RESOLVER |
+            RegistryRolesLib.ROLE_EDIT_PUBLIC_RESOLVER_ADMIN
         );
         // emit Initializable.Initialized()
         vm.expectEmit();
@@ -450,10 +450,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             tokenId,
             expectedRegistry,
             0 /*old roles*/,
-            RegistryRolesLib.ROLE_SET_RESOLVER |
-            RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
-            RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
-            RegistryRolesLib.ROLE_WAS_RESERVED
+            RegistryRolesLib.ROLE_SET_RESOLVER | RegistryRolesLib.ROLE_WAS_RESERVED
         );
         vm.expectEmit();
         emit IRegistryEvents.SubregistryUpdated(
@@ -564,6 +561,55 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
+    function test_migrate_setParentResolver() external {
+        bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        bytes32 node = NameCoder.namehash(name, 0);
+        LibMigration.Data memory md = _lockedData(name);
+
+        vm.prank(testOwner);
+        nameWrapper.safeTransferFrom(
+            testOwner,
+            address(migrationController),
+            uint256(node),
+            1,
+            abi.encode(md)
+        );
+
+        uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(md.label));
+        IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
+
+        assertTrue(
+            registry.hasRootRoles(RegistryRolesLib.ROLE_SET_PARENT_RESOLVER, testOwner),
+            "setParent:owner"
+        );
+        assertFalse(
+            registry.hasRootRoles(RegistryRolesLib.ROLE_SET_PARENT_RESOLVER, address(registry)),
+            "setParent:registry"
+        );
+        assertFalse(
+            ethRegistry.hasRoles(tokenId, RegistryRolesLib.ROLE_SET_RESOLVER, testOwner),
+            "set:owner"
+        );
+        assertTrue(
+            ethRegistry.hasRoles(tokenId, RegistryRolesLib.ROLE_SET_RESOLVER, address(registry)),
+            "set:registry"
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                registry.ROOT_RESOURCE(),
+                RegistryRolesLib.ROLE_SET_PARENT_RESOLVER,
+                address(actor)
+            )
+        );
+        vm.prank(actor);
+        registry.setParentResolver(testResolver);
+
+        vm.prank(testOwner);
+        registry.setParentResolver(testResolver);
+    }
+
     function test_migrate_lockedResolver() external {
         bytes memory name = registerWrappedETH2LD(testLabel, CAN_DO_EVERYTHING);
         bytes32 node = NameCoder.namehash(name, 0);
@@ -585,20 +631,39 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             abi.encode(md)
         );
 
-        uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(md.label));
         assertEq(ethRegistry.getResolver(md.label), frozenResolver, "frozen");
         checkResolution(name, frozenResolver, frozenResolver);
-        assertFalse(ethRegistry.hasRoles(tokenId, RegistryRolesLib.ROLE_SET_RESOLVER, testOwner));
+
+        uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(md.label));
+        IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
+
+        assertFalse(
+            registry.hasRootRoles(RegistryRolesLib.ROLE_SET_PARENT_RESOLVER, testOwner),
+            "setParent:owner"
+        );
+        assertFalse(
+            registry.hasRootRoles(RegistryRolesLib.ROLE_SET_PARENT_RESOLVER, address(registry)),
+            "setParent:registry"
+        );
+        assertFalse(
+            ethRegistry.hasRoles(tokenId, RegistryRolesLib.ROLE_SET_RESOLVER, testOwner),
+            "set:owner"
+        );
+        assertFalse(
+            ethRegistry.hasRoles(tokenId, RegistryRolesLib.ROLE_SET_RESOLVER, address(registry)),
+            "set:registry"
+        );
+
         vm.expectRevert(
             abi.encodeWithSelector(
                 IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
-                tokenId,
-                RegistryRolesLib.ROLE_SET_RESOLVER,
-                testOwner
+                registry.ROOT_RESOURCE(),
+                RegistryRolesLib.ROLE_SET_PARENT_RESOLVER,
+                address(testOwner)
             )
         );
         vm.prank(testOwner);
-        ethRegistry.setResolver(tokenId, testResolver);
+        registry.setParentResolver(testResolver);
     }
 
     function test_migrate_lockedResolver_publicResolver() external {
@@ -665,8 +730,8 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(md.label));
         IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
         assertEq(
-            ethRegistry.roles(tokenId, address(registry)) & EACBaseRolesLib.ADMIN_ROLES,
-            RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN,
+            ethRegistry.roles(tokenId, address(registry)),
+            RegistryRolesLib.ROLE_SET_RESOLVER | RegistryRolesLib.ROLE_WAS_RESERVED,
             "token"
         );
         assertEq(
@@ -674,8 +739,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             RegistryRolesLib.ROLE_UPGRADE_ADMIN |
             RegistryRolesLib.ROLE_RENEW_ADMIN |
             RegistryRolesLib.ROLE_CAN_NAME_ADMIN |
-            RegistryRolesLib.ROLE_SET_PARENT_RESOLVER_ADMIN |
-            RegistryRolesLib.ROLE_RENEW_PARENT_ADMIN,
+            RegistryRolesLib.ROLE_EDIT_PUBLIC_RESOLVER_ADMIN,
             "registry"
         );
     }
@@ -762,6 +826,18 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
 
         uint64 expiry = registry2.getExpiry(LibLabel.id(data3.label));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                registry2.ROOT_RESOURCE(),
+                RegistryRolesLib.ROLE_RENEW_PARENT,
+                actor
+            )
+        );
+        vm.prank(actor);
+        registry3.renewParent(expiry + 1);
+
         vm.prank(friend);
         registry3.renewParent(expiry + 1);
     }

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -561,6 +561,56 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
+    function test_migrate_transferNonCanonical() external {
+        bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        bytes32 node = NameCoder.namehash(name, 0);
+        LibMigration.Data memory md = _lockedData(name);
+
+        vm.prank(testOwner);
+        nameWrapper.safeTransferFrom(
+            testOwner,
+            address(migrationController),
+            uint256(node),
+            1,
+            abi.encode(md)
+        );
+
+        IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(testLabel)));
+
+        // transfer from same registry, diff label
+        uint256 tokenId1 =
+            ethRegistry.register(
+                "1",
+                testOwner,
+                testRegistry,
+                testResolver,
+                RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN,
+                _soon()
+            );
+        vm.expectRevert(abi.encodeWithSelector(WrapperRegistry.TokenNotCanonical.selector));
+        vm.prank(testOwner);
+        ethRegistry.safeTransferFrom(address(testOwner), address(registry), tokenId1, 1, "");
+
+        // transfer from diff registry, same label
+        vm.prank(testOwner);
+        uint256 tokenId2 =
+            registry.register(
+                testLabel,
+                testOwner,
+                testRegistry,
+                testResolver,
+                RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN,
+                _soon()
+            );
+        vm.expectRevert(
+            WrappedErrorLib.wrap(
+                abi.encodeWithSelector(UnauthorizedCaller.selector, address(registry))
+            )
+        );
+        vm.prank(testOwner);
+        registry.safeTransferFrom(address(testOwner), address(registry), tokenId2, 1, "");
+    }
+
     function test_migrate_setParentResolver() external {
         bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         bytes32 node = NameCoder.namehash(name, 0);


### PR DESCRIPTION
- changed so `WrapperRegistry` owns the token
- reverts `TokenNotCanonical` if transferred a different token
- added `ROLE_SET_PARENT_RESOLVER`
- added `WrapperRegistry.setParentResolver(resolver)`
- added `ROLE_RENEW_PARENT`
- added `WrapperRegistry.renewParent(expiry)`
- added `ROLE_EDIT_PUBLIC_RESOLVER`
- changed `PublicResolverV2.canModifyName()` such that if `owner` is `WrapperRegistry` returns `hasRootRoles(ROLE_EDIT_PUBLIC_RESOLVER, operator)`
- converted locked token roles to subregistry roles