### PR TITLE
Add `RegistryHelper`

### DIFF
--- a/contracts/src/utils/RegistryHelper.sol
+++ b/contracts/src/utils/RegistryHelper.sol
@@ -1,39 +1,59 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
 import {IEnhancedAccessControl} from "../access-control/interfaces/IEnhancedAccessControl.sol";
-import {LibRegistry} from "../universalResolver/libraries/LibRegistry.sol";
-
-import {IRegistry} from "../registry/interfaces/IRegistry.sol";
 import {IOwnedRegistry} from "../registry/interfaces/IOwnedRegistry.sol";
+import {IRegistry} from "../registry/interfaces/IRegistry.sol";
 import {ITemporalRegistry} from "../registry/interfaces/ITemporalRegistry.sol";
 import {ITokenizedRegistry} from "../registry/interfaces/ITokenizedRegistry.sol";
 import {RegistryRolesLib} from "../registry/libraries/RegistryRolesLib.sol";
+import {LibRegistry} from "../universalResolver/libraries/LibRegistry.sol";
 
 /// @notice Immutable read-only convenience contract that provides functions to inspect
 ///         name state, ownership, verification, and emancipation status across the
 ///         ENSv2 registry hierarchy.
 contract RegistryHelper {
+    ////////////////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////////////////
+
+    struct LabelInfo {
+        /// @dev The label's own subregistry, or address(0) if none.
+        IRegistry registry;
+        /// @dev Resolver set on the governing parent registry for this label.
+        address resolver;
+        /// @dev Owner of this label, or address(0) if unowned.
+        address owner;
+        /// @dev The label string (e.g. "alice" for alice.eth).
+        string label;
+        /// @dev Token ID from ITokenizedRegistry, or 0 if not minted.
+        uint256 tokenId;
+        /// @dev Expiry timestamp in seconds, or 0 if no expiry.
+        uint64 expiry;
+        /// @dev Bitfield of FLAG_* constants describing the name's state.
+        uint8 flags;
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Constants & Immutables
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev The root resource ID used by EnhancedAccessControl.
     uint256 private constant ROOT_RESOURCE = 0;
 
-    IRegistry public immutable ROOT_REGISTRY;
-    IRegistry public immutable ETH_REGISTRY;
-    IVerifiableFactory public immutable VERIFIABLE_FACTORY;
-    address public immutable USER_REGISTRY_IMPL;
-    address public immutable WRAPPER_REGISTRY_IMPL;
-
-    /// @dev Roles whose presence on ROOT_RESOURCE endangers name owners.
-    ///      Two categories:
-    ///      - Per-token roles (SET_RESOLVER, SET_SUBREGISTRY, UNREGISTER and their admins,
-    ///        plus CAN_TRANSFER_ADMIN): exercisable on any token via the hasRoles ROOT union.
-    ///      - Registry-wide roles (UPGRADE, UPGRADE_ADMIN): can replace the entire
-    ///        implementation via UUPS proxy, bypassing all access control.
-    ///      ROLE_RENEW and ROLE_RENEW_ADMIN are excluded: RENEW can only extend expiry
-    ///      (CannotReduceExpiry), and its admin can only grant/revoke that harmless capability.
+    /// @notice Roles whose presence on ROOT_RESOURCE endangers name owners.
+    /// @dev Two categories:
+    /// - Per-token roles (SET_RESOLVER, SET_SUBREGISTRY, UNREGISTER and their admins,
+    ///   plus CAN_TRANSFER_ADMIN): exercisable on any token via the hasRoles ROOT union.
+    /// - Registry-wide roles (UPGRADE, UPGRADE_ADMIN): can replace the entire
+    ///   implementation via UUPS proxy, bypassing all access control.
+    /// ROLE_RENEW and ROLE_RENEW_ADMIN are excluded: RENEW can only extend expiry
+    /// (CannotReduceExpiry), and its admin can only grant/revoke that harmless capability.
+    ///
     uint256 public constant DANGEROUS_ROOT_ROLES =
         RegistryRolesLib.ROLE_SET_RESOLVER |
         RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
@@ -58,22 +78,20 @@ contract RegistryHelper {
     /// @notice Set when the governing parent registry has no dangerous roles on ROOT_RESOURCE.
     uint8 public constant FLAG_IS_EMANCIPATED = 1 << 5;
 
-    struct LabelInfo {
-        /// @dev The label's own subregistry, or address(0) if none.
-        IRegistry registry;
-        /// @dev Resolver set on the governing parent registry for this label.
-        address resolver;
-        /// @dev Owner of this label, or address(0) if unowned.
-        address owner;
-        /// @dev The label string (e.g. "alice" for alice.eth).
-        string label;
-        /// @dev Token ID from ITokenizedRegistry, or 0 if not minted.
-        uint256 tokenId;
-        /// @dev Expiry timestamp in seconds, or 0 if no expiry.
-        uint64 expiry;
-        /// @dev Bitfield of FLAG_* constants describing the name's state.
-        uint8 flags;
-    }
+    /// @notice The root registry (trust anchor).
+    IRegistry public immutable ROOT_REGISTRY;
+    /// @notice The .eth TLD registry (trusted by endorsement).
+    IRegistry public immutable ETH_REGISTRY;
+    /// @notice The VerifiableFactory used to verify registry deployments.
+    IVerifiableFactory public immutable VERIFIABLE_FACTORY;
+    /// @notice The approved UserRegistry implementation address.
+    address public immutable USER_REGISTRY_IMPL;
+    /// @notice The approved WrapperRegistry implementation address.
+    address public immutable WRAPPER_REGISTRY_IMPL;
+
+    ////////////////////////////////////////////////////////////////////////
+    // Initialization
+    ////////////////////////////////////////////////////////////////////////
 
     /// @param rootRegistry The root registry (trust anchor).
     /// @param ethRegistry The .eth TLD registry (trusted by endorsement).
@@ -86,7 +104,8 @@ contract RegistryHelper {
         IVerifiableFactory verifiableFactory,
         address userRegistryImpl,
         address wrapperRegistryImpl
-    ) {
+    )
+    {
         ROOT_REGISTRY = rootRegistry;
         ETH_REGISTRY = ethRegistry;
         VERIFIABLE_FACTORY = verifiableFactory;
@@ -95,7 +114,7 @@ contract RegistryHelper {
     }
 
     ////////////////////////////////////////////////////////////////////////
-    // Name-based lookups (accept DNS-encoded name)
+    // Implementation
     ////////////////////////////////////////////////////////////////////////
 
     /// @notice Find the owner of a name.
@@ -121,6 +140,7 @@ contract RegistryHelper {
 
     /// @notice Find the canonical registry for a name, or address(0) if not canonical.
     /// @param name DNS-encoded name.
+    /// @return The canonical registry or address(0).
     function findCanonicalRegistry(bytes calldata name) external view returns (IRegistry) {
         return LibRegistry.findCanonicalRegistry(ROOT_REGISTRY, name);
     }
@@ -128,40 +148,43 @@ contract RegistryHelper {
     /// @notice Check whether a name's registry chain is canonical (every parent pointer
     ///         is consistent with the subregistry pointer above it).
     /// @param name DNS-encoded name.
+    /// @return True if the name's registry chain is canonical.
     function isCanonical(bytes calldata name) external view returns (bool) {
         return address(LibRegistry.findCanonicalRegistry(ROOT_REGISTRY, name)) != address(0);
     }
 
     /// @notice Check whether every registry in a name's ancestry is trusted.
     /// @param name DNS-encoded name.
+    /// @return True if every registry in the chain is verified.
     function isVerified(bytes calldata name) external view returns (bool) {
         IRegistry[] memory registries = LibRegistry.findRegistries(ROOT_REGISTRY, name, 0);
         // Skip index 0 (leaf's own subregistry) and last (root, always trusted)
         for (uint256 i = 1; i + 1 < registries.length; i++) {
-            if (!isVerified(registries[i])) return false;
+            if (!isVerified(registries[i]))
+                return false;
         }
         return true;
     }
 
     /// @notice Check whether a name is emancipated: at every level of the hierarchy, the
-    ///         governing registry is trusted and no dangerous role has assignees on
-    ///         ROOT_RESOURCE.
-    ///         This only covers on-chain governance; DNS-imported names remain subject
-    ///         to off-chain reassertion via DNSSEC proofs regardless of on-chain state.
+    /// governing registry is trusted and no dangerous role has assignees on
+    /// ROOT_RESOURCE.
+    /// This only covers on-chain governance; DNS-imported names remain subject
+    /// to off-chain reassertion via DNSSEC proofs regardless of on-chain state.
+    ///
     /// @param name DNS-encoded name.
+    /// @return True if the name is emancipated.
     function isEmancipated(bytes calldata name) external view returns (bool) {
         IRegistry[] memory registries = LibRegistry.findRegistries(ROOT_REGISTRY, name, 0);
         // Skip index 0 (leaf's own subregistry) and last (root, always trusted)
         for (uint256 i = 1; i + 1 < registries.length; i++) {
-            if (!isVerified(registries[i])) return false;
-            if (!_isRegistryEmancipated(registries[i])) return false;
+            if (!isVerified(registries[i]))
+                return false;
+            if (!_isRegistryEmancipated(registries[i]))
+                return false;
         }
         return true;
     }
-
-    ////////////////////////////////////////////////////////////////////////
-    // Registry-based lookups
-    ////////////////////////////////////////////////////////////////////////
 
     /// @notice Reconstruct the canonical DNS-encoded name for a registry by walking parent pointers.
     /// @param registry The registry to name.
@@ -170,27 +193,13 @@ contract RegistryHelper {
         return LibRegistry.findCanonicalName(ROOT_REGISTRY, registry);
     }
 
-    /// @notice Check whether a registry is trusted: either an infrastructure registry
-    ///         (root or .eth) or deployed by the VerifiableFactory with an approved
-    ///         implementation (UserRegistry or WrapperRegistry).
-    /// @param registry The registry to check.
-    function isVerified(IRegistry registry) public view returns (bool) {
-        return registry == ROOT_REGISTRY ||
-            registry == ETH_REGISTRY ||
-            VERIFIABLE_FACTORY.verifyContract(address(registry), USER_REGISTRY_IMPL) ||
-            VERIFIABLE_FACTORY.verifyContract(address(registry), WRAPPER_REGISTRY_IMPL);
-    }
-
     /// @notice Check whether a registry is emancipated: verified and no dangerous role
     ///         has assignees on ROOT_RESOURCE.
     /// @param registry The registry to check.
+    /// @return True if the registry is emancipated.
     function isEmancipated(IRegistry registry) external view returns (bool) {
         return isVerified(registry) && _isRegistryEmancipated(registry);
     }
-
-    ////////////////////////////////////////////////////////////////////////
-    // Batch inspection
-    ////////////////////////////////////////////////////////////////////////
 
     /// @notice Get detailed info for every label in a name's hierarchy.
     ///         For "sub.alice.eth", returns info for ["sub", "alice", "eth"].
@@ -201,6 +210,7 @@ contract RegistryHelper {
         labels = new LabelInfo[](count);
 
         IRegistry[] memory registries = LibRegistry.findRegistries(ROOT_REGISTRY, name, 0);
+
         // registries has length count+1: [leaf_subreg, ..., eth_registry, root]
         // We iterate labels from leaf (offset 0) to the TLD
 
@@ -222,7 +232,9 @@ contract RegistryHelper {
             labels[i].resolver = parent.getResolver(label);
 
             // Expiry
-            if (ERC165Checker.supportsInterface(address(parent), type(ITemporalRegistry).interfaceId)) {
+            if (
+                ERC165Checker.supportsInterface(address(parent), type(ITemporalRegistry).interfaceId)
+            ) {
                 labels[i].expiry = ITemporalRegistry(address(parent)).findExpiry(label);
                 if (labels[i].expiry != 0) {
                     labels[i].flags |= FLAG_HAS_EXPIRY;
@@ -240,7 +252,10 @@ contract RegistryHelper {
             // Token ID (only populate if the token was actually minted)
             if (
                 labels[i].owner != address(0) &&
-                ERC165Checker.supportsInterface(address(parent), type(ITokenizedRegistry).interfaceId)
+                ERC165Checker.supportsInterface(
+                    address(parent),
+                    type(ITokenizedRegistry).interfaceId
+                )
             ) {
                 labels[i].tokenId = ITokenizedRegistry(address(parent)).findTokenId(label);
                 labels[i].flags |= FLAG_HAS_TOKEN;
@@ -274,19 +289,38 @@ contract RegistryHelper {
         }
     }
 
+    /// @notice Check whether a registry is trusted: either an infrastructure registry
+    ///         (root or .eth) or deployed by the VerifiableFactory with an approved
+    ///         implementation (UserRegistry or WrapperRegistry).
+    /// @param registry The registry to check.
+    /// @return True if the registry is verified.
+    function isVerified(IRegistry registry) public view returns (bool) {
+        return
+            registry == ROOT_REGISTRY ||
+            registry == ETH_REGISTRY ||
+            VERIFIABLE_FACTORY.verifyContract(address(registry), USER_REGISTRY_IMPL) ||
+            VERIFIABLE_FACTORY.verifyContract(address(registry), WRAPPER_REGISTRY_IMPL);
+    }
+
     ////////////////////////////////////////////////////////////////////////
-    // Internal
+    // Internal Functions
     ////////////////////////////////////////////////////////////////////////
 
     /// @dev Check whether a registry is emancipated: no account holds any dangerous
-    ///      role on ROOT_RESOURCE. Per-token roles (SET_RESOLVER, SET_SUBREGISTRY,
-    ///      UNREGISTER and their admins, plus CAN_TRANSFER_ADMIN) can be exercised on
-    ///      any token via the hasRoles ROOT union. Registry-wide roles (UPGRADE,
-    ///      UPGRADE_ADMIN) can replace the entire implementation, bypassing all
-    ///      access control.
+    /// role on ROOT_RESOURCE. Per-token roles (SET_RESOLVER, SET_SUBREGISTRY,
+    /// UNREGISTER and their admins, plus CAN_TRANSFER_ADMIN) can be exercised on
+    /// any token via the hasRoles ROOT union. Registry-wide roles (UPGRADE,
+    /// UPGRADE_ADMIN) can replace the entire implementation, bypassing all
+    /// access control.
+    ///
     /// @param registry The registry to check.
     function _isRegistryEmancipated(IRegistry registry) internal view returns (bool) {
-        if (!ERC165Checker.supportsInterface(address(registry), type(IEnhancedAccessControl).interfaceId)) {
+        if (
+            !ERC165Checker.supportsInterface(
+                address(registry),
+                type(IEnhancedAccessControl).interfaceId
+            )
+        ) {
             return false;
         }
         IEnhancedAccessControl eac = IEnhancedAccessControl(address(registry));

--- a/contracts/src/utils/RegistryHelper.sol
+++ b/contracts/src/utils/RegistryHelper.sol
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
+import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
+
+import {IEnhancedAccessControl} from "../access-control/interfaces/IEnhancedAccessControl.sol";
+import {LibRegistry} from "../universalResolver/libraries/LibRegistry.sol";
+
+import {IRegistry} from "../registry/interfaces/IRegistry.sol";
+import {IOwnedRegistry} from "../registry/interfaces/IOwnedRegistry.sol";
+import {ITemporalRegistry} from "../registry/interfaces/ITemporalRegistry.sol";
+import {ITokenizedRegistry} from "../registry/interfaces/ITokenizedRegistry.sol";
+import {RegistryRolesLib} from "../registry/libraries/RegistryRolesLib.sol";
+
+/// @notice Immutable read-only convenience contract that provides functions to inspect
+///         name state, ownership, verification, and emancipation status across the
+///         ENSv2 registry hierarchy.
+contract RegistryHelper {
+    uint256 private constant ROOT_RESOURCE = 0;
+
+    IRegistry public immutable ROOT_REGISTRY;
+    IRegistry public immutable ETH_REGISTRY;
+    IVerifiableFactory public immutable VERIFIABLE_FACTORY;
+    address public immutable USER_REGISTRY_IMPL;
+    address public immutable WRAPPER_REGISTRY_IMPL;
+
+    /// @dev Roles whose presence on ROOT_RESOURCE endangers name owners.
+    ///      Two categories:
+    ///      - Per-token roles (SET_RESOLVER, SET_SUBREGISTRY, UNREGISTER and their admins,
+    ///        plus CAN_TRANSFER_ADMIN): exercisable on any token via the hasRoles ROOT union.
+    ///      - Registry-wide roles (UPGRADE, UPGRADE_ADMIN): can replace the entire
+    ///        implementation via UUPS proxy, bypassing all access control.
+    ///      ROLE_RENEW and ROLE_RENEW_ADMIN are excluded: RENEW can only extend expiry
+    ///      (CannotReduceExpiry), and its admin can only grant/revoke that harmless capability.
+    uint256 public constant DANGEROUS_ROOT_ROLES =
+        RegistryRolesLib.ROLE_SET_RESOLVER |
+        RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
+        RegistryRolesLib.ROLE_SET_SUBREGISTRY |
+        RegistryRolesLib.ROLE_SET_SUBREGISTRY_ADMIN |
+        RegistryRolesLib.ROLE_UNREGISTER |
+        RegistryRolesLib.ROLE_UNREGISTER_ADMIN |
+        RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
+        RegistryRolesLib.ROLE_UPGRADE |
+        RegistryRolesLib.ROLE_UPGRADE_ADMIN;
+
+    /// @notice Set when the name has a minted ERC-1155 token (parent supports ITokenizedRegistry and name has an owner).
+    uint8 public constant FLAG_HAS_TOKEN = 1 << 0;
+    /// @notice Set when the parent registry supports IOwnedRegistry and returns a nonzero owner.
+    uint8 public constant FLAG_HAS_OWNER = 1 << 1;
+    /// @notice Set when the parent registry supports ITemporalRegistry and returns a nonzero expiry.
+    uint8 public constant FLAG_HAS_EXPIRY = 1 << 2;
+    /// @notice Set when the governing parent registry is trusted (root, eth, or factory-deployed with an approved implementation).
+    uint8 public constant FLAG_IS_VERIFIED = 1 << 3;
+    /// @notice Set when the parent's subregistry pointer and the child's parent pointer are bidirectionally consistent.
+    uint8 public constant FLAG_IS_CANONICAL = 1 << 4;
+    /// @notice Set when the governing parent registry has no dangerous roles on ROOT_RESOURCE.
+    uint8 public constant FLAG_IS_EMANCIPATED = 1 << 5;
+
+    struct LabelInfo {
+        /// @dev The label's own subregistry, or address(0) if none.
+        IRegistry registry;
+        /// @dev Resolver set on the governing parent registry for this label.
+        address resolver;
+        /// @dev Owner of this label, or address(0) if unowned.
+        address owner;
+        /// @dev The label string (e.g. "alice" for alice.eth).
+        string label;
+        /// @dev Token ID from ITokenizedRegistry, or 0 if not minted.
+        uint256 tokenId;
+        /// @dev Expiry timestamp in seconds, or 0 if no expiry.
+        uint64 expiry;
+        /// @dev Bitfield of FLAG_* constants describing the name's state.
+        uint8 flags;
+    }
+
+    /// @param rootRegistry The root registry (trust anchor).
+    /// @param ethRegistry The .eth TLD registry (trusted by endorsement).
+    /// @param verifiableFactory The VerifiableFactory used to verify registry deployments.
+    /// @param userRegistryImpl The approved UserRegistry implementation address.
+    /// @param wrapperRegistryImpl The approved WrapperRegistry implementation address.
+    constructor(
+        IRegistry rootRegistry,
+        IRegistry ethRegistry,
+        IVerifiableFactory verifiableFactory,
+        address userRegistryImpl,
+        address wrapperRegistryImpl
+    ) {
+        ROOT_REGISTRY = rootRegistry;
+        ETH_REGISTRY = ethRegistry;
+        VERIFIABLE_FACTORY = verifiableFactory;
+        USER_REGISTRY_IMPL = userRegistryImpl;
+        WRAPPER_REGISTRY_IMPL = wrapperRegistryImpl;
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Name-based lookups (accept DNS-encoded name)
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Find the owner of a name.
+    /// @param name DNS-encoded name.
+    /// @return owner The owner address, or address(0) if unowned or parent doesn't support IOwnedRegistry.
+    function findOwner(bytes calldata name) external view returns (address owner) {
+        return LibRegistry.findOwner(ROOT_REGISTRY, name, 0);
+    }
+
+    /// @notice Find the expiry of the leaf label in its immediate parent registry.
+    /// @param name DNS-encoded name.
+    /// @return expiry The expiry timestamp, or 0 if parent doesn't support ITemporalRegistry.
+    function findExpiry(bytes calldata name) external view returns (uint64 expiry) {
+        IRegistry parent = LibRegistry.findParentRegistry(ROOT_REGISTRY, name, 0);
+        if (
+            address(parent) != address(0) &&
+            ERC165Checker.supportsInterface(address(parent), type(ITemporalRegistry).interfaceId)
+        ) {
+            (string memory label, ) = NameCoder.extractLabel(name, 0);
+            expiry = ITemporalRegistry(address(parent)).findExpiry(label);
+        }
+    }
+
+    /// @notice Find the canonical registry for a name, or address(0) if not canonical.
+    /// @param name DNS-encoded name.
+    function findCanonicalRegistry(bytes calldata name) external view returns (IRegistry) {
+        return LibRegistry.findCanonicalRegistry(ROOT_REGISTRY, name);
+    }
+
+    /// @notice Check whether a name's registry chain is canonical (every parent pointer
+    ///         is consistent with the subregistry pointer above it).
+    /// @param name DNS-encoded name.
+    function isCanonical(bytes calldata name) external view returns (bool) {
+        return address(LibRegistry.findCanonicalRegistry(ROOT_REGISTRY, name)) != address(0);
+    }
+
+    /// @notice Check whether every registry in a name's ancestry is trusted.
+    /// @param name DNS-encoded name.
+    function isVerified(bytes calldata name) external view returns (bool) {
+        IRegistry[] memory registries = LibRegistry.findRegistries(ROOT_REGISTRY, name, 0);
+        // Skip index 0 (leaf's own subregistry) and last (root, always trusted)
+        for (uint256 i = 1; i + 1 < registries.length; i++) {
+            if (!isVerified(registries[i])) return false;
+        }
+        return true;
+    }
+
+    /// @notice Check whether a name is emancipated: at every level of the hierarchy, the
+    ///         governing registry is trusted and no dangerous role has assignees on
+    ///         ROOT_RESOURCE.
+    ///         This only covers on-chain governance; DNS-imported names remain subject
+    ///         to off-chain reassertion via DNSSEC proofs regardless of on-chain state.
+    /// @param name DNS-encoded name.
+    function isEmancipated(bytes calldata name) external view returns (bool) {
+        IRegistry[] memory registries = LibRegistry.findRegistries(ROOT_REGISTRY, name, 0);
+        // Skip index 0 (leaf's own subregistry) and last (root, always trusted)
+        for (uint256 i = 1; i + 1 < registries.length; i++) {
+            if (!isVerified(registries[i])) return false;
+            if (!_isRegistryEmancipated(registries[i])) return false;
+        }
+        return true;
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Registry-based lookups
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Reconstruct the canonical DNS-encoded name for a registry by walking parent pointers.
+    /// @param registry The registry to name.
+    /// @return name The DNS-encoded canonical name, or empty bytes if not canonical.
+    function findCanonicalName(IRegistry registry) external view returns (bytes memory name) {
+        return LibRegistry.findCanonicalName(ROOT_REGISTRY, registry);
+    }
+
+    /// @notice Check whether a registry is trusted: either an infrastructure registry
+    ///         (root or .eth) or deployed by the VerifiableFactory with an approved
+    ///         implementation (UserRegistry or WrapperRegistry).
+    /// @param registry The registry to check.
+    function isVerified(IRegistry registry) public view returns (bool) {
+        return registry == ROOT_REGISTRY ||
+            registry == ETH_REGISTRY ||
+            VERIFIABLE_FACTORY.verifyContract(address(registry), USER_REGISTRY_IMPL) ||
+            VERIFIABLE_FACTORY.verifyContract(address(registry), WRAPPER_REGISTRY_IMPL);
+    }
+
+    /// @notice Check whether a registry is emancipated: verified and no dangerous role
+    ///         has assignees on ROOT_RESOURCE.
+    /// @param registry The registry to check.
+    function isEmancipated(IRegistry registry) external view returns (bool) {
+        return isVerified(registry) && _isRegistryEmancipated(registry);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Batch inspection
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Get detailed info for every label in a name's hierarchy.
+    ///         For "sub.alice.eth", returns info for ["sub", "alice", "eth"].
+    /// @param name DNS-encoded name.
+    /// @return labels Array of LabelInfo structs, one per label, ordered leaf-first.
+    function getLabels(bytes calldata name) external view returns (LabelInfo[] memory labels) {
+        uint256 count = NameCoder.countLabels(name, 0);
+        labels = new LabelInfo[](count);
+
+        IRegistry[] memory registries = LibRegistry.findRegistries(ROOT_REGISTRY, name, 0);
+        // registries has length count+1: [leaf_subreg, ..., eth_registry, root]
+        // We iterate labels from leaf (offset 0) to the TLD
+
+        uint256 offset = 0;
+        for (uint256 i = 0; i < count; i++) {
+            (string memory label, uint256 nextOffset) = NameCoder.extractLabel(name, offset);
+            // The parent registry for label at index i is registries[i+1]
+            // (registries[count] = root, registries[0] = leaf's own subregistry)
+            IRegistry parent = registries[i + 1];
+
+            labels[i].label = label;
+            labels[i].registry = registries[i]; // the name's own subregistry
+
+            if (address(parent) == address(0)) {
+                offset = nextOffset;
+                continue;
+            }
+
+            labels[i].resolver = parent.getResolver(label);
+
+            // Expiry
+            if (ERC165Checker.supportsInterface(address(parent), type(ITemporalRegistry).interfaceId)) {
+                labels[i].expiry = ITemporalRegistry(address(parent)).findExpiry(label);
+                if (labels[i].expiry != 0) {
+                    labels[i].flags |= FLAG_HAS_EXPIRY;
+                }
+            }
+
+            // Owner
+            if (ERC165Checker.supportsInterface(address(parent), type(IOwnedRegistry).interfaceId)) {
+                labels[i].owner = IOwnedRegistry(address(parent)).findOwner(label);
+                if (labels[i].owner != address(0)) {
+                    labels[i].flags |= FLAG_HAS_OWNER;
+                }
+            }
+
+            // Token ID (only populate if the token was actually minted)
+            if (
+                labels[i].owner != address(0) &&
+                ERC165Checker.supportsInterface(address(parent), type(ITokenizedRegistry).interfaceId)
+            ) {
+                labels[i].tokenId = ITokenizedRegistry(address(parent)).findTokenId(label);
+                labels[i].flags |= FLAG_HAS_TOKEN;
+            }
+
+            bool parentVerified = isVerified(parent);
+
+            // Verified
+            if (parentVerified) {
+                labels[i].flags |= FLAG_IS_VERIFIED;
+            }
+
+            // Canonical: bidirectional link check
+            if (address(registries[i]) != address(0)) {
+                (IRegistry childParent, string memory childLabel) = registries[i].getParent();
+                if (
+                    address(parent.getSubregistry(label)) == address(registries[i]) &&
+                    address(childParent) == address(parent) &&
+                    keccak256(bytes(childLabel)) == keccak256(bytes(label))
+                ) {
+                    labels[i].flags |= FLAG_IS_CANONICAL;
+                }
+            }
+
+            // Emancipated: parent must be verified and no dangerous roles on ROOT_RESOURCE
+            if (parentVerified && _isRegistryEmancipated(parent)) {
+                labels[i].flags |= FLAG_IS_EMANCIPATED;
+            }
+
+            offset = nextOffset;
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Internal
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Check whether a registry is emancipated: no account holds any dangerous
+    ///      role on ROOT_RESOURCE. Per-token roles (SET_RESOLVER, SET_SUBREGISTRY,
+    ///      UNREGISTER and their admins, plus CAN_TRANSFER_ADMIN) can be exercised on
+    ///      any token via the hasRoles ROOT union. Registry-wide roles (UPGRADE,
+    ///      UPGRADE_ADMIN) can replace the entire implementation, bypassing all
+    ///      access control.
+    /// @param registry The registry to check.
+    function _isRegistryEmancipated(IRegistry registry) internal view returns (bool) {
+        if (!ERC165Checker.supportsInterface(address(registry), type(IEnhancedAccessControl).interfaceId)) {
+            return false;
+        }
+        IEnhancedAccessControl eac = IEnhancedAccessControl(address(registry));
+        return !eac.hasAssignees(ROOT_RESOURCE, DANGEROUS_ROOT_ROLES);
+    }
+}

--- a/contracts/test/unit/utils/RegistryHelper.t.sol
+++ b/contracts/test/unit/utils/RegistryHelper.t.sol
@@ -10,7 +10,6 @@ import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
 import {RegistryHelper} from "~src/utils/RegistryHelper.sol";
 import {UserRegistry} from "~src/registry/UserRegistry.sol";
-
 import {V2Fixture} from "~test/fixtures/V2Fixture.sol";
 
 contract RegistryHelperTest is V2Fixture {
@@ -110,8 +109,12 @@ contract RegistryHelperTest is V2Fixture {
 
         vm.prank(alice);
         aliceRegistry.register(
-            "sub", bob, IRegistry(address(0)), address(0),
-            REGISTRATION_ROLES, uint64(block.timestamp + 365 days)
+            "sub",
+            bob,
+            IRegistry(address(0)),
+            address(0),
+            REGISTRATION_ROLES,
+            uint64(block.timestamp + 365 days)
         );
 
         // alice's UserRegistry was deployed via VerifiableFactory
@@ -140,8 +143,12 @@ contract RegistryHelperTest is V2Fixture {
 
         vm.prank(alice);
         aliceRegistry.register(
-            "sub", bob, IRegistry(address(0)), address(0),
-            REGISTRATION_ROLES, uint64(block.timestamp + 365 days)
+            "sub",
+            bob,
+            IRegistry(address(0)),
+            address(0),
+            REGISTRATION_ROLES,
+            uint64(block.timestamp + 365 days)
         );
 
         // sub.alice.eth is NOT emancipated because alice's registry has dangerous roles
@@ -155,8 +162,12 @@ contract RegistryHelperTest is V2Fixture {
 
         vm.prank(alice);
         aliceRegistry.register(
-            "sub", bob, IRegistry(address(0)), address(0),
-            REGISTRATION_ROLES, uint64(block.timestamp + 365 days)
+            "sub",
+            bob,
+            IRegistry(address(0)),
+            address(0),
+            REGISTRATION_ROLES,
+            uint64(block.timestamp + 365 days)
         );
 
         assertFalse(helper.isEmancipated(NameCoder.encode("sub.alice.eth")));
@@ -227,8 +238,7 @@ contract RegistryHelperTest is V2Fixture {
     function test_getLabels_aliceEth() external {
         _registerOnEth("alice", alice);
 
-        RegistryHelper.LabelInfo[] memory labels =
-            helper.getLabels(NameCoder.encode("alice.eth"));
+        RegistryHelper.LabelInfo[] memory labels = helper.getLabels(NameCoder.encode("alice.eth"));
 
         assertEq(labels.length, 2);
 
@@ -252,8 +262,12 @@ contract RegistryHelperTest is V2Fixture {
 
         vm.prank(alice);
         aliceRegistry.register(
-            "sub", bob, IRegistry(address(0)), address(0),
-            REGISTRATION_ROLES, uint64(block.timestamp + 365 days)
+            "sub",
+            bob,
+            IRegistry(address(0)),
+            address(0),
+            REGISTRATION_ROLES,
+            uint64(block.timestamp + 365 days)
         );
 
         RegistryHelper.LabelInfo[] memory labels =
@@ -278,8 +292,7 @@ contract RegistryHelperTest is V2Fixture {
 
         vm.warp(block.timestamp + 366 days);
 
-        RegistryHelper.LabelInfo[] memory labels =
-            helper.getLabels(NameCoder.encode("alice.eth"));
+        RegistryHelper.LabelInfo[] memory labels = helper.getLabels(NameCoder.encode("alice.eth"));
 
         assertEq(labels[0].owner, address(0));
         assertFalse(labels[0].flags & helper.FLAG_HAS_OWNER() != 0, "expired:FLAG_HAS_OWNER");
@@ -290,8 +303,7 @@ contract RegistryHelperTest is V2Fixture {
     }
 
     function test_getLabels_unregisteredName_noToken() external view {
-        RegistryHelper.LabelInfo[] memory labels =
-            helper.getLabels(NameCoder.encode("nobody.eth"));
+        RegistryHelper.LabelInfo[] memory labels = helper.getLabels(NameCoder.encode("nobody.eth"));
 
         assertEq(labels[0].owner, address(0));
         assertFalse(labels[0].flags & helper.FLAG_HAS_OWNER() != 0, "unregistered:FLAG_HAS_OWNER");
@@ -302,8 +314,7 @@ contract RegistryHelperTest is V2Fixture {
     function test_getLabels_registeredName_hasToken() external {
         _registerOnEth("alice", alice);
 
-        RegistryHelper.LabelInfo[] memory labels =
-            helper.getLabels(NameCoder.encode("alice.eth"));
+        RegistryHelper.LabelInfo[] memory labels = helper.getLabels(NameCoder.encode("alice.eth"));
 
         assertTrue(labels[0].flags & helper.FLAG_HAS_OWNER() != 0, "registered:FLAG_HAS_OWNER");
         assertTrue(labels[0].flags & helper.FLAG_HAS_TOKEN() != 0, "registered:FLAG_HAS_TOKEN");
@@ -317,8 +328,12 @@ contract RegistryHelperTest is V2Fixture {
 
         vm.prank(alice);
         aliceRegistry.register(
-            "sub", bob, IRegistry(address(0)), resolver1,
-            REGISTRATION_ROLES, uint64(block.timestamp + 180 days)
+            "sub",
+            bob,
+            IRegistry(address(0)),
+            resolver1,
+            REGISTRATION_ROLES,
+            uint64(block.timestamp + 180 days)
         );
 
         RegistryHelper.LabelInfo[] memory labels =
@@ -342,8 +357,7 @@ contract RegistryHelperTest is V2Fixture {
         // Deploy subregistry but never call setParent
         UserRegistry aliceRegistry = _registerWithSubregistry("alice", alice);
 
-        RegistryHelper.LabelInfo[] memory labels =
-            helper.getLabels(NameCoder.encode("alice.eth"));
+        RegistryHelper.LabelInfo[] memory labels = helper.getLabels(NameCoder.encode("alice.eth"));
 
         // Forward link exists (ethRegistry.getSubregistry("alice") == aliceRegistry)
         // but reverse link is missing (aliceRegistry.getParent() == (address(0), ""))
@@ -360,8 +374,7 @@ contract RegistryHelperTest is V2Fixture {
         vm.prank(alice);
         aliceRegistry.setParent(ethRegistry, "bob");
 
-        RegistryHelper.LabelInfo[] memory labels =
-            helper.getLabels(NameCoder.encode("alice.eth"));
+        RegistryHelper.LabelInfo[] memory labels = helper.getLabels(NameCoder.encode("alice.eth"));
 
         assertFalse(
             labels[0].flags & helper.FLAG_IS_CANONICAL() != 0,
@@ -375,8 +388,7 @@ contract RegistryHelperTest is V2Fixture {
         vm.prank(alice);
         aliceRegistry.setParent(rootRegistry, "alice");
 
-        RegistryHelper.LabelInfo[] memory labels =
-            helper.getLabels(NameCoder.encode("alice.eth"));
+        RegistryHelper.LabelInfo[] memory labels = helper.getLabels(NameCoder.encode("alice.eth"));
 
         assertFalse(
             labels[0].flags & helper.FLAG_IS_CANONICAL() != 0,
@@ -482,7 +494,11 @@ contract RegistryHelperTest is V2Fixture {
         internal
         returns (UserRegistry registry)
     {
-        registry = deployUserRegistry(owner, EACBaseRolesLib.ALL_ROLES, uint256(keccak256(bytes(label))));
+        registry = deployUserRegistry(
+            owner,
+            EACBaseRolesLib.ALL_ROLES,
+            uint256(keccak256(bytes(label)))
+        );
 
         ethRegistry.register(
             label,

--- a/contracts/test/unit/utils/RegistryHelper.t.sol
+++ b/contracts/test/unit/utils/RegistryHelper.t.sol
@@ -3,8 +3,6 @@ pragma solidity >=0.8.13;
 
 // solhint-disable no-console, private-vars-leading-underscore, state-visibility, func-name-mixedcase, contracts-v2/ordering, one-contract-per-file
 
-import {Test} from "forge-std/Test.sol";
-
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 
 import {EACBaseRolesLib} from "~src/access-control/EnhancedAccessControl.sol";

--- a/contracts/test/unit/utils/RegistryHelper.t.sol
+++ b/contracts/test/unit/utils/RegistryHelper.t.sol
@@ -1,0 +1,498 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+// solhint-disable no-console, private-vars-leading-underscore, state-visibility, func-name-mixedcase, contracts-v2/ordering, one-contract-per-file
+
+import {Test} from "forge-std/Test.sol";
+
+import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
+
+import {EACBaseRolesLib} from "~src/access-control/EnhancedAccessControl.sol";
+import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
+import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
+import {RegistryHelper} from "~src/utils/RegistryHelper.sol";
+import {UserRegistry} from "~src/registry/UserRegistry.sol";
+
+import {V2Fixture} from "~test/fixtures/V2Fixture.sol";
+
+contract RegistryHelperTest is V2Fixture {
+    RegistryHelper helper;
+
+    address alice = makeAddr("alice");
+    address bob = makeAddr("bob");
+    address resolver1 = makeAddr("resolver1");
+
+    uint256 constant REGISTRATION_ROLES =
+        RegistryRolesLib.ROLE_SET_SUBREGISTRY |
+        RegistryRolesLib.ROLE_SET_SUBREGISTRY_ADMIN |
+        RegistryRolesLib.ROLE_SET_RESOLVER |
+        RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
+        RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
+
+    function setUp() external {
+        deployV2Fixture();
+        helper = new RegistryHelper(
+            rootRegistry,
+            ethRegistry,
+            verifiableFactory,
+            address(userRegistryImpl),
+            address(0) // no WrapperRegistry impl for now
+        );
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // findOwner
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_findOwner_eth() external view {
+        assertEq(helper.findOwner(NameCoder.encode("eth")), address(this));
+    }
+
+    function test_findOwner_registered() external {
+        _registerOnEth("alice", alice);
+        assertEq(helper.findOwner(NameCoder.encode("alice.eth")), alice);
+    }
+
+    function test_findOwner_unregistered() external view {
+        assertEq(helper.findOwner(NameCoder.encode("nobody.eth")), address(0));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // findExpiry
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_findExpiry_registered() external {
+        _registerOnEth("alice", alice);
+        uint64 expiry = helper.findExpiry(NameCoder.encode("alice.eth"));
+        assertEq(expiry, uint64(block.timestamp + 365 days));
+    }
+
+    function test_findExpiry_unregistered() external view {
+        assertEq(helper.findExpiry(NameCoder.encode("nobody.eth")), 0);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // isCanonical
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_isCanonical_eth() external view {
+        assertTrue(helper.isCanonical(NameCoder.encode("eth")));
+    }
+
+    function test_isCanonical_withSubregistry() external {
+        UserRegistry aliceRegistry = _registerWithSubregistry("alice", alice);
+        vm.prank(alice);
+        aliceRegistry.setParent(ethRegistry, "alice");
+        assertTrue(helper.isCanonical(NameCoder.encode("alice.eth")));
+    }
+
+    function test_isCanonical_noSubregistry() external {
+        _registerOnEth("alice", alice);
+        assertFalse(helper.isCanonical(NameCoder.encode("alice.eth")));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // isVerified (name-based)
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_isVerified_eth() external view {
+        assertTrue(helper.isVerified(NameCoder.encode("eth")));
+    }
+
+    function test_isVerified_aliceEth() external {
+        _registerOnEth("alice", alice);
+        // eth registry is trusted by endorsement (direct child of root)
+        assertTrue(helper.isVerified(NameCoder.encode("alice.eth")));
+    }
+
+    function test_isVerified_threeLevel_factoryDeployed() external {
+        UserRegistry aliceRegistry = _registerWithSubregistry("alice", alice);
+        vm.prank(alice);
+        aliceRegistry.setParent(ethRegistry, "alice");
+
+        vm.prank(alice);
+        aliceRegistry.register(
+            "sub", bob, IRegistry(address(0)), address(0),
+            REGISTRATION_ROLES, uint64(block.timestamp + 365 days)
+        );
+
+        // alice's UserRegistry was deployed via VerifiableFactory
+        assertTrue(helper.isVerified(NameCoder.encode("sub.alice.eth")));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // isEmancipated (name-based)
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_isEmancipated_eth() external view {
+        assertTrue(helper.isEmancipated(NameCoder.encode("eth")));
+    }
+
+    function test_isEmancipated_aliceEth() external {
+        _registerOnEth("alice", alice);
+        // eth registry has no dangerous roles on ROOT_RESOURCE
+        assertTrue(helper.isEmancipated(NameCoder.encode("alice.eth")));
+    }
+
+    function test_isEmancipated_failsWithDangerousRoles() external {
+        // alice's UserRegistry has ALL_ROLES for alice on ROOT, including dangerous roles
+        UserRegistry aliceRegistry = _registerWithSubregistry("alice", alice);
+        vm.prank(alice);
+        aliceRegistry.setParent(ethRegistry, "alice");
+
+        vm.prank(alice);
+        aliceRegistry.register(
+            "sub", bob, IRegistry(address(0)), address(0),
+            REGISTRATION_ROLES, uint64(block.timestamp + 365 days)
+        );
+
+        // sub.alice.eth is NOT emancipated because alice's registry has dangerous roles
+        assertFalse(helper.isEmancipated(NameCoder.encode("sub.alice.eth")));
+    }
+
+    function test_isEmancipated_afterRevokingDangerousRoles() external {
+        UserRegistry aliceRegistry = _registerWithSubregistry("alice", alice);
+        vm.prank(alice);
+        aliceRegistry.setParent(ethRegistry, "alice");
+
+        vm.prank(alice);
+        aliceRegistry.register(
+            "sub", bob, IRegistry(address(0)), address(0),
+            REGISTRATION_ROLES, uint64(block.timestamp + 365 days)
+        );
+
+        assertFalse(helper.isEmancipated(NameCoder.encode("sub.alice.eth")));
+
+        // Revoke all dangerous roles from alice's registry
+        uint256 dangerousRoles = helper.DANGEROUS_ROOT_ROLES();
+        vm.prank(alice);
+        aliceRegistry.revokeRootRoles(dangerousRoles, alice);
+
+        assertTrue(helper.isEmancipated(NameCoder.encode("sub.alice.eth")));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // isVerified / isEmancipated (registry-based)
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_isVerified_registry_factoryDeployed() external {
+        UserRegistry aliceRegistry = deployUserRegistry(alice, EACBaseRolesLib.ALL_ROLES, 1);
+        assertTrue(helper.isVerified(IRegistry(address(aliceRegistry))));
+    }
+
+    function test_isVerified_registry_ethRegistry() external view {
+        // ethRegistry is not factory-deployed but trusted as infrastructure
+        assertTrue(helper.isVerified(IRegistry(address(ethRegistry))));
+    }
+
+    function test_isVerified_registry_rootRegistry() external view {
+        assertTrue(helper.isVerified(IRegistry(address(rootRegistry))));
+    }
+
+    function test_isVerified_registry_untrusted() external view {
+        assertFalse(helper.isVerified(IRegistry(address(0xdead))));
+    }
+
+    function test_isEmancipated_registry_withDangerousRoles() external {
+        UserRegistry aliceRegistry = deployUserRegistry(alice, EACBaseRolesLib.ALL_ROLES, 2);
+        assertFalse(helper.isEmancipated(IRegistry(address(aliceRegistry))));
+    }
+
+    function test_isEmancipated_registry_afterRevoke() external {
+        UserRegistry aliceRegistry = deployUserRegistry(alice, EACBaseRolesLib.ALL_ROLES, 3);
+
+        uint256 dangerousRoles = helper.DANGEROUS_ROOT_ROLES();
+        vm.prank(alice);
+        aliceRegistry.revokeRootRoles(dangerousRoles, alice);
+
+        assertTrue(helper.isEmancipated(IRegistry(address(aliceRegistry))));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // getLabels
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_getLabels_eth() external view {
+        RegistryHelper.LabelInfo[] memory labels = helper.getLabels(NameCoder.encode("eth"));
+
+        assertEq(labels.length, 1);
+        assertEq(labels[0].label, "eth");
+        assertEq(address(labels[0].registry), address(ethRegistry));
+        assertEq(labels[0].owner, address(this));
+        assertTrue(labels[0].flags & helper.FLAG_HAS_OWNER() != 0, "FLAG_HAS_OWNER");
+        assertTrue(labels[0].flags & helper.FLAG_HAS_EXPIRY() != 0, "FLAG_HAS_EXPIRY");
+        assertTrue(labels[0].flags & helper.FLAG_IS_VERIFIED() != 0, "FLAG_IS_VERIFIED");
+        assertTrue(labels[0].flags & helper.FLAG_IS_CANONICAL() != 0, "FLAG_IS_CANONICAL");
+        assertTrue(labels[0].flags & helper.FLAG_IS_EMANCIPATED() != 0, "FLAG_IS_EMANCIPATED");
+    }
+
+    function test_getLabels_aliceEth() external {
+        _registerOnEth("alice", alice);
+
+        RegistryHelper.LabelInfo[] memory labels =
+            helper.getLabels(NameCoder.encode("alice.eth"));
+
+        assertEq(labels.length, 2);
+
+        // labels[0] = "alice" (leaf)
+        assertEq(labels[0].label, "alice");
+        assertEq(labels[0].owner, alice);
+        assertTrue(labels[0].flags & helper.FLAG_HAS_OWNER() != 0, "alice:FLAG_HAS_OWNER");
+        assertTrue(labels[0].flags & helper.FLAG_IS_VERIFIED() != 0, "alice:FLAG_IS_VERIFIED");
+        assertTrue(labels[0].flags & helper.FLAG_IS_EMANCIPATED() != 0, "alice:FLAG_IS_EMANCIPATED");
+
+        // labels[1] = "eth"
+        assertEq(labels[1].label, "eth");
+        assertTrue(labels[1].flags & helper.FLAG_IS_VERIFIED() != 0, "eth:FLAG_IS_VERIFIED");
+        assertTrue(labels[1].flags & helper.FLAG_IS_EMANCIPATED() != 0, "eth:FLAG_IS_EMANCIPATED");
+    }
+
+    function test_getLabels_dangerousRoles_affectsEmancipation() external {
+        UserRegistry aliceRegistry = _registerWithSubregistry("alice", alice);
+        vm.prank(alice);
+        aliceRegistry.setParent(ethRegistry, "alice");
+
+        vm.prank(alice);
+        aliceRegistry.register(
+            "sub", bob, IRegistry(address(0)), address(0),
+            REGISTRATION_ROLES, uint64(block.timestamp + 365 days)
+        );
+
+        RegistryHelper.LabelInfo[] memory labels =
+            helper.getLabels(NameCoder.encode("sub.alice.eth"));
+
+        // sub's parent (alice's registry) has dangerous roles on ROOT_RESOURCE
+        assertTrue(labels[0].flags & helper.FLAG_IS_VERIFIED() != 0, "sub:FLAG_IS_VERIFIED");
+        assertFalse(
+            labels[0].flags & helper.FLAG_IS_EMANCIPATED() != 0,
+            "sub:FLAG_IS_EMANCIPATED should be false"
+        );
+
+        // alice's parent (ethRegistry) has no dangerous roles
+        assertTrue(labels[1].flags & helper.FLAG_IS_EMANCIPATED() != 0, "alice:FLAG_IS_EMANCIPATED");
+
+        // eth is governed by root (trusted unconditionally)
+        assertTrue(labels[2].flags & helper.FLAG_IS_EMANCIPATED() != 0, "eth:FLAG_IS_EMANCIPATED");
+    }
+
+    function test_getLabels_expiredName() external {
+        _registerOnEth("alice", alice);
+
+        vm.warp(block.timestamp + 366 days);
+
+        RegistryHelper.LabelInfo[] memory labels =
+            helper.getLabels(NameCoder.encode("alice.eth"));
+
+        assertEq(labels[0].owner, address(0));
+        assertFalse(labels[0].flags & helper.FLAG_HAS_OWNER() != 0, "expired:FLAG_HAS_OWNER");
+        assertFalse(labels[0].flags & helper.FLAG_HAS_TOKEN() != 0, "expired:FLAG_HAS_TOKEN");
+        assertEq(labels[0].tokenId, 0, "expired:tokenId should be zero");
+        assertTrue(labels[0].expiry != 0, "expired:expiry nonzero");
+        assertTrue(labels[0].flags & helper.FLAG_HAS_EXPIRY() != 0, "expired:FLAG_HAS_EXPIRY");
+    }
+
+    function test_getLabels_unregisteredName_noToken() external view {
+        RegistryHelper.LabelInfo[] memory labels =
+            helper.getLabels(NameCoder.encode("nobody.eth"));
+
+        assertEq(labels[0].owner, address(0));
+        assertFalse(labels[0].flags & helper.FLAG_HAS_OWNER() != 0, "unregistered:FLAG_HAS_OWNER");
+        assertFalse(labels[0].flags & helper.FLAG_HAS_TOKEN() != 0, "unregistered:FLAG_HAS_TOKEN");
+        assertEq(labels[0].tokenId, 0, "unregistered:tokenId should be zero");
+    }
+
+    function test_getLabels_registeredName_hasToken() external {
+        _registerOnEth("alice", alice);
+
+        RegistryHelper.LabelInfo[] memory labels =
+            helper.getLabels(NameCoder.encode("alice.eth"));
+
+        assertTrue(labels[0].flags & helper.FLAG_HAS_OWNER() != 0, "registered:FLAG_HAS_OWNER");
+        assertTrue(labels[0].flags & helper.FLAG_HAS_TOKEN() != 0, "registered:FLAG_HAS_TOKEN");
+        assertTrue(labels[0].tokenId != 0, "registered:tokenId should be nonzero");
+    }
+
+    function test_getLabels_threeLevel() external {
+        UserRegistry aliceRegistry = _registerWithSubregistry("alice", alice);
+        vm.prank(alice);
+        aliceRegistry.setParent(ethRegistry, "alice");
+
+        vm.prank(alice);
+        aliceRegistry.register(
+            "sub", bob, IRegistry(address(0)), resolver1,
+            REGISTRATION_ROLES, uint64(block.timestamp + 180 days)
+        );
+
+        RegistryHelper.LabelInfo[] memory labels =
+            helper.getLabels(NameCoder.encode("sub.alice.eth"));
+
+        assertEq(labels.length, 3);
+        assertEq(labels[0].label, "sub");
+        assertEq(labels[0].owner, bob);
+        assertEq(labels[0].resolver, resolver1);
+        assertEq(labels[1].label, "alice");
+        assertEq(labels[1].owner, alice);
+        assertEq(labels[2].label, "eth");
+    }
+
+    function test_getLabels_rootName() external view {
+        RegistryHelper.LabelInfo[] memory labels = helper.getLabels(NameCoder.encode(""));
+        assertEq(labels.length, 0);
+    }
+
+    function test_getLabels_canonical_missingSetParent() external {
+        // Deploy subregistry but never call setParent
+        UserRegistry aliceRegistry = _registerWithSubregistry("alice", alice);
+
+        RegistryHelper.LabelInfo[] memory labels =
+            helper.getLabels(NameCoder.encode("alice.eth"));
+
+        // Forward link exists (ethRegistry.getSubregistry("alice") == aliceRegistry)
+        // but reverse link is missing (aliceRegistry.getParent() == (address(0), ""))
+        assertEq(address(labels[0].registry), address(aliceRegistry), "subregistry should be set");
+        assertFalse(
+            labels[0].flags & helper.FLAG_IS_CANONICAL() != 0,
+            "canonical:missing setParent should not be canonical"
+        );
+    }
+
+    function test_getLabels_canonical_wrongParentLabel() external {
+        UserRegistry aliceRegistry = _registerWithSubregistry("alice", alice);
+        // setParent with wrong label
+        vm.prank(alice);
+        aliceRegistry.setParent(ethRegistry, "bob");
+
+        RegistryHelper.LabelInfo[] memory labels =
+            helper.getLabels(NameCoder.encode("alice.eth"));
+
+        assertFalse(
+            labels[0].flags & helper.FLAG_IS_CANONICAL() != 0,
+            "canonical:wrong label should not be canonical"
+        );
+    }
+
+    function test_getLabels_canonical_wrongParentRegistry() external {
+        UserRegistry aliceRegistry = _registerWithSubregistry("alice", alice);
+        // setParent pointing to wrong registry
+        vm.prank(alice);
+        aliceRegistry.setParent(rootRegistry, "alice");
+
+        RegistryHelper.LabelInfo[] memory labels =
+            helper.getLabels(NameCoder.encode("alice.eth"));
+
+        assertFalse(
+            labels[0].flags & helper.FLAG_IS_CANONICAL() != 0,
+            "canonical:wrong parent registry should not be canonical"
+        );
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // findCanonicalName / findCanonicalRegistry
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_findCanonicalName() external {
+        UserRegistry aliceRegistry = _registerWithSubregistry("alice", alice);
+        vm.prank(alice);
+        aliceRegistry.setParent(ethRegistry, "alice");
+
+        bytes memory name = helper.findCanonicalName(IRegistry(address(aliceRegistry)));
+        assertEq(name, NameCoder.encode("alice.eth"));
+    }
+
+    function test_findCanonicalRegistry() external {
+        UserRegistry aliceRegistry = _registerWithSubregistry("alice", alice);
+        vm.prank(alice);
+        aliceRegistry.setParent(ethRegistry, "alice");
+
+        IRegistry found = helper.findCanonicalRegistry(NameCoder.encode("alice.eth"));
+        assertEq(address(found), address(aliceRegistry));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Edge cases
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_isVerified_rootName() external view {
+        assertTrue(helper.isVerified(NameCoder.encode("")));
+    }
+
+    function test_isEmancipated_rootName() external view {
+        assertTrue(helper.isEmancipated(NameCoder.encode("")));
+    }
+
+    function test_getLabels_brokenChain() external view {
+        // sub.nobody.eth: "nobody" is not registered, so the chain breaks
+        RegistryHelper.LabelInfo[] memory labels =
+            helper.getLabels(NameCoder.encode("sub.nobody.eth"));
+
+        assertEq(labels.length, 3);
+
+        // sub: parent is address(0) (nobody has no subregistry), all fields zero
+        assertEq(labels[0].label, "sub");
+        assertEq(labels[0].owner, address(0));
+        assertEq(labels[0].flags, 0, "sub: no flags on broken chain");
+
+        // nobody: parent is ethRegistry, name is not registered but no revert
+        assertEq(labels[1].label, "nobody");
+        assertEq(labels[1].owner, address(0));
+        assertFalse(labels[1].flags & helper.FLAG_HAS_OWNER() != 0, "nobody:FLAG_HAS_OWNER");
+        assertTrue(labels[1].flags & helper.FLAG_IS_VERIFIED() != 0, "nobody:FLAG_IS_VERIFIED");
+        assertTrue(labels[1].flags & helper.FLAG_IS_EMANCIPATED() != 0, "nobody:FLAG_IS_EMANCIPATED");
+
+        // eth: normal
+        assertEq(labels[2].label, "eth");
+        assertTrue(labels[2].flags & helper.FLAG_IS_VERIFIED() != 0, "eth:FLAG_IS_VERIFIED");
+    }
+
+    function test_isVerified_brokenChain() external view {
+        // sub.nobody.eth: chain breaks at nobody (no subregistry)
+        // registries = [address(0), address(0), ethRegistry, rootRegistry]
+        // Loop checks registries[1] = address(0) -> not verified
+        assertFalse(helper.isVerified(NameCoder.encode("sub.nobody.eth")));
+    }
+
+    function test_isEmancipated_brokenChain() external view {
+        assertFalse(helper.isEmancipated(NameCoder.encode("sub.nobody.eth")));
+    }
+
+    function test_isVerified_unregistered() external view {
+        // nobody.eth: name doesn't exist but registry chain (ethRegistry) is valid
+        assertTrue(helper.isVerified(NameCoder.encode("nobody.eth")));
+    }
+
+    function test_isEmancipated_unregistered() external view {
+        // nobody.eth: name doesn't exist but registry chain is emancipated
+        assertTrue(helper.isEmancipated(NameCoder.encode("nobody.eth")));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Helpers
+    ////////////////////////////////////////////////////////////////////////
+
+    function _registerOnEth(string memory label, address owner) internal {
+        ethRegistry.register(
+            label,
+            owner,
+            IRegistry(address(0)),
+            address(0),
+            REGISTRATION_ROLES,
+            uint64(block.timestamp + 365 days)
+        );
+    }
+
+    function _registerWithSubregistry(string memory label, address owner)
+        internal
+        returns (UserRegistry registry)
+    {
+        registry = deployUserRegistry(owner, EACBaseRolesLib.ALL_ROLES, uint256(keccak256(bytes(label))));
+
+        ethRegistry.register(
+            label,
+            owner,
+            IRegistry(address(registry)),
+            address(0),
+            REGISTRATION_ROLES,
+            uint64(block.timestamp + 365 days)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

  - Immutable read-only contract for inspecting name state, verification, and emancipation across the registry hierarchy
  - Lightweight functions (`isCanonical`, `isVerified`, `isEmancipated`) for common marketplace queries, plus `getLabels` for full per-label breakdown
  - `findOwner`, `findCanonicalName`, `findCanonicalRegistry` are 1:1 wrappers around `LibRegistry`, matching URv2

## Verification and emancipation

  **Verified:** Every registry in the name's ancestry is trusted, audited code (root registry, .eth registry, or a UserRegistry/WrapperRegistry deployed via the VerifiableFactory).

  **Emancipated:** Verified, and no registry in the chain has dangerous roles assigned on ROOT_RESOURCE. The owner is fully sovereign: no admin can change the resolver, delete the name, 
  swap the subregistry, transfer ownership, or upgrade the implementation.

  **Dangerous roles:** 
  
  ```
  DANGEROUS_ROOT_ROLES =
        RegistryRolesLib.ROLE_SET_RESOLVER |
        RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
        RegistryRolesLib.ROLE_SET_SUBREGISTRY |
        RegistryRolesLib.ROLE_SET_SUBREGISTRY_ADMIN |
        RegistryRolesLib.ROLE_UNREGISTER |
        RegistryRolesLib.ROLE_UNREGISTER_ADMIN |
        RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
        RegistryRolesLib.ROLE_UPGRADE |
        RegistryRolesLib.ROLE_UPGRADE_ADMIN;
 ```

  ## Marketplace integration
  
```
  owner = registryHelper.findOwner(name)
  if owner == address(0):
      show "Name not registered"
  
  if registryHelper.isEmancipated(name):
      show "Emancipated" (green)        -- owner is fully sovereign, no admin can interfere
  elif registryHelper.isVerified(name):
      show "Verified" (yellow)          -- trusted code, but admin retains some power
  else:
      show warning (red)                -- unverified registry in the chain
```
For the common case (emancipated .eth name), this is two calls: `findOwner` + `isEmancipated`.


  ## Test plan

  - [x] 41 tests covering all public functions, edge cases, canonical checks, and emancipation logic
  - [ ] Add WrapperRegistry verification test coverage (`wrapperRegistryImpl` is `address(0)` in the test fixture)
  - [ ] Optionally remove `findOwner`, `findCanonicalName`, `findCanonicalRegistry` functions from URv2