### PR TITLE
Finish Contract Naming

### DIFF
--- a/contracts/deploy/02_DefaultReverseRegistrarHCAAdapter.ts
+++ b/contracts/deploy/02_DefaultReverseRegistrarHCAAdapter.ts
@@ -9,17 +9,23 @@ export default execute(
     namedAccounts: { deployer, owner },
     network,
   }) => {
-    const hcaFactory =
-      get<(typeof artifacts.HCAFactory)["abi"]>("HCAFactory");
+    const hcaFactory = get<(typeof artifacts.HCAFactory)["abi"]>("HCAFactory");
 
     const defaultReverseRegistrar = get<
       (typeof artifacts.DefaultReverseRegistrar)["abi"]
     >("DefaultReverseRegistrar");
 
+    const contractNamer =
+      get<(typeof artifacts.IContractNamer)["abi"]>("ContractNamer");
+
     const adapter = await deploy("DefaultReverseRegistrarHCAAdapter", {
       account: deployer,
       artifact: artifacts.DefaultReverseRegistrarHCAAdapter,
-      args: [hcaFactory.address, defaultReverseRegistrar.address],
+      args: [
+        hcaFactory.address,
+        defaultReverseRegistrar.address,
+        contractNamer.address,
+      ],
     });
 
     if (network.name === "mainnet" && !network.tags?.tenderly) return;
@@ -39,6 +45,6 @@ export default execute(
   },
   {
     tags: ["DefaultReverseRegistrarHCAAdapter", "v2"],
-    dependencies: ["HCAFactory", "DefaultReverseRegistrar"],
+    dependencies: ["HCAFactory", "DefaultReverseRegistrar", "ContractNamer"],
   },
 );

--- a/contracts/deploy/02_ReverseRegistrarHCAAdapter.ts
+++ b/contracts/deploy/02_ReverseRegistrarHCAAdapter.ts
@@ -9,16 +9,22 @@ export default execute(
     namedAccounts: { deployer, owner },
     network,
   }) => {
-    const hcaFactory =
-      get<(typeof artifacts.HCAFactory)["abi"]>("HCAFactory");
+    const hcaFactory = get<(typeof artifacts.HCAFactory)["abi"]>("HCAFactory");
 
     const reverseRegistrar =
       get<(typeof artifacts.ReverseRegistrar)["abi"]>("ReverseRegistrar");
 
+    const contractNamer =
+      get<(typeof artifacts.IContractNamer)["abi"]>("ContractNamer");
+
     const adapter = await deploy("ReverseRegistrarHCAAdapter", {
       account: deployer,
       artifact: artifacts.ReverseRegistrarHCAAdapter,
-      args: [hcaFactory.address, reverseRegistrar.address],
+      args: [
+        hcaFactory.address,
+        reverseRegistrar.address,
+        contractNamer.address,
+      ],
     });
 
     if (network.name === "mainnet" && !network.tags?.tenderly) return;
@@ -38,6 +44,6 @@ export default execute(
   },
   {
     tags: ["ReverseRegistrarHCAAdapter", "v2"],
-    dependencies: ["HCAFactory", "ReverseRegistrar"],
+    dependencies: ["HCAFactory", "ReverseRegistrar", "ContractNamer"],
   },
 );

--- a/contracts/deploy/05_MigrationHelper.ts
+++ b/contracts/deploy/05_MigrationHelper.ts
@@ -2,8 +2,7 @@ import { artifacts, execute } from "@rocketh";
 
 export default execute(
   async ({ deploy, get, namedAccounts: { deployer } }) => {
-    const hcaFactory =
-      get<(typeof artifacts.HCAFactory)["abi"]>("HCAFactory");
+    const hcaFactory = get<(typeof artifacts.HCAFactory)["abi"]>("HCAFactory");
 
     const rootRegistry =
       get<(typeof artifacts.PermissionedRegistry)["abi"]>("RootRegistry");
@@ -16,6 +15,9 @@ export default execute(
       (typeof artifacts.LockedMigrationController)["abi"]
     >("LockedMigrationController");
 
+    const contractNamer =
+      get<(typeof artifacts.IContractNamer)["abi"]>("ContractNamer");
+
     await deploy("MigrationHelper", {
       account: deployer,
       artifact: artifacts["src/migration/MigrationHelper.sol/MigrationHelper"],
@@ -24,6 +26,7 @@ export default execute(
         rootRegistry.address,
         unlockedMigrationController.address,
         lockedMigrationController.address,
+        contractNamer.address,
       ],
     });
   },
@@ -34,6 +37,7 @@ export default execute(
       "RootRegistry",
       "UnlockedMigrationController",
       "LockedMigrationController",
+      "ContractNamer",
     ],
   },
 );

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -9,20 +9,8 @@ gas_reports = ["*"]
 evm_version = "cancun"
 optimizer = true
 optimizer_runs = 200
-skip = [
-    "HCAProxyInitCode.yul",
-    "HCAProxyNoInitCode.yul",
-]
-
-ignored_warnings_from = [
-    "lib/ens-contracts/contracts/registry/ENSRegistry.sol",
-    "lib/ens-contracts/contracts/ethregistrar/BaseRegistrarImplementation.sol",
-    "lib/ens-contracts/contracts/reverseRegistrar/ReverseRegistrar.sol",
-    "lib/ens-contracts/contracts/wrapper/NameWrapper.sol",
-    "lib/ens-contracts/contracts/reverseRegistrar/ReverseRegistrar.sol",
-    "lib/verifiable-factory/src/UUPSProxyLogic.sol",
-    "src/hca/HCAProxyInitCode.yul",
-]
+skip = ["HCAProxyInitCode.yul", "HCAProxyNoInitCode.yul"]
+ignored_warnings_from = ["lib/", "src/hca/HCAProxyInitCode.yul"]
 
 [fuzz]
 runs = 4096

--- a/contracts/script/setup.ts
+++ b/contracts/script/setup.ts
@@ -916,7 +916,7 @@ export async function setupDevnet({
       await setName("registrar", v2.ETHRegistrar.address);
       await setName("renewer", v2.ETHRenewerV1.address);
       await setName("oracle", v2.StandardRentPriceOracle.address);
-      // BatchRegistrar
+      // await setName("batch.migration", v2.BatchRegistrar.address); // this is only used internally for premigration
       await setName("addr.reverse", shared.ReverseRegistrarHCAAdapter.address);
       await setName(
         "default.reverse",

--- a/contracts/src/migration/MigrationHelper.sol
+++ b/contracts/src/migration/MigrationHelper.sol
@@ -9,7 +9,9 @@ import {HCAContext} from "../hca/HCAContext.sol";
 import {HCAEquivalence} from "../hca/HCAEquivalence.sol";
 import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
 import {IRegistry} from "../registry/interfaces/IRegistry.sol";
+import {IContractNamer} from "../reverse-registrar/interfaces/IContractNamer.sol";
 import {LibRegistry} from "../universalResolver/libraries/LibRegistry.sol";
+import {DelegatedContractNamer} from "../utils/DelegatedContractNamer.sol";
 
 import {AbstractWrapperReceiver} from "./AbstractWrapperReceiver.sol";
 import {LibMigration} from "./libraries/LibMigration.sol";
@@ -23,7 +25,7 @@ struct LockedChildren {
 }
 
 /// @notice Migration helper for mixed (ERC-721 and ERC-1155) batch migration using approval.
-contract MigrationHelper is HCAContext {
+contract MigrationHelper is DelegatedContractNamer, HCAContext {
     ////////////////////////////////////////////////////////////////////////
     // Immutables
     ////////////////////////////////////////////////////////////////////////
@@ -63,18 +65,20 @@ contract MigrationHelper is HCAContext {
     // Initialization
     ////////////////////////////////////////////////////////////////////////
 
-    /// @notice Initializes `MigrationHelper`.
     /// @param hcaFactory The HCA factory to use.
     /// @param rootRegistry The root registry.
     /// @param unlockedController The ENSv2 `UnlockedMigrationController`.
     /// @param lockedController The ENSv2 `LockedMigrationController`.
+    /// @param contractNamer Delegated contract namer.
     constructor(
         IHCAFactoryBasic hcaFactory,
         IRegistry rootRegistry,
         AbstractWrapperReceiver unlockedController,
-        AbstractWrapperReceiver lockedController
+        AbstractWrapperReceiver lockedController,
+        IContractNamer contractNamer
     )
         HCAEquivalence(hcaFactory)
+        DelegatedContractNamer(contractNamer)
     {
         ROOT_REGISTRY = rootRegistry;
         UNLOCKED_CONTROLLER = unlockedController;

--- a/contracts/src/reverse-registrar/DefaultReverseRegistrarHCAAdapter.sol
+++ b/contracts/src/reverse-registrar/DefaultReverseRegistrarHCAAdapter.sol
@@ -8,13 +8,15 @@ import {
 import {HCAContext} from "../hca/HCAContext.sol";
 import {HCAEquivalence} from "../hca/HCAEquivalence.sol";
 import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
+import {DelegatedContractNamer} from "../utils/DelegatedContractNamer.sol";
 
+import {IContractNamer} from "./interfaces/IContractNamer.sol";
 import {AccountNamerLib} from "./libraries/AccountNamerLib.sol";
 
 /// @title Default Reverse Registrar HCA Adapter
 /// @notice HCA-aware forwarder for v1 `default.reverse` registrar updates.
 /// @dev The adapter must be configured as a controller on the default reverse registrar.
-contract DefaultReverseRegistrarHCAAdapter is HCAContext {
+contract DefaultReverseRegistrarHCAAdapter is DelegatedContractNamer, HCAContext {
     ////////////////////////////////////////////////////////////////////////
     // Immutables
     ////////////////////////////////////////////////////////////////////////
@@ -29,8 +31,14 @@ contract DefaultReverseRegistrarHCAAdapter is HCAContext {
     /// @notice Initializes the adapter with its HCA context and target registrar.
     /// @param hcaFactory The HCA factory used to resolve HCA callers to their owners.
     /// @param defaultReverseRegistrar The v1 default reverse registrar for `default.reverse`.
-    constructor(IHCAFactoryBasic hcaFactory, IDefaultReverseRegistrar defaultReverseRegistrar)
+    /// @param contractNamer Delegated contract namer.
+    constructor(
+        IHCAFactoryBasic hcaFactory,
+        IDefaultReverseRegistrar defaultReverseRegistrar,
+        IContractNamer contractNamer
+    )
         HCAEquivalence(hcaFactory)
+        DelegatedContractNamer(contractNamer)
     {
         DEFAULT_REVERSE_REGISTRAR = defaultReverseRegistrar;
     }

--- a/contracts/src/reverse-registrar/ReverseRegistrarHCAAdapter.sol
+++ b/contracts/src/reverse-registrar/ReverseRegistrarHCAAdapter.sol
@@ -6,13 +6,15 @@ import {IReverseRegistrar} from "@ens/contracts/reverseRegistrar/IReverseRegistr
 import {HCAContext} from "../hca/HCAContext.sol";
 import {HCAEquivalence} from "../hca/HCAEquivalence.sol";
 import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
+import {DelegatedContractNamer} from "../utils/DelegatedContractNamer.sol";
 
+import {IContractNamer} from "./interfaces/IContractNamer.sol";
 import {AccountNamerLib} from "./libraries/AccountNamerLib.sol";
 
 /// @title Reverse Registrar HCA Adapter
 /// @notice HCA-aware forwarder for v1 `addr.reverse` registrar updates.
 /// @dev The adapter must be configured as a controller on the reverse registrar.
-contract ReverseRegistrarHCAAdapter is HCAContext {
+contract ReverseRegistrarHCAAdapter is DelegatedContractNamer, HCAContext {
     ////////////////////////////////////////////////////////////////////////
     // Immutables
     ////////////////////////////////////////////////////////////////////////
@@ -27,8 +29,14 @@ contract ReverseRegistrarHCAAdapter is HCAContext {
     /// @notice Initializes the adapter with its HCA context and target registrar.
     /// @param hcaFactory The HCA factory used to resolve HCA callers to their owners.
     /// @param reverseRegistrar The v1 reverse registrar for `addr.reverse`.
-    constructor(IHCAFactoryBasic hcaFactory, IReverseRegistrar reverseRegistrar)
+    /// @param contractNamer Delegated contract namer.
+    constructor(
+        IHCAFactoryBasic hcaFactory,
+        IReverseRegistrar reverseRegistrar,
+        IContractNamer contractNamer
+    )
         HCAEquivalence(hcaFactory)
+        DelegatedContractNamer(contractNamer)
     {
         REVERSE_REGISTRAR = reverseRegistrar;
     }

--- a/contracts/test/unit/migration/MigrationHelper.t.sol
+++ b/contracts/test/unit/migration/MigrationHelper.t.sol
@@ -74,7 +74,13 @@ contract MigrationHelperTest is MigrationControllerFixture {
             address(lockedController)
         );
 
-        helper = new MigrationHelper(hcaFactory, rootRegistry, unlockedController, lockedController);
+        helper = new MigrationHelper(
+            hcaFactory,
+            rootRegistry,
+            unlockedController,
+            lockedController,
+            contractNamer
+        );
     }
 
     function test_migrate_unwrapped_notApproved() external {

--- a/contracts/test/unit/reverse-registrar/DefaultReverseRegistrarHCAAdapter.t.sol
+++ b/contracts/test/unit/reverse-registrar/DefaultReverseRegistrarHCAAdapter.t.sol
@@ -11,6 +11,7 @@ import {
     DefaultReverseRegistrarHCAAdapter
 } from "~src/reverse-registrar/DefaultReverseRegistrarHCAAdapter.sol";
 import {MockHCAFactoryBasic} from "~test/mocks/MockHCAFactoryBasic.sol";
+import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
 
 contract DefaultReverseRegistrarHCAAdapterTest is Test {
     MockHCAFactoryBasic hcaFactory;
@@ -23,7 +24,11 @@ contract DefaultReverseRegistrarHCAAdapterTest is Test {
     function setUp() public {
         hcaFactory = new MockHCAFactoryBasic();
         defaultReverseRegistrar = new DefaultReverseRegistrar();
-        defaultAdapter = new DefaultReverseRegistrarHCAAdapter(hcaFactory, defaultReverseRegistrar);
+        defaultAdapter = new DefaultReverseRegistrarHCAAdapter(
+            hcaFactory,
+            defaultReverseRegistrar,
+            IContractNamer(address(0))
+        );
 
         defaultReverseRegistrar.setController(address(defaultAdapter), true);
     }

--- a/contracts/test/unit/reverse-registrar/ReverseRegistrarHCAAdapter.t.sol
+++ b/contracts/test/unit/reverse-registrar/ReverseRegistrarHCAAdapter.t.sol
@@ -31,7 +31,11 @@ contract ReverseRegistrarHCAAdapterTest is Test {
         hcaFactory = new MockHCAFactoryBasic();
         registry = new ENSRegistry();
         reverseRegistrar = new ReverseRegistrar(registry);
-        reverseAdapter = new ReverseRegistrarHCAAdapter(hcaFactory, reverseRegistrar);
+        reverseAdapter = new ReverseRegistrarHCAAdapter(
+            hcaFactory,
+            reverseRegistrar,
+            IContractNamer(address(0))
+        );
 
         registry.setSubnodeOwner(bytes32(0), REVERSE_LABELHASH, address(this));
         registry.setSubnodeOwner(REVERSE_NODE, ADDR_LABELHASH, address(reverseRegistrar));

--- a/contracts/test/unit/utils/ContactNamer.t.sol
+++ b/contracts/test/unit/utils/ContactNamer.t.sol
@@ -4,18 +4,21 @@ pragma solidity ^0.8.13;
 import {Test} from "forge-std/Test.sol";
 
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 import {ContractNamer} from "~src/utils/ContractNamer.sol";
+import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
 
 contract ContractNamerTest is Test {
     ContractNamer contractNamer;
+    address owner = makeAddr("owner");
 
     function setUp() external {
         contractNamer = ContractNamer(
             address(
                 new ERC1967Proxy(
                     address(new ContractNamer()),
-                    abi.encodeCall(ContractNamer.initialize, (address(this)))
+                    abi.encodeCall(ContractNamer.initialize, (owner))
                 )
             )
         );
@@ -23,6 +26,27 @@ contract ContractNamerTest is Test {
 
     function test_isContractNamer() external view {
         assertFalse(contractNamer.isContractNamer(address(0)));
-        assertTrue(contractNamer.isContractNamer(address(this)));
+        assertTrue(contractNamer.isContractNamer(owner));
     }
+
+    function test_upgrade() external {
+        MockUpgrade c = new MockUpgrade();
+        vm.prank(owner);
+        contractNamer.upgradeToAndCall(address(c), "");
+        assertTrue(c.isContractNamer(address(1)));
+    }
+
+    function test_upgrade_notAuthorized() external {
+        MockUpgrade c = new MockUpgrade();
+        vm.expectRevert();
+        contractNamer.upgradeToAndCall(address(c), "");
+    }
+}
+
+
+contract MockUpgrade is UUPSUpgradeable, IContractNamer {
+    function isContractNamer(address namer) external pure returns (bool) {
+        return namer == address(1);
+    }
+    function _authorizeUpgrade(address) internal override {}
 }

--- a/contracts/test/unit/utils/ContactNamer.t.sol
+++ b/contracts/test/unit/utils/ContactNamer.t.sol
@@ -33,7 +33,7 @@ contract ContractNamerTest is Test {
         MockUpgrade c = new MockUpgrade();
         vm.prank(owner);
         contractNamer.upgradeToAndCall(address(c), "");
-        assertTrue(c.isContractNamer(address(1)));
+        assertTrue(contractNamer.isContractNamer(address(1)));
     }
 
     function test_upgrade_notAuthorized() external {


### PR DESCRIPTION
- named `ReverseRegistrarHCAAdapter`
- named `DefaultReverseRegistrarHCAAdapter`
- named `MigrationHelper`
- added upgrade test for `ContractNamer`