### PR TITLE
[Idea 4] Change `WrapperRegistry` to use virtual root admin

### DIFF
--- a/contracts/foundry.lock
+++ b/contracts/foundry.lock
@@ -17,11 +17,11 @@
   "lib/openzeppelin-contracts-v4": {
     "rev": "54b3f14346da01ba0d159114b399197fea8b7cda"
   },
-  "lib/solsha1": {
-    "rev": "c4fbe97cf5e8c1b8d607001588fd23abb5bfb923"
-  },
   "lib/solady": {
     "rev": "90db92ce173856605d24a554969f2c67cadbc7e9"
+  },
+  "lib/solsha1": {
+    "rev": "c4fbe97cf5e8c1b8d607001588fd23abb5bfb923"
   },
   "lib/unruggable-gateways": {
     "rev": "7426ac57509e2023a673956439eed29998d2e371"

--- a/contracts/src/access-control/EnhancedAccessControl.sol
+++ b/contracts/src/access-control/EnhancedAccessControl.sol
@@ -424,9 +424,10 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         virtual
         returns (uint256)
     {
-        uint256 roleBitmap =
-            (_roles[resource][account] | _roles[ROOT_RESOURCE][account]) >> 128;
-        return (roleBitmap << 128) | roleBitmap;
+        return
+            EACBaseRolesLib.withAdminRolesApplied(
+                _roles[resource][account] | _roles[ROOT_RESOURCE][account]
+            );
     }
 
     /// @dev Returns the revokable roles for `account` within `resource`.
@@ -442,9 +443,10 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         virtual
         returns (uint256)
     {
-        uint256 roleBitmap =
-            (_roles[resource][account] | _roles[ROOT_RESOURCE][account]) >> 128;
-        return (roleBitmap << 128) | roleBitmap;
+        return
+            EACBaseRolesLib.withAdminRolesApplied(
+                _roles[resource][account] | _roles[ROOT_RESOURCE][account]
+            );
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/src/access-control/EnhancedAccessControl.sol
+++ b/contracts/src/access-control/EnhancedAccessControl.sol
@@ -327,13 +327,13 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
 
         if (isGrant) {
             // Check for overflow
-            if (_hasZeroNybbles(~(roleMask & _roleCount[resource]))) {
+            if (EACBaseRolesLib.hasZeroNybbles(~(roleMask & _roleCount[resource]))) {
                 revert EACMaxAssignees(resource, roleBitmap);
             }
             _roleCount[resource] += roleBitmap;
         } else {
             // Check for underflow
-            if (_hasZeroNybbles(~(roleMask & ~_roleCount[resource]))) {
+            if (EACBaseRolesLib.hasZeroNybbles(~(roleMask & ~_roleCount[resource]))) {
                 revert EACMinAssignees(resource, roleBitmap);
             }
             _roleCount[resource] -= roleBitmap;
@@ -471,20 +471,5 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         _checkRoleBitmap(roleBitmap);
         roleMask = roleBitmap | (roleBitmap << 1);
         roleMask |= roleMask << 2;
-    }
-
-    /// @dev Checks if the given value has any zero nybbles.
-    /// @param value The value to check.
-    /// @return `true` if the value has any zero nybbles, `false` otherwise.
-    function _hasZeroNybbles(uint256 value) private pure returns (bool) {
-        // Algorithm source: https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord
-        uint256 hasZeroNybbles;
-        unchecked {
-            hasZeroNybbles =
-                (value - 0x1111111111111111111111111111111111111111111111111111111111111111) &
-                ~value &
-                0x8888888888888888888888888888888888888888888888888888888888888888;
-        }
-        return hasZeroNybbles != 0;
     }
 }

--- a/contracts/src/access-control/libraries/EACBaseRolesLib.sol
+++ b/contracts/src/access-control/libraries/EACBaseRolesLib.sol
@@ -11,6 +11,10 @@ pragma solidity ^0.8.20;
 /// just the 32 admin role slots. Used to extract which admin roles an account holds.
 ///
 library EACBaseRolesLib {
+    ////////////////////////////////////////////////////////////////////////
+    // Constants
+    ////////////////////////////////////////////////////////////////////////
+
     /// @dev Mask with bit 0 set in every nybble — represents one unit per role slot across all 64 slots.
     uint256 internal constant ALL_ROLES =
         0x1111111111111111111111111111111111111111111111111111111111111111;
@@ -18,4 +22,17 @@ library EACBaseRolesLib {
     /// @dev Mask selecting only the 32 admin role nybbles (upper 128 bits).
     uint256 internal constant ADMIN_ROLES =
         0x1111111111111111111111111111111100000000000000000000000000000000;
+
+    ////////////////////////////////////////////////////////////////////////
+    // Implementation
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Derive roles bitmap from role counts for a resource.
+    function fromCounts(uint256 count) internal pure returns (uint256) {
+        return
+            (count & ALL_ROLES) |
+            ((count >> 1) & ALL_ROLES) |
+            ((count >> 2) & ALL_ROLES) |
+            ((count >> 3) & ALL_ROLES);
+    }
 }

--- a/contracts/src/access-control/libraries/EACBaseRolesLib.sol
+++ b/contracts/src/access-control/libraries/EACBaseRolesLib.sol
@@ -34,7 +34,23 @@ library EACBaseRolesLib {
     }
 
     /// @dev Derive roles bitmap from assignee counts.
+    /// @param counts Packed role counts (0-15) as `uint4x64`.
     function fromCounts(uint256 counts) internal pure returns (uint256) {
         return (counts | (counts >> 1) | (counts >> 2) | (counts >> 3)) & ALL_ROLES;
+    }
+
+    /// @dev Checks if the given value has any zero nybbles.
+    /// @param value The value to check.
+    /// @return `true` if the value has any zero nybbles, `false` otherwise.
+    function hasZeroNybbles(uint256 value) internal pure returns (bool) {
+        // Algorithm source: https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord
+        uint256 zeroNybbles;
+        unchecked {
+            zeroNybbles =
+                (value - 0x1111111111111111111111111111111111111111111111111111111111111111) &
+                ~value &
+                0x8888888888888888888888888888888888888888888888888888888888888888;
+        }
+        return zeroNybbles != 0;
     }
 }

--- a/contracts/src/access-control/libraries/EACBaseRolesLib.sol
+++ b/contracts/src/access-control/libraries/EACBaseRolesLib.sol
@@ -28,11 +28,7 @@ library EACBaseRolesLib {
     ////////////////////////////////////////////////////////////////////////
 
     /// @dev Derive roles bitmap from role counts for a resource.
-    function fromCounts(uint256 count) internal pure returns (uint256) {
-        return
-            (count & ALL_ROLES) |
-            ((count >> 1) & ALL_ROLES) |
-            ((count >> 2) & ALL_ROLES) |
-            ((count >> 3) & ALL_ROLES);
+    function fromCounts(uint256 counts) internal pure returns (uint256) {
+        return (counts | (counts >> 1) | (counts >> 2) | (counts >> 3)) & ALL_ROLES;
     }
 }

--- a/contracts/src/access-control/libraries/EACBaseRolesLib.sol
+++ b/contracts/src/access-control/libraries/EACBaseRolesLib.sol
@@ -27,7 +27,13 @@ library EACBaseRolesLib {
     // Implementation
     ////////////////////////////////////////////////////////////////////////
 
-    /// @dev Derive roles bitmap from role counts for a resource.
+    /// @dev Admin roles imply their corresponding regular roles.
+    function withAdminRolesApplied(uint256 roleBitmap) internal pure returns (uint256) {
+        roleBitmap >>= 128;
+        return (roleBitmap << 128) | roleBitmap;
+    }
+
+    /// @dev Derive roles bitmap from assignee counts.
     function fromCounts(uint256 counts) internal pure returns (uint256) {
         return (counts | (counts >> 1) | (counts >> 2) | (counts >> 3)) & ALL_ROLES;
     }

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -242,7 +242,10 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
             roleBitmap |= roleBitmap << 128; // give admin
         }
         if ((fuses & CANNOT_TRANSFER) == 0) {
-            roleBitmap |= RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
+            roleBitmap |=
+                RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
+                RegistryRolesLib.ROLE_WRAPPER_RECLAIM |
+                RegistryRolesLib.ROLE_WRAPPER_RECLAIM_ADMIN;
         }
     }
 }

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -155,7 +155,6 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
                                     node,
                                     parentRegistry,
                                     md.label,
-                                    md.owner,
                                     _subregistryRoleBitmapFromFuses(fuses)
                                 )
                             )
@@ -225,7 +224,6 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
         if (LibMigration.notFrozen(fuses)) {
             roleBitmap |= roleBitmap << 128; // give admin
         }
-        roleBitmap |= RegistryRolesLib.ROLE_WRAPPER_RECLAIM; // no admin, used for "tracking"
     }
 
     /// @dev Convert fuses to equivalent token roles.
@@ -236,7 +234,6 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
         if ((fuses & CANNOT_SET_RESOLVER) == 0) {
             roleBitmap |= RegistryRolesLib.ROLE_SET_RESOLVER;
         }
-        roleBitmap |= RegistryRolesLib.ROLE_WRAPPER_RECLAIM;
         if (LibMigration.notFrozen(fuses)) {
             roleBitmap |= roleBitmap << 128; // give admin
         }

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -218,17 +218,14 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
         if ((fuses & CANNOT_CREATE_SUBDOMAIN) == 0) {
             roleBitmap |= RegistryRolesLib.ROLE_REGISTRAR;
         }
+        roleBitmap |=
+            RegistryRolesLib.ROLE_RENEW |
+            RegistryRolesLib.ROLE_UPGRADE |
+            RegistryRolesLib.ROLE_CAN_NAME;
         if (LibMigration.notFrozen(fuses)) {
             roleBitmap |= roleBitmap << 128; // give admin
         }
-        roleBitmap |=
-            RegistryRolesLib.ROLE_RENEW |
-            RegistryRolesLib.ROLE_RENEW_ADMIN |
-            RegistryRolesLib.ROLE_UPGRADE |
-            RegistryRolesLib.ROLE_UPGRADE_ADMIN |
-            RegistryRolesLib.ROLE_CAN_NAME |
-            RegistryRolesLib.ROLE_CAN_NAME_ADMIN |
-            RegistryRolesLib.ROLE_WRAPPER_RECLAIM; // no admin, used for "tracking"
+        roleBitmap |= RegistryRolesLib.ROLE_WRAPPER_RECLAIM; // no admin, used for "tracking"
     }
 
     /// @dev Convert fuses to equivalent token roles.
@@ -239,14 +236,12 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
         if ((fuses & CANNOT_SET_RESOLVER) == 0) {
             roleBitmap |= RegistryRolesLib.ROLE_SET_RESOLVER;
         }
+        roleBitmap |= RegistryRolesLib.ROLE_WRAPPER_RECLAIM;
         if (LibMigration.notFrozen(fuses)) {
             roleBitmap |= roleBitmap << 128; // give admin
         }
         if ((fuses & CANNOT_TRANSFER) == 0) {
-            roleBitmap |=
-                RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
-                RegistryRolesLib.ROLE_WRAPPER_RECLAIM |
-                RegistryRolesLib.ROLE_WRAPPER_RECLAIM_ADMIN;
+            roleBitmap |= RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN; // no user
         }
     }
 }

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -227,7 +227,8 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
             RegistryRolesLib.ROLE_UPGRADE |
             RegistryRolesLib.ROLE_UPGRADE_ADMIN |
             RegistryRolesLib.ROLE_CAN_NAME |
-            RegistryRolesLib.ROLE_CAN_NAME_ADMIN;
+            RegistryRolesLib.ROLE_CAN_NAME_ADMIN |
+            RegistryRolesLib.ROLE_WRAPPER_RECLAIM; // no admin, used for "tracking"
     }
 
     /// @dev Convert fuses to equivalent token roles.

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -279,7 +279,7 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
     }
 
     /// @inheritdoc IContractNamer
-    function isContractNamer(address namer) public view returns (bool) {
+    function isContractNamer(address namer) public view virtual returns (bool) {
         return hasRootRoles(RegistryRolesLib.ROLE_CAN_NAME, namer);
     }
 

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -569,6 +569,7 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
     function _getSettableRoles(uint256 resource, address account)
         internal
         view
+        virtual
         override
         returns (uint256)
     {

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -9,6 +9,7 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
+import {EACBaseRolesLib} from "../access-control/libraries/EACBaseRolesLib.sol";
 import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
 import {AbstractWrapperReceiver} from "../migration/AbstractWrapperReceiver.sol";
 import {LibMigration} from "../migration/libraries/LibMigration.sol";
@@ -143,6 +144,30 @@ contract WrapperRegistry is
     ////////////////////////////////////////////////////////////////////////
     // Implementation
     ////////////////////////////////////////////////////////////////////////
+
+    /// @inheritdoc IWrapperRegistry
+    function reclaim(address to, address[] calldata revokes) external {
+        address sender = _msgSender();
+        if (
+            !PermissionedRegistry(address(_parentRegistry)).hasRoles(
+                LibLabel.id(_childLabel),
+                RegistryRolesLib.ROLE_WRAPPER_RECLAIM,
+                sender
+            )
+        ) {
+            revert EACUnauthorizedAccountRoles(
+                PermissionedRegistry(address(_parentRegistry)).findTokenId(_childLabel),
+                RegistryRolesLib.ROLE_WRAPPER_RECLAIM,
+                sender
+            );
+        }
+        (uint256 counts, ) = getAssigneeCount(ROOT_RESOURCE, EACBaseRolesLib.ALL_ROLES);
+        uint256 unionRoles = EACBaseRolesLib.fromCounts(counts);
+        for (uint256 i; i < revokes.length; ++i) {
+            _revokeRoles(ROOT_RESOURCE, EACBaseRolesLib.ALL_ROLES, revokes[i], false);
+        }
+        _grantRoles(ROOT_RESOURCE, unionRoles | (unionRoles >> 128), to, false);
+    }
 
     /// @notice Declares this implementation as an eligible verifiable proxy upgrade target.
     /// @dev Upgrade authorization is still enforced by the current implementation during the UUPS

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -9,7 +9,6 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
-import {EACBaseRolesLib} from "../access-control/libraries/EACBaseRolesLib.sol";
 import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
 import {AbstractWrapperReceiver} from "../migration/AbstractWrapperReceiver.sol";
 import {LibMigration} from "../migration/libraries/LibMigration.sol";
@@ -137,7 +136,8 @@ contract WrapperRegistry is
     ////////////////////////////////////////////////////////////////////////
 
     /// @inheritdoc IWrapperRegistry
-    function reclaim(address to, address[] calldata revokes) external {
+    function reclaim(address from, address to) external {
+        // caller must have permission token (on parent registry)
         address sender = _msgSender();
         if (
             !PermissionedRegistry(address(_parentRegistry)).hasRoles(
@@ -152,15 +152,10 @@ contract WrapperRegistry is
                 sender
             );
         }
-        (uint256 counts, ) = getAssigneeCount(ROOT_RESOURCE, EACBaseRolesLib.ALL_ROLES);
-        uint256 unionRoles = EACBaseRolesLib.fromCounts(counts);
-        for (uint256 i; i < revokes.length; ++i) {
-            _revokeRoles(ROOT_RESOURCE, EACBaseRolesLib.ALL_ROLES, revokes[i], false);
-        }
-        if (hasAssignees(ROOT_RESOURCE, EACBaseRolesLib.ADMIN_ROLES)) {
-            revert AdminRolesNotFullyRevoked();
-        }
-        _grantRoles(ROOT_RESOURCE, unionRoles, to, false);
+        // from must have "tracking" role on root (on this registry)
+        // see: LockedWrapperReceiver._subregistryRoleBitmapFromFuses()
+        _checkRoles(ROOT_RESOURCE, RegistryRolesLib.ROLE_WRAPPER_RECLAIM, from);
+        _transferRoles(ROOT_RESOURCE, from, to, false);
     }
 
     /// @notice Declares this implementation as an eligible verifiable proxy upgrade target.
@@ -250,6 +245,24 @@ contract WrapperRegistry is
         returns (uint256 tokenId)
     {
         return _register(label, owner, subregistry, resolver, roleBitmap, expiry, false);
+    }
+
+    /// @inheritdoc PermissionedRegistry
+    /// @dev Override for token-dependent logic:
+    ///
+    /// Root admin roles cannot be granted.
+    ///
+    /// @param resource The resource to get settable roles for.
+    /// @param account The account to get settable roles for.
+    /// @return The settable roles.
+    function _getSettableRoles(uint256 resource, address account)
+        internal
+        view
+        override
+        returns (uint256)
+    {
+        uint256 roleBitmap = super._getSettableRoles(resource, account);
+        return resource == ROOT_RESOURCE ? roleBitmap >> 128 : roleBitmap;
     }
 
     /// @dev Requires `ROLE_UPGRADE` and approval for the target implementation.

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -53,15 +53,6 @@ contract WrapperRegistry is
     bytes32 internal _node;
 
     ////////////////////////////////////////////////////////////////////////
-    // Errors
-    ////////////////////////////////////////////////////////////////////////
-
-    /// @notice Upgrade target is not approved for `WrapperRegistry` proxies.
-    /// @dev Error selector: `0xf74d7dd0`
-    /// @param implementation The disallowed implementation address.
-    error UpgradeTargetNotApproved(address implementation);
-
-    ////////////////////////////////////////////////////////////////////////
     // Initialization
     ////////////////////////////////////////////////////////////////////////
 
@@ -166,7 +157,10 @@ contract WrapperRegistry is
         for (uint256 i; i < revokes.length; ++i) {
             _revokeRoles(ROOT_RESOURCE, EACBaseRolesLib.ALL_ROLES, revokes[i], false);
         }
-        _grantRoles(ROOT_RESOURCE, EACBaseRolesLib.withAdminRolesApplied(unionRoles), to, false);
+        if (hasAssignees(ROOT_RESOURCE, EACBaseRolesLib.ADMIN_ROLES)) {
+            revert AdminRolesNotFullyRevoked();
+        }
+        _grantRoles(ROOT_RESOURCE, unionRoles, to, false);
     }
 
     /// @notice Declares this implementation as an eligible verifiable proxy upgrade target.

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -127,7 +127,8 @@ contract WrapperRegistry is
         _parentRegistry = parentRegistry;
         _childLabel = childLabel;
         emit RegistryCreated();
-        _grantRoles(ROOT_RESOURCE, roleBitmap, address(this), false);
+        // grant to virtual account
+        _grantRoles(ROOT_RESOURCE, roleBitmap, address(_parentRegistry), false);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -226,9 +227,10 @@ contract WrapperRegistry is
     /// @dev If the caller is the token owner, return the virtual owner. 
     function _msgSender() internal view override returns (address) {
         address sender = super._msgSender();
+        address parent = address(_parentRegistry); // virtual account
         return
-            sender == PermissionedRegistry(address(_parentRegistry)).findOwner(_childLabel)
-                ? address(this)
+            sender == PermissionedRegistry(parent).findOwner(_childLabel)
+                ? parent
                 : sender;
     }
 

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -117,7 +117,6 @@ contract WrapperRegistry is
         bytes32 node,
         IRegistry parentRegistry,
         string calldata childLabel,
-        address rootAccount,
         uint256 roleBitmap
     )
         public
@@ -128,35 +127,12 @@ contract WrapperRegistry is
         _parentRegistry = parentRegistry;
         _childLabel = childLabel;
         emit RegistryCreated();
-        _grantRoles(ROOT_RESOURCE, roleBitmap, rootAccount, false);
+        _grantRoles(ROOT_RESOURCE, roleBitmap, address(this), false);
     }
 
     ////////////////////////////////////////////////////////////////////////
     // Implementation
     ////////////////////////////////////////////////////////////////////////
-
-    /// @inheritdoc IWrapperRegistry
-    function reclaim(address from, address to) external {
-        // caller must have permission token (on parent registry)
-        address sender = _msgSender();
-        if (
-            !PermissionedRegistry(address(_parentRegistry)).hasRoles(
-                LibLabel.id(_childLabel),
-                RegistryRolesLib.ROLE_WRAPPER_RECLAIM,
-                sender
-            )
-        ) {
-            revert EACUnauthorizedAccountRoles(
-                PermissionedRegistry(address(_parentRegistry)).findTokenId(_childLabel),
-                RegistryRolesLib.ROLE_WRAPPER_RECLAIM,
-                sender
-            );
-        }
-        // from must have "tracking" role on root (on this registry)
-        // see: LockedWrapperReceiver._subregistryRoleBitmapFromFuses()
-        _checkRoles(ROOT_RESOURCE, RegistryRolesLib.ROLE_WRAPPER_RECLAIM, from);
-        _transferRoles(ROOT_RESOURCE, from, to, false);
-    }
 
     /// @notice Declares this implementation as an eligible verifiable proxy upgrade target.
     /// @dev Upgrade authorization is still enforced by the current implementation during the UUPS
@@ -245,6 +221,15 @@ contract WrapperRegistry is
         returns (uint256 tokenId)
     {
         return _register(label, owner, subregistry, resolver, roleBitmap, expiry, false);
+    }
+
+    /// @dev If the caller is the token owner, return the virtual owner. 
+    function _msgSender() internal view override returns (address) {
+        address sender = super._msgSender();
+        return
+            sender == PermissionedRegistry(address(_parentRegistry)).findOwner(_childLabel)
+                ? address(this)
+                : sender;
     }
 
     /// @inheritdoc PermissionedRegistry

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -9,11 +9,13 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
+import {HCAContext} from "../hca/HCAContext.sol";
 import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
 import {AbstractWrapperReceiver} from "../migration/AbstractWrapperReceiver.sol";
 import {LibMigration} from "../migration/libraries/LibMigration.sol";
 import {LockedWrapperReceiver} from "../migration/LockedWrapperReceiver.sol";
 import {IWrapperRegistry} from "../registry/interfaces/IWrapperRegistry.sol";
+import {IContractNamer} from "../reverse-registrar/interfaces/IContractNamer.sol";
 import {IAddressSet} from "../utils/interfaces/IAddressSet.sol";
 import {ILabelStore} from "../utils/interfaces/ILabelStore.sol";
 import {LibLabel} from "../utils/LibLabel.sol";
@@ -204,6 +206,17 @@ contract WrapperRegistry is
         return _node;
     }
 
+    /// @inheritdoc PermissionedRegistry
+    /// @dev Respect virtual owner.
+    function isContractNamer(address namer)
+        public
+        view
+        override(IContractNamer, PermissionedRegistry)
+        returns (bool)
+    {
+        return hasRootRoles(RegistryRolesLib.ROLE_CAN_NAME, _remapVirtualOwner(namer));
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // Internal Functions
     ////////////////////////////////////////////////////////////////////////
@@ -225,14 +238,10 @@ contract WrapperRegistry is
         return _register(label, owner, subregistry, resolver, roleBitmap, expiry, false);
     }
 
-    /// @dev If the caller is the token owner, return the virtual owner. 
+    /// @inheritdoc HCAContext
+    /// @dev Respect virtual owner.
     function _msgSender() internal view override returns (address) {
-        address sender = super._msgSender();
-        address parent = address(_parentRegistry); // virtual owner
-        return
-            sender == PermissionedRegistry(parent).findOwner(_childLabel)
-                ? parent
-                : sender;
+        return _remapVirtualOwner(super._msgSender());
     }
 
     /// @inheritdoc PermissionedRegistry
@@ -284,5 +293,14 @@ contract WrapperRegistry is
         // and reserving the label would lock it forever; positive expiry on either
         // side marks a completed migration.
         return LibMigration.isEmancipatedChild(fuses) && _REGISTRY_V1.owner(node) != address(0);
+    }
+
+    /// @dev If `account` is the token owner, return the virtual owner. 
+    function _remapVirtualOwner(address account) internal view returns (address) {
+        address parent = address(_parentRegistry); // virtual owner
+        return
+            parent != address(0) && account == PermissionedRegistry(parent).findOwner(_childLabel)
+                ? parent
+                : account;
     }
 }

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -166,7 +166,7 @@ contract WrapperRegistry is
         for (uint256 i; i < revokes.length; ++i) {
             _revokeRoles(ROOT_RESOURCE, EACBaseRolesLib.ALL_ROLES, revokes[i], false);
         }
-        _grantRoles(ROOT_RESOURCE, unionRoles | (unionRoles >> 128), to, false);
+        _grantRoles(ROOT_RESOURCE, EACBaseRolesLib.withAdminRolesApplied(unionRoles), to, false);
     }
 
     /// @notice Declares this implementation as an eligible verifiable proxy upgrade target.

--- a/contracts/src/registry/interfaces/IWrapperRegistry.sol
+++ b/contracts/src/registry/interfaces/IWrapperRegistry.sol
@@ -5,7 +5,7 @@ import {IPermissionedRegistry} from "./IPermissionedRegistry.sol";
 import {IRegistry} from "./IRegistry.sol";
 
 /// @notice Interface for a registry that manages a locked NameWrapper name.
-/// @dev Interface selector: `0x6b2f7339`
+/// @dev Interface selector: `0xf9fc8b9c`
 interface IWrapperRegistry is IPermissionedRegistry {
     /// @notice Initializes WrapperRegistry.
     /// @param node Namehash of this registry.
@@ -21,6 +21,12 @@ interface IWrapperRegistry is IPermissionedRegistry {
         uint256 roleBitmap
     )
         external;
+
+    /// @notice Reclaim the registry from a prior owner.
+    /// @dev Requires `ROLE_WRAPPER_RECLAIM` on token.
+    /// @param to The new root account.
+    /// @param revokes The old root accounts which get fully revoked.
+    function reclaim(address to, address[] calldata revokes) external;
 
     /// @notice Returns the DNS-encoded name for this registry.
     function getWrappedName() external view returns (bytes memory);

--- a/contracts/src/registry/interfaces/IWrapperRegistry.sol
+++ b/contracts/src/registry/interfaces/IWrapperRegistry.sol
@@ -7,6 +7,23 @@ import {IRegistry} from "./IRegistry.sol";
 /// @notice Interface for a registry that manages a locked NameWrapper name.
 /// @dev Interface selector: `0xf9fc8b9c`
 interface IWrapperRegistry is IPermissionedRegistry {
+    ////////////////////////////////////////////////////////////////////////
+    // Errors
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Upgrade target is not approved for `WrapperRegistry` proxies.
+    /// @dev Error selector: `0xf74d7dd0`
+    /// @param implementation The disallowed implementation address.
+    error UpgradeTargetNotApproved(address implementation);
+
+    /// @notice All prior admin roles must be revoked by reclaim.
+    /// @dev Error selector: `0x74c75408`
+    error AdminRolesNotFullyRevoked();
+
+    ////////////////////////////////////////////////////////////////////////
+    // Functions
+    ////////////////////////////////////////////////////////////////////////
+
     /// @notice Initializes WrapperRegistry.
     /// @param node Namehash of this registry.
     /// @param parentRegistry The parent of this registry.
@@ -22,8 +39,9 @@ interface IWrapperRegistry is IPermissionedRegistry {
     )
         external;
 
-    /// @notice Reclaim the registry from a prior owner.
+    /// @notice Reclaim the registry from prior ownership.
     /// @dev Requires `ROLE_WRAPPER_RECLAIM` on token.
+    ///      Reverts `AdminRolesNotFullyRevoked` unless all admins are revoked.
     /// @param to The new root account.
     /// @param revokes The old root accounts which get fully revoked.
     function reclaim(address to, address[] calldata revokes) external;

--- a/contracts/src/registry/interfaces/IWrapperRegistry.sol
+++ b/contracts/src/registry/interfaces/IWrapperRegistry.sol
@@ -5,7 +5,7 @@ import {IPermissionedRegistry} from "./IPermissionedRegistry.sol";
 import {IRegistry} from "./IRegistry.sol";
 
 /// @notice Interface for a registry that manages a locked NameWrapper name.
-/// @dev Interface selector: `0x309dafc4`
+/// @dev Interface selector: `0xe01aaa11`
 interface IWrapperRegistry is IPermissionedRegistry {
     ////////////////////////////////////////////////////////////////////////
     // Errors
@@ -24,23 +24,14 @@ interface IWrapperRegistry is IPermissionedRegistry {
     /// @param node Namehash of this registry.
     /// @param parentRegistry The parent of this registry.
     /// @param childLabel The subdomain for this registry.
-    /// @param rootAccount Account granted root roles.
-    /// @param roleBitmap The role bitmap granted to `rootAccount`.
+    /// @param roleBitmap The role bitmap granted to the virtual admin.
     function initialize(
         bytes32 node,
         IRegistry parentRegistry,
         string calldata childLabel,
-        address rootAccount,
         uint256 roleBitmap
     )
         external;
-
-    /// @notice Reclaim control of the registry.
-    /// @dev Requires `ROLE_WRAPPER_RECLAIM` on token for caller.
-    ///      Requires `ROLE_WRAPPER_RECLAIM` on root for `from`.
-    /// @param from The old root account with `ROLE_WRAPPER_RECLAIM`.
-    /// @param to The new root account.
-    function reclaim(address from, address to) external;
 
     /// @notice Returns the DNS-encoded name for this registry.
     function getWrappedName() external view returns (bytes memory);

--- a/contracts/src/registry/interfaces/IWrapperRegistry.sol
+++ b/contracts/src/registry/interfaces/IWrapperRegistry.sol
@@ -5,7 +5,7 @@ import {IPermissionedRegistry} from "./IPermissionedRegistry.sol";
 import {IRegistry} from "./IRegistry.sol";
 
 /// @notice Interface for a registry that manages a locked NameWrapper name.
-/// @dev Interface selector: `0xf9fc8b9c`
+/// @dev Interface selector: `0x309dafc4`
 interface IWrapperRegistry is IPermissionedRegistry {
     ////////////////////////////////////////////////////////////////////////
     // Errors
@@ -15,10 +15,6 @@ interface IWrapperRegistry is IPermissionedRegistry {
     /// @dev Error selector: `0xf74d7dd0`
     /// @param implementation The disallowed implementation address.
     error UpgradeTargetNotApproved(address implementation);
-
-    /// @notice All prior admin roles must be revoked by reclaim.
-    /// @dev Error selector: `0x74c75408`
-    error AdminRolesNotFullyRevoked();
 
     ////////////////////////////////////////////////////////////////////////
     // Functions
@@ -39,12 +35,12 @@ interface IWrapperRegistry is IPermissionedRegistry {
     )
         external;
 
-    /// @notice Reclaim the registry from prior ownership.
-    /// @dev Requires `ROLE_WRAPPER_RECLAIM` on token.
-    ///      Reverts `AdminRolesNotFullyRevoked` unless all admins are revoked.
+    /// @notice Reclaim control of the registry.
+    /// @dev Requires `ROLE_WRAPPER_RECLAIM` on token for caller.
+    ///      Requires `ROLE_WRAPPER_RECLAIM` on root for `from`.
+    /// @param from The old root account with `ROLE_WRAPPER_RECLAIM`.
     /// @param to The new root account.
-    /// @param revokes The old root accounts which get fully revoked.
-    function reclaim(address to, address[] calldata revokes) external;
+    function reclaim(address from, address to) external;
 
     /// @notice Returns the DNS-encoded name for this registry.
     function getWrappedName() external view returns (bytes memory);

--- a/contracts/src/registry/libraries/RegistryRolesLib.sol
+++ b/contracts/src/registry/libraries/RegistryRolesLib.sol
@@ -52,6 +52,11 @@ library RegistryRolesLib {
     /// @dev Nybble 41: authorizes setting `ROLE_SET_URI`.
     uint256 internal constant ROLE_SET_URI_ADMIN = ROLE_SET_URI << 128;
 
+    /// @dev Nybble 10: authorizes reclaiming the `WrapperRegistry`. Token-only.
+    uint256 internal constant ROLE_WRAPPER_RECLAIM = 1 << 40;
+    /// @dev Nybble 42: authorizes setting `ROLE_WRAPPER_RECLAIM`.
+    uint256 internal constant ROLE_WRAPPER_RECLAIM_ADMIN = ROLE_WRAPPER_RECLAIM << 128;
+
     /// @dev Nybble 30: authorizes contract naming. Root-only.
     uint256 internal constant ROLE_CAN_NAME = 1 << 120;
     /// @dev Nybble 63: authorizes setting ROLE_CAN_NAME.

--- a/contracts/src/registry/libraries/RegistryRolesLib.sol
+++ b/contracts/src/registry/libraries/RegistryRolesLib.sol
@@ -52,11 +52,6 @@ library RegistryRolesLib {
     /// @dev Nybble 41: authorizes setting `ROLE_SET_URI`.
     uint256 internal constant ROLE_SET_URI_ADMIN = ROLE_SET_URI << 128;
 
-    /// @dev Nybble 10: authorizes reclaiming the `WrapperRegistry`. Token-only.
-    uint256 internal constant ROLE_WRAPPER_RECLAIM = 1 << 40;
-    /// @dev Nybble 42: authorizes setting `ROLE_WRAPPER_RECLAIM`.
-    uint256 internal constant ROLE_WRAPPER_RECLAIM_ADMIN = ROLE_WRAPPER_RECLAIM << 128;
-
     /// @dev Nybble 30: authorizes contract naming. Root-only.
     uint256 internal constant ROLE_CAN_NAME = 1 << 120;
     /// @dev Nybble 63: authorizes setting ROLE_CAN_NAME.

--- a/contracts/test/unit/access-control/libraries/EACBaseRolesLib.t.sol
+++ b/contracts/test/unit/access-control/libraries/EACBaseRolesLib.t.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {EACBaseRolesLib} from "~src/access-control/libraries/EACBaseRolesLib.sol";
+
+contract EACBaseRolesLibTest is Test {
+    function test_withAdminRolesApplied() external pure {
+        assertEq(EACBaseRolesLib.withAdminRolesApplied(EACBaseRolesLib.ALL_ROLES >> 128), 0);
+        assertEq(
+            EACBaseRolesLib.withAdminRolesApplied(EACBaseRolesLib.ADMIN_ROLES),
+            EACBaseRolesLib.ALL_ROLES
+        );
+    }
+
+    function test_withAdminRolesApplied(uint8 i) external pure {
+        vm.assume(i >= 32 && i < 64);
+        uint256 roleBitmap = 1 << (i << 2); // admin bit
+        assertEq(
+            EACBaseRolesLib.withAdminRolesApplied(roleBitmap | (EACBaseRolesLib.ALL_ROLES >> 128)),
+            roleBitmap | (roleBitmap >> 128)
+        );
+    }
+
+    function test_fromCounts() external pure {
+        assertEq(EACBaseRolesLib.fromCounts(0x0123456789abcdef), 0x111111111111111);
+    }
+
+    function test_fromCounts(uint8 i) external pure {
+        vm.assume(i > 0 && i < 16);
+        assertEq(
+            EACBaseRolesLib.fromCounts(EACBaseRolesLib.ALL_ROLES * i),
+            EACBaseRolesLib.ALL_ROLES
+        );
+    }
+
+    function test_hasZeroNybbles() external pure {
+        assertFalse(EACBaseRolesLib.hasZeroNybbles(EACBaseRolesLib.ALL_ROLES));
+    }
+
+    function test_hasZeroNybbles(uint8 i) external pure {
+        vm.assume(i < 64);
+        assertTrue(EACBaseRolesLib.hasZeroNybbles(~(0xF << (i << 2))));
+    }
+}

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -451,6 +451,8 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             RegistryRolesLib.ROLE_SET_RESOLVER |
             RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
             RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
+            RegistryRolesLib.ROLE_WRAPPER_RECLAIM |
+            RegistryRolesLib.ROLE_WRAPPER_RECLAIM_ADMIN |
             RegistryRolesLib.ROLE_WAS_RESERVED
         );
         vm.expectEmit();
@@ -562,6 +564,49 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
+    function test_migrate_transferAndReclaim() external {
+        bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        bytes32 node = NameCoder.namehash(name, 0);
+        LibMigration.Data memory md = _lockedData(name);
+
+        vm.prank(testOwner);
+        nameWrapper.safeTransferFrom(
+            testOwner,
+            address(migrationController),
+            uint256(node),
+            1,
+            abi.encode(md)
+        );
+
+        // transfer token
+        uint256 tokenId = ethRegistry.findTokenId(md.label);
+        vm.prank(testOwner);
+        ethRegistry.safeTransferFrom(testOwner, friend, tokenId, 1, "");
+
+        IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
+
+        uint256 rootRoles = registry.roles(registry.ROOT_RESOURCE(), testOwner);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                tokenId,
+                RegistryRolesLib.ROLE_WRAPPER_RECLAIM,
+                testOwner
+            )
+        );
+        vm.prank(testOwner);
+        registry.reclaim(friend, new address[](0));
+
+        address[] memory revokes = new address[](1);
+        revokes[0] = testOwner;
+        vm.prank(friend);
+        registry.reclaim(friend, revokes);
+
+        assertEq(registry.roles(registry.ROOT_RESOURCE(), testOwner), 0, "old");
+        assertEq(registry.roles(registry.ROOT_RESOURCE(), friend), rootRoles, "new");
+    }
+
     function test_migrate_lockedResolver() external {
         bytes memory name = registerWrappedETH2LD(testLabel, CAN_DO_EVERYTHING);
         bytes32 node = NameCoder.namehash(name, 0);
@@ -663,7 +708,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(md.label));
         assertEq(
             ethRegistry.roles(tokenId, testOwner) & EACBaseRolesLib.ADMIN_ROLES,
-            RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN,
+            RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN | RegistryRolesLib.ROLE_WRAPPER_RECLAIM_ADMIN,
             "token"
         );
         IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -420,7 +420,8 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             RegistryRolesLib.ROLE_RENEW |
             RegistryRolesLib.ROLE_RENEW_ADMIN |
             RegistryRolesLib.ROLE_CAN_NAME |
-            RegistryRolesLib.ROLE_CAN_NAME_ADMIN
+            RegistryRolesLib.ROLE_CAN_NAME_ADMIN |
+            RegistryRolesLib.ROLE_WRAPPER_RECLAIM
         );
         // emit Initializable.Initialized()
         vm.expectEmit();
@@ -587,6 +588,19 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
 
         uint256 rootRoles = registry.roles(registry.ROOT_RESOURCE(), testOwner);
 
+        // prior owner cannot grant admin
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACCannotGrantRoles.selector,
+                registry.ROOT_RESOURCE(),
+                rootRoles,
+                testOwner
+            )
+        );
+        vm.prank(testOwner);
+        registry.grantRootRoles(rootRoles, friend);
+
+        // caller lacks token permission
         vm.expectRevert(
             abi.encodeWithSelector(
                 IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
@@ -596,16 +610,22 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             )
         );
         vm.prank(testOwner);
-        registry.reclaim(friend, new address[](0));
+        registry.reclaim(testOwner, friend);
 
-        address[] memory revokes = new address[](1);
-        vm.expectRevert(abi.encodeWithSelector(IWrapperRegistry.AdminRolesNotFullyRevoked.selector));
+        // from is not the prior owner
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                registry.ROOT_RESOURCE(),
+                RegistryRolesLib.ROLE_WRAPPER_RECLAIM,
+                actor
+            )
+        );
         vm.prank(friend);
-        registry.reclaim(friend, revokes);
+        registry.reclaim(actor, friend);
 
-        revokes[0] = testOwner;
         vm.prank(friend);
-        registry.reclaim(friend, revokes);
+        registry.reclaim(testOwner, friend);
 
         assertEq(registry.roles(registry.ROOT_RESOURCE(), testOwner), 0, "old");
         assertEq(registry.roles(registry.ROOT_RESOURCE(), friend), rootRoles, "new");

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -164,7 +164,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                WrapperRegistry.UpgradeTargetNotApproved.selector,
+                IWrapperRegistry.UpgradeTargetNotApproved.selector,
                 address(newImplementation)
             )
         );
@@ -599,6 +599,10 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         registry.reclaim(friend, new address[](0));
 
         address[] memory revokes = new address[](1);
+        vm.expectRevert(abi.encodeWithSelector(IWrapperRegistry.AdminRolesNotFullyRevoked.selector));
+        vm.prank(friend);
+        registry.reclaim(friend, revokes);
+
         revokes[0] = testOwner;
         vm.prank(friend);
         registry.reclaim(friend, revokes);

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -159,7 +159,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
     }
 
     function test_wrapperRegistryUpgrade_revertsForUnapprovedTarget() external {
-        WrapperRegistry registry = _deployWrapperRegistryProxy(address(this));
+        WrapperRegistry registry = _deployWrapperRegistryProxy();
         WrapperRegistryV2Mock newImplementation = _newWrapperRegistryV2Mock();
 
         vm.expectRevert(
@@ -168,21 +168,24 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
                 address(newImplementation)
             )
         );
+        vm.prank(testOwner);
         registry.upgradeToAndCall(address(newImplementation), "");
     }
 
     function test_wrapperRegistryUpgrade_allowsApprovedTarget() external {
-        WrapperRegistry registry = _deployWrapperRegistryProxy(address(this));
+        WrapperRegistry registry = _deployWrapperRegistryProxy();
         WrapperRegistryV2Mock newImplementation = _newWrapperRegistryV2Mock();
 
         approvedUpgradeGate.setImplementationApproval(address(newImplementation), true);
+
+        vm.prank(testOwner);
         registry.upgradeToAndCall(address(newImplementation), "");
 
         assertEq(WrapperRegistryV2Mock(address(registry)).version(), 2, "version");
     }
 
     function test_wrapperRegistryUpgrade_requiresUpgradeRole() external {
-        WrapperRegistry registry = _deployWrapperRegistryProxy(address(this));
+        WrapperRegistry registry = _deployWrapperRegistryProxy();
         WrapperRegistryV2Mock newImplementation = _newWrapperRegistryV2Mock();
 
         approvedUpgradeGate.setImplementationApproval(address(newImplementation), true);
@@ -411,7 +414,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         vm.expectEmit();
         emit IEnhancedAccessControl.EACRolesChanged(
             0 /*ROOT_RESOURCE*/,
-            md.owner,
+            expectedRegistry,
             0 /*old roles*/,
             RegistryRolesLib.ROLE_UPGRADE |
             RegistryRolesLib.ROLE_UPGRADE_ADMIN |
@@ -420,8 +423,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             RegistryRolesLib.ROLE_RENEW |
             RegistryRolesLib.ROLE_RENEW_ADMIN |
             RegistryRolesLib.ROLE_CAN_NAME |
-            RegistryRolesLib.ROLE_CAN_NAME_ADMIN |
-            RegistryRolesLib.ROLE_WRAPPER_RECLAIM
+            RegistryRolesLib.ROLE_CAN_NAME_ADMIN
         );
         // emit Initializable.Initialized()
         vm.expectEmit();
@@ -452,8 +454,6 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             RegistryRolesLib.ROLE_SET_RESOLVER |
             RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
             RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN |
-            RegistryRolesLib.ROLE_WRAPPER_RECLAIM |
-            RegistryRolesLib.ROLE_WRAPPER_RECLAIM_ADMIN |
             RegistryRolesLib.ROLE_WAS_RESERVED
         );
         vm.expectEmit();
@@ -487,7 +487,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             "IWrapperRegistry"
         );
         assertTrue(
-            subregistry.hasRootRoles(RegistryRolesLib.ROLE_REGISTRAR, md.owner),
+            subregistry.hasRootRoles(RegistryRolesLib.ROLE_REGISTRAR, address(subregistry)),
             "ROLE_REGISTRAR"
         );
         assertEq(
@@ -579,56 +579,31 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             abi.encode(md)
         );
 
-        // transfer token
-        uint256 tokenId = ethRegistry.findTokenId(md.label);
-        vm.prank(testOwner);
-        ethRegistry.safeTransferFrom(testOwner, friend, tokenId, 1, "");
-
         IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
 
-        uint256 rootRoles = registry.roles(registry.ROOT_RESOURCE(), testOwner);
+        assertEq(registry.roles(registry.ROOT_RESOURCE(), testOwner), 0, "old");
+        uint256 rootRoles = registry.roles(registry.ROOT_RESOURCE(), address(registry));
 
-        // prior owner cannot grant admin
+        // owner cannot grant admin
         vm.expectRevert(
             abi.encodeWithSelector(
                 IEnhancedAccessControl.EACCannotGrantRoles.selector,
                 registry.ROOT_RESOURCE(),
                 rootRoles,
-                testOwner
+                address(registry)
             )
         );
         vm.prank(testOwner);
         registry.grantRootRoles(rootRoles, friend);
 
-        // caller lacks token permission
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
-                tokenId,
-                RegistryRolesLib.ROLE_WRAPPER_RECLAIM,
-                testOwner
-            )
-        );
+        // transfer token
+        uint256 tokenId = ethRegistry.findTokenId(md.label);
         vm.prank(testOwner);
-        registry.reclaim(testOwner, friend);
+        ethRegistry.safeTransferFrom(testOwner, friend, tokenId, 1, "");
 
-        // from is not the prior owner
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
-                registry.ROOT_RESOURCE(),
-                RegistryRolesLib.ROLE_WRAPPER_RECLAIM,
-                actor
-            )
-        );
-        vm.prank(friend);
-        registry.reclaim(actor, friend);
-
-        vm.prank(friend);
-        registry.reclaim(testOwner, friend);
-
-        assertEq(registry.roles(registry.ROOT_RESOURCE(), testOwner), 0, "old");
-        assertEq(registry.roles(registry.ROOT_RESOURCE(), friend), rootRoles, "new");
+        // new virtual owner but no roles have changed
+        assertEq(registry.roles(registry.ROOT_RESOURCE(), friend), 0, "new");
+        assertEq(registry.roles(registry.ROOT_RESOURCE(), address(registry)), rootRoles, "virtual");
     }
 
     function test_migrate_lockedResolver() external {
@@ -732,15 +707,14 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         uint256 tokenId = ethRegistry.getTokenId(LibLabel.id(md.label));
         assertEq(
             ethRegistry.roles(tokenId, testOwner) & EACBaseRolesLib.ADMIN_ROLES,
-            RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN | RegistryRolesLib.ROLE_WRAPPER_RECLAIM_ADMIN,
+            RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN,
             "token"
         );
         IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
         assertEq(
-            registry.roles(registry.ROOT_RESOURCE(), testOwner) & EACBaseRolesLib.ADMIN_ROLES,
-            RegistryRolesLib.ROLE_UPGRADE_ADMIN |
-            RegistryRolesLib.ROLE_RENEW_ADMIN |
-            RegistryRolesLib.ROLE_CAN_NAME_ADMIN,
+            registry.roles(registry.ROOT_RESOURCE(), address(registry)) &
+            EACBaseRolesLib.ADMIN_ROLES,
+            0,
             "registry"
         );
     }
@@ -1010,10 +984,14 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         IWrapperRegistry registry2 =
             IWrapperRegistry(address(ethRegistry.getSubregistry(data2.label)));
 
-        // testOwner (parent's root account) holds ROLE_REGISTRAR on registry2 by default,
+        // the registry itself holds ROLE_REGISTRAR on registry2 by default,
         // so they could otherwise re-register the unwrapped emancipated subname in v2
         assertTrue(
-            registry2.hasRoles(registry2.ROOT_RESOURCE(), RegistryRolesLib.ROLE_REGISTRAR, testOwner),
+            registry2.hasRoles(
+                registry2.ROOT_RESOURCE(),
+                RegistryRolesLib.ROLE_REGISTRAR,
+                address(registry2)
+            ),
             "testOwner has ROLE_REGISTRAR on registry2"
         );
         vm.expectRevert(abi.encodeWithSelector(LibMigration.NameRequiresMigration.selector));
@@ -1136,7 +1114,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
-    function _deployWrapperRegistryProxy(address rootAccount) internal returns (WrapperRegistry) {
+    function _deployWrapperRegistryProxy() internal returns (WrapperRegistry) {
         bytes memory name = NameCoder.ethName(testLabel);
         bytes32 node = NameCoder.namehash(name, 0);
         uint256 salt = uint256(node);
@@ -1146,9 +1124,10 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
                 salt,
                 abi.encodeCall(
                     IWrapperRegistry.initialize,
-                    (node, ethRegistry, testLabel, rootAccount, RegistryRolesLib.ROLE_UPGRADE)
+                    (node, ethRegistry, testLabel, RegistryRolesLib.ROLE_UPGRADE)
                 )
             );
+        ethRegistry.register(testLabel, testOwner, IRegistry(proxyAddress), address(0), 0, _soon());
         return WrapperRegistry(proxyAddress);
     }
 

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -398,6 +398,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             _computeVerifiableFactoryAddress(address(migrationController), salt);
         uint64 expectedExpiry =
             uint64(baseRegistrar.nameExpires(tokenIdV1)) + premigrationBonusPeriod;
+        address virtualOwner = address(ethRegistry);
         vm.expectEmit();
         emit IERC1155.TransferSingle(
             testOwner,
@@ -414,7 +415,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         vm.expectEmit();
         emit IEnhancedAccessControl.EACRolesChanged(
             0 /*ROOT_RESOURCE*/,
-            expectedRegistry,
+            virtualOwner,
             0 /*old roles*/,
             RegistryRolesLib.ROLE_UPGRADE |
             RegistryRolesLib.ROLE_UPGRADE_ADMIN |
@@ -487,7 +488,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             "IWrapperRegistry"
         );
         assertTrue(
-            subregistry.hasRootRoles(RegistryRolesLib.ROLE_REGISTRAR, address(subregistry)),
+            subregistry.hasRootRoles(RegistryRolesLib.ROLE_REGISTRAR, address(ethRegistry)),
             "ROLE_REGISTRAR"
         );
         assertEq(
@@ -580,9 +581,10 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
 
         IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
+        address virtualOwner = address(ethRegistry);
 
         assertEq(registry.roles(registry.ROOT_RESOURCE(), testOwner), 0, "old");
-        uint256 rootRoles = registry.roles(registry.ROOT_RESOURCE(), address(registry));
+        uint256 rootRoles = registry.roles(registry.ROOT_RESOURCE(), virtualOwner);
 
         // owner cannot grant admin
         vm.expectRevert(
@@ -590,7 +592,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
                 IEnhancedAccessControl.EACCannotGrantRoles.selector,
                 registry.ROOT_RESOURCE(),
                 rootRoles,
-                address(registry)
+                virtualOwner
             )
         );
         vm.prank(testOwner);
@@ -603,7 +605,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
 
         // new virtual owner but no roles have changed
         assertEq(registry.roles(registry.ROOT_RESOURCE(), friend), 0, "new");
-        assertEq(registry.roles(registry.ROOT_RESOURCE(), address(registry)), rootRoles, "virtual");
+        assertEq(registry.roles(registry.ROOT_RESOURCE(), virtualOwner), rootRoles, "virtual");
     }
 
     function test_migrate_lockedResolver() external {
@@ -711,9 +713,9 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             "token"
         );
         IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
+        address virtualOwner = address(ethRegistry);
         assertEq(
-            registry.roles(registry.ROOT_RESOURCE(), address(registry)) &
-            EACBaseRolesLib.ADMIN_ROLES,
+            registry.roles(registry.ROOT_RESOURCE(), virtualOwner) & EACBaseRolesLib.ADMIN_ROLES,
             0,
             "registry"
         );
@@ -983,6 +985,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
         IWrapperRegistry registry2 =
             IWrapperRegistry(address(ethRegistry.getSubregistry(data2.label)));
+        address virtualOwner = address(ethRegistry);
 
         // the registry itself holds ROLE_REGISTRAR on registry2 by default,
         // so they could otherwise re-register the unwrapped emancipated subname in v2
@@ -990,7 +993,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
             registry2.hasRoles(
                 registry2.ROOT_RESOURCE(),
                 RegistryRolesLib.ROLE_REGISTRAR,
-                address(registry2)
+                virtualOwner
             ),
             "testOwner has ROLE_REGISTRAR on registry2"
         );


### PR DESCRIPTION
- changed `WrapperRegistry` to have at most one account with admin
    * roles granted to "virtual owner" — actual owner is parent registry
    * `_msgSender()` remaps from token owner to "virtual owner"
- changed `WrapperRegistry` to respect frozen `NameWrapper` fuses for `ROLE_RENEW`, `ROLE_UPGRADE`, and `ROLE_CAN_NAME` (like `ROLE_REGISTRAR`)
