### PR TITLE
Leverage `PermissionRegistry.setApprovalForAll()` in `EAC`

### DIFF
--- a/contracts/src/access-control/EnhancedAccessControl.sol
+++ b/contracts/src/access-control/EnhancedAccessControl.sol
@@ -170,7 +170,7 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
 
     /// @inheritdoc IEnhancedAccessControl
     function roles(uint256 resource, address account) public view virtual returns (uint256) {
-        return _roles[resource][account];
+        return _getRoles(resource, account);
     }
 
     /// @inheritdoc IEnhancedAccessControl
@@ -180,7 +180,7 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
 
     /// @inheritdoc IEnhancedAccessControl
     function hasRootRoles(uint256 roleBitmap, address account) public view virtual returns (bool) {
-        return _roles[ROOT_RESOURCE][account] & roleBitmap == roleBitmap;
+        return _getRoles(ROOT_RESOURCE, account) & roleBitmap == roleBitmap;
     }
 
     /// @inheritdoc IEnhancedAccessControl
@@ -191,7 +191,8 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         returns (bool)
     {
         return
-            (_roles[ROOT_RESOURCE][account] | _roles[resource][account]) & roleBitmap == roleBitmap;
+            (_getRoles(ROOT_RESOURCE, account) | _getRoles(resource, account)) & roleBitmap ==
+            roleBitmap;
     }
 
     /// @inheritdoc IEnhancedAccessControl
@@ -424,6 +425,7 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         virtual
         returns (uint256)
     {
+        account = _getUnderlyingAccount(resource, account);
         return
             EACBaseRolesLib.withAdminRolesApplied(
                 _roles[resource][account] | _roles[ROOT_RESOURCE][account]
@@ -443,15 +445,31 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         virtual
         returns (uint256)
     {
+        account = _getUnderlyingAccount(resource, account);
         return
             EACBaseRolesLib.withAdminRolesApplied(
                 _roles[resource][account] | _roles[ROOT_RESOURCE][account]
             );
     }
 
+    /// @dev Returns the underlying account with permissions.
+    function _getUnderlyingAccount(uint256 resource, address operator)
+        internal
+        view
+        virtual
+        returns (address)
+    {
+        return operator;
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // Private Functions
     ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Returns the roles bitmap for an account in a resource.
+    function _getRoles(uint256 resource, address account) private view returns (uint256) {
+        return _roles[resource][_getUnderlyingAccount(resource, account)];
+    }
 
     /// @dev Checks if a role bitmap contains only valid role bits.
     /// @param roleBitmap The role bitmap to check.

--- a/contracts/src/access-control/EnhancedAccessControl.sol
+++ b/contracts/src/access-control/EnhancedAccessControl.sol
@@ -190,9 +190,7 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         virtual
         returns (bool)
     {
-        return
-            (_getRoles(ROOT_RESOURCE, account) | _getRoles(resource, account)) & roleBitmap ==
-            roleBitmap;
+        return _getEffectiveRoles(resource, account) & roleBitmap == roleBitmap;
     }
 
     /// @inheritdoc IEnhancedAccessControl
@@ -426,10 +424,7 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         returns (uint256)
     {
         account = _getUnderlyingAccount(resource, account);
-        return
-            EACBaseRolesLib.withAdminRolesApplied(
-                _roles[resource][account] | _roles[ROOT_RESOURCE][account]
-            );
+        return EACBaseRolesLib.withAdminRolesApplied(_getEffectiveRoles(resource, account));
     }
 
     /// @dev Returns the revokable roles for `account` within `resource`.
@@ -445,11 +440,7 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         virtual
         returns (uint256)
     {
-        account = _getUnderlyingAccount(resource, account);
-        return
-            EACBaseRolesLib.withAdminRolesApplied(
-                _roles[resource][account] | _roles[ROOT_RESOURCE][account]
-            );
+        return EACBaseRolesLib.withAdminRolesApplied(_getEffectiveRoles(resource, account));
     }
 
     /// @dev Returns the underlying account with permissions.
@@ -469,6 +460,11 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
     /// @dev Returns the roles bitmap for an account in a resource.
     function _getRoles(uint256 resource, address account) private view returns (uint256) {
         return _roles[resource][_getUnderlyingAccount(resource, account)];
+    }
+
+    /// @dev Returns the effective roles bitmap for an account.
+    function _getEffectiveRoles(uint256 resource, address account) private view returns (uint256) {
+        return _getRoles(ROOT_RESOURCE, account) | _getRoles(resource, account);
     }
 
     /// @dev Checks if a role bitmap contains only valid role bits.

--- a/contracts/src/access-control/EnhancedAccessControl.sol
+++ b/contracts/src/access-control/EnhancedAccessControl.sol
@@ -170,7 +170,7 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
 
     /// @inheritdoc IEnhancedAccessControl
     function roles(uint256 resource, address account) public view virtual returns (uint256) {
-        return _getRoles(resource, account);
+        return _checkedRoles(resource, account);
     }
 
     /// @inheritdoc IEnhancedAccessControl
@@ -180,7 +180,7 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
 
     /// @inheritdoc IEnhancedAccessControl
     function hasRootRoles(uint256 roleBitmap, address account) public view virtual returns (bool) {
-        return _getRoles(ROOT_RESOURCE, account) & roleBitmap == roleBitmap;
+        return _checkedRoles(ROOT_RESOURCE, account) & roleBitmap == roleBitmap;
     }
 
     /// @inheritdoc IEnhancedAccessControl
@@ -190,7 +190,7 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         virtual
         returns (bool)
     {
-        return _getEffectiveRoles(resource, account) & roleBitmap == roleBitmap;
+        return _effectiveRoles(resource, account) & roleBitmap == roleBitmap;
     }
 
     /// @inheritdoc IEnhancedAccessControl
@@ -423,8 +423,7 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         virtual
         returns (uint256)
     {
-        account = _getUnderlyingAccount(resource, account);
-        return EACBaseRolesLib.withAdminRolesApplied(_getEffectiveRoles(resource, account));
+        return EACBaseRolesLib.withAdminRolesApplied(_effectiveRoles(resource, account));
     }
 
     /// @dev Returns the revokable roles for `account` within `resource`.
@@ -440,35 +439,26 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         virtual
         returns (uint256)
     {
-        return EACBaseRolesLib.withAdminRolesApplied(_getEffectiveRoles(resource, account));
+        return EACBaseRolesLib.withAdminRolesApplied(_effectiveRoles(resource, account));
     }
 
-    /// @dev Returns the underlying account with permissions.
-    function _getUnderlyingAccount(uint256 resource, address operator)
+    /// @dev Returns the effective roles bitmap for an account.
+    function _checkedRoles(uint256 resource, address account)
         internal
         view
         virtual
-        returns (address)
+        returns (uint256)
     {
-        return operator;
+        return _roles[resource][account];
     }
 
     ////////////////////////////////////////////////////////////////////////
     // Private Functions
     ////////////////////////////////////////////////////////////////////////
 
-    /// @dev Returns the roles bitmap for an account in a resource.
-    function _getRoles(uint256 resource, address account) private view returns (uint256 roleBitmap) {
-        roleBitmap = _roles[resource][account];
-        address underlying = _getUnderlyingAccount(resource, account);
-        if (underlying != address(0) && underlying != account) {
-            roleBitmap |= _roles[resource][underlying];
-        }
-    }
-
     /// @dev Returns the effective roles bitmap for an account.
-    function _getEffectiveRoles(uint256 resource, address account) private view returns (uint256) {
-        return _getRoles(ROOT_RESOURCE, account) | _getRoles(resource, account);
+    function _effectiveRoles(uint256 resource, address account) private view returns (uint256) {
+        return _checkedRoles(ROOT_RESOURCE, account) | _checkedRoles(resource, account);
     }
 
     /// @dev Checks if a role bitmap contains only valid role bits.

--- a/contracts/src/access-control/EnhancedAccessControl.sol
+++ b/contracts/src/access-control/EnhancedAccessControl.sol
@@ -170,7 +170,7 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
 
     /// @inheritdoc IEnhancedAccessControl
     function roles(uint256 resource, address account) public view virtual returns (uint256) {
-        return _checkedRoles(resource, account);
+        return _getRoles(resource, account);
     }
 
     /// @inheritdoc IEnhancedAccessControl
@@ -180,7 +180,7 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
 
     /// @inheritdoc IEnhancedAccessControl
     function hasRootRoles(uint256 roleBitmap, address account) public view virtual returns (bool) {
-        return _checkedRoles(ROOT_RESOURCE, account) & roleBitmap == roleBitmap;
+        return _getRoles(ROOT_RESOURCE, account) & roleBitmap == roleBitmap;
     }
 
     /// @inheritdoc IEnhancedAccessControl
@@ -442,13 +442,8 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
         return EACBaseRolesLib.withAdminRolesApplied(_effectiveRoles(resource, account));
     }
 
-    /// @dev Returns the effective roles bitmap for an account.
-    function _checkedRoles(uint256 resource, address account)
-        internal
-        view
-        virtual
-        returns (uint256)
-    {
+    /// @dev Returns the roles bitmap for an account for permission checks.
+    function _getRoles(uint256 resource, address account) internal view virtual returns (uint256) {
         return _roles[resource][account];
     }
 
@@ -456,9 +451,9 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
     // Private Functions
     ////////////////////////////////////////////////////////////////////////
 
-    /// @dev Returns the effective roles bitmap for an account.
+    /// @dev Returns the effective roles bitmap for an account for permission checks.
     function _effectiveRoles(uint256 resource, address account) private view returns (uint256) {
-        return _checkedRoles(ROOT_RESOURCE, account) | _checkedRoles(resource, account);
+        return _getRoles(ROOT_RESOURCE, account) | _getRoles(resource, account);
     }
 
     /// @dev Checks if a role bitmap contains only valid role bits.

--- a/contracts/src/access-control/EnhancedAccessControl.sol
+++ b/contracts/src/access-control/EnhancedAccessControl.sol
@@ -458,8 +458,12 @@ abstract contract EnhancedAccessControl is HCAContext, ERC165, IEnhancedAccessCo
     ////////////////////////////////////////////////////////////////////////
 
     /// @dev Returns the roles bitmap for an account in a resource.
-    function _getRoles(uint256 resource, address account) private view returns (uint256) {
-        return _roles[resource][_getUnderlyingAccount(resource, account)];
+    function _getRoles(uint256 resource, address account) private view returns (uint256 roleBitmap) {
+        roleBitmap = _roles[resource][account];
+        address underlying = _getUnderlyingAccount(resource, account);
+        if (underlying != address(0) && underlying != account) {
+            roleBitmap |= _roles[resource][underlying];
+        }
     }
 
     /// @dev Returns the effective roles bitmap for an account.

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -581,20 +581,20 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
     /// * if token is expired (available or reserved), return null.
     /// * if caller is approved by token, return token owner.
     ///
-    function _getUnderlyingAccount(uint256 resource, address operator)
+    function _checkedRoles(uint256 resource, address operator)
         internal
         view
         virtual
         override
-        returns (address)
+        returns (uint256 roleBitmap)
     {
+        roleBitmap = super._checkedRoles(resource, operator);
         if (resource != ROOT_RESOURCE) {
             address owner = ownerOf(_constructTokenId(resource, _entry(resource)));
-            if (owner == address(0) || isApprovedForAll(owner, operator)) {
-                return owner;
+            if (owner != address(0) && isApprovedForAll(owner, operator)) {
+                roleBitmap |= super._checkedRoles(resource, owner);
             }
         }
-        return operator;
     }
 
     /// @dev Zeroes version bits in `anyId` to return the canonical storage entry for the name.

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -581,18 +581,18 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
     /// * if token is expired (available or reserved), return null.
     /// * if caller is approved by token owner, OR the caller's roles with the owner's roles
     ///
-    function _checkedRoles(uint256 resource, address operator)
+    function _getRoles(uint256 resource, address operator)
         internal
         view
         virtual
         override
         returns (uint256 roleBitmap)
     {
-        roleBitmap = super._checkedRoles(resource, operator);
+        roleBitmap = super._getRoles(resource, operator);
         if (resource != ROOT_RESOURCE) {
             address owner = ownerOf(_constructTokenId(resource, _entry(resource)));
             if (owner != address(0) && isApprovedForAll(owner, operator)) {
-                roleBitmap |= super._checkedRoles(resource, owner);
+                roleBitmap |= super._getRoles(resource, owner);
             }
         }
     }

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -572,34 +572,29 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
         returns (uint256)
     {
         uint256 roleBitmap = super._getSettableRoles(resource, account);
-        if (resource == ROOT_RESOURCE) {
-            return roleBitmap;
-        } else if (ownerOf(_constructTokenId(resource, _entry(resource))) == address(0)) {
-            return 0; // available or reserved
-        }
-        return roleBitmap >> 128; // remove admin
+        return resource == ROOT_RESOURCE ? roleBitmap : roleBitmap >> 128;
     }
 
     /// @inheritdoc EnhancedAccessControl
     /// @dev Override for token-dependent logic:
     ///
-    /// Token roles can only be revoked from registered tokens.
+    /// * if token is expired (available or reserved), return null.
+    /// * if caller is approved by token, return token owner.
     ///
-    /// Root roles are unaffected.
-    ///
-    function _getRevokableRoles(uint256 resource, address account)
+    function _getUnderlyingAccount(uint256 resource, address operator)
         internal
         view
+        virtual
         override
-        returns (uint256)
+        returns (address)
     {
-        if (
-            resource != ROOT_RESOURCE &&
-            ownerOf(_constructTokenId(resource, _entry(resource))) == address(0)
-        ) {
-            return 0; // available or reserved
+        if (resource != ROOT_RESOURCE) {
+            address owner = ownerOf(_constructTokenId(resource, _entry(resource)));
+            if (owner == address(0) || isApprovedForAll(owner, operator)) {
+                return owner;
+            }
         }
-        return super._getRevokableRoles(resource, account);
+        return operator;
     }
 
     /// @dev Zeroes version bits in `anyId` to return the canonical storage entry for the name.

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -581,17 +581,17 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
     /// * if token is expired (available or reserved), return null.
     /// * if caller is approved by token owner, OR the caller's roles with the owner's roles
     ///
-    function _getRoles(uint256 resource, address operator)
+    function _getRoles(uint256 resource, address account)
         internal
         view
         virtual
         override
         returns (uint256 roleBitmap)
     {
-        roleBitmap = super._getRoles(resource, operator);
+        roleBitmap = super._getRoles(resource, account);
         if (resource != ROOT_RESOURCE) {
             address owner = ownerOf(_constructTokenId(resource, _entry(resource)));
-            if (owner != address(0) && isApprovedForAll(owner, operator)) {
+            if (owner != address(0) && isApprovedForAll(owner, account)) {
                 roleBitmap |= super._getRoles(resource, owner);
             }
         }

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -579,7 +579,7 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
     /// @dev Override for token-dependent logic:
     ///
     /// * if token is expired (available or reserved), return null.
-    /// * if caller is approved by token, return token owner.
+    /// * if caller is approved by token owner, OR the caller's roles with the owner's roles
     ///
     function _checkedRoles(uint256 resource, address operator)
         internal

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -14,7 +14,6 @@ import {AbstractWrapperReceiver} from "../migration/AbstractWrapperReceiver.sol"
 import {LibMigration} from "../migration/libraries/LibMigration.sol";
 import {LockedWrapperReceiver} from "../migration/LockedWrapperReceiver.sol";
 import {IWrapperRegistry} from "../registry/interfaces/IWrapperRegistry.sol";
-import {IContractNamer} from "../reverse-registrar/interfaces/IContractNamer.sol";
 import {IAddressSet} from "../utils/interfaces/IAddressSet.sol";
 import {ILabelStore} from "../utils/interfaces/ILabelStore.sol";
 import {LibLabel} from "../utils/LibLabel.sol";
@@ -203,17 +202,6 @@ contract WrapperRegistry is
         returns (bytes32)
     {
         return _node;
-    }
-
-    /// @inheritdoc PermissionedRegistry
-    /// @dev Respect virtual owner.
-    function isContractNamer(address namer)
-        public
-        view
-        override(IContractNamer, PermissionedRegistry)
-        returns (bool)
-    {
-        return hasRootRoles(RegistryRolesLib.ROLE_CAN_NAME, namer);
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -246,20 +246,20 @@ contract WrapperRegistry is
     /// @inheritdoc PermissionedRegistry
     /// @dev Override for token-dependent logic:
     ///
-    /// * if root and operator is token owner, remap to virtual owner.
+    /// * if root and account is token owner, remap to virtual owner.
     ///
-    function _getRoles(uint256 resource, address operator)
+    function _getRoles(uint256 resource, address account)
         internal
         view
         override
         returns (uint256 roleBitmap)
     {
-        roleBitmap = super._getRoles(resource, operator);
+        roleBitmap = super._getRoles(resource, account);
         if (resource == ROOT_RESOURCE) {
             address parent = address(_parentRegistry); // virtual owner
             if (
                 parent != address(0) &&
-                operator == PermissionedRegistry(parent).findOwner(_childLabel)
+                account == PermissionedRegistry(parent).findOwner(_childLabel)
             ) {
                 roleBitmap = super._getRoles(resource, parent); // replace, instead of OR
             }

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -261,7 +261,7 @@ contract WrapperRegistry is
                 parent != address(0) &&
                 operator == PermissionedRegistry(parent).findOwner(_childLabel)
             ) {
-                roleBitmap |= super._checkedRoles(resource, parent);
+                roleBitmap = super._checkedRoles(resource, parent); // replace, instead of OR
             }
         }
     }

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -248,20 +248,20 @@ contract WrapperRegistry is
     ///
     /// * if root and operator is token owner, remap to virtual owner.
     ///
-    function _checkedRoles(uint256 resource, address operator)
+    function _getRoles(uint256 resource, address operator)
         internal
         view
         override
         returns (uint256 roleBitmap)
     {
-        roleBitmap = super._checkedRoles(resource, operator);
+        roleBitmap = super._getRoles(resource, operator);
         if (resource == ROOT_RESOURCE) {
             address parent = address(_parentRegistry); // virtual owner
             if (
                 parent != address(0) &&
                 operator == PermissionedRegistry(parent).findOwner(_childLabel)
             ) {
-                roleBitmap = super._checkedRoles(resource, parent); // replace, instead of OR
+                roleBitmap = super._getRoles(resource, parent); // replace, instead of OR
             }
         }
     }

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -213,7 +213,8 @@ contract WrapperRegistry is
         override(IContractNamer, PermissionedRegistry)
         returns (bool)
     {
-        return hasRootRoles(RegistryRolesLib.ROLE_CAN_NAME, _remapVirtualOwner(namer));
+        return
+            hasRootRoles(RegistryRolesLib.ROLE_CAN_NAME, _getUnderlyingAccount(ROOT_RESOURCE, namer));
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -258,7 +259,7 @@ contract WrapperRegistry is
     /// @inheritdoc PermissionedRegistry
     /// @dev Override for token-dependent logic:
     ///
-    /// * if root, remap underlying account.
+    /// * if root and operator is token owner, remap to virtual owner.
     ///
     function _getUnderlyingAccount(uint256 resource, address operator)
         internal
@@ -268,7 +269,13 @@ contract WrapperRegistry is
     {
         account = super._getUnderlyingAccount(resource, operator);
         if (resource == ROOT_RESOURCE) {
-            account = _remapVirtualOwner(account);
+            address parent = address(_parentRegistry); // virtual owner
+            if (
+                parent != address(0) &&
+                account == PermissionedRegistry(parent).findOwner(_childLabel)
+            ) {
+                account = parent;
+            }
         }
     }
 
@@ -303,14 +310,5 @@ contract WrapperRegistry is
         // and reserving the label would lock it forever; positive expiry on either
         // side marks a completed migration.
         return LibMigration.isEmancipatedChild(fuses) && _REGISTRY_V1.owner(node) != address(0);
-    }
-
-    /// @dev If `account` is the token owner, return the virtual owner. 
-    function _remapVirtualOwner(address account) internal view returns (address) {
-        address parent = address(_parentRegistry); // virtual owner
-        return
-            parent != address(0) && account == PermissionedRegistry(parent).findOwner(_childLabel)
-                ? parent
-                : account;
     }
 }

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -213,7 +213,7 @@ contract WrapperRegistry is
         override(IContractNamer, PermissionedRegistry)
         returns (bool)
     {
-        return hasRootRoles(RegistryRolesLib.ROLE_CAN_NAME, _remapVirtualOwner(namer));
+        return hasRootRoles(RegistryRolesLib.ROLE_CAN_NAME, namer);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -268,9 +268,12 @@ contract WrapperRegistry is
     {
         roleBitmap = super._checkedRoles(resource, operator);
         if (resource == ROOT_RESOURCE) {
-            address virtualOwner = _remapVirtualOwner(operator);
-            if (virtualOwner != operator) {
-                roleBitmap |= super._checkedRoles(resource, virtualOwner);
+            address parent = address(_parentRegistry); // virtual owner
+            if (
+                parent != address(0) &&
+                operator == PermissionedRegistry(parent).findOwner(_childLabel)
+            ) {
+                roleBitmap |= super._checkedRoles(resource, parent);
             }
         }
     }
@@ -306,14 +309,5 @@ contract WrapperRegistry is
         // and reserving the label would lock it forever; positive expiry on either
         // side marks a completed migration.
         return LibMigration.isEmancipatedChild(fuses) && _REGISTRY_V1.owner(node) != address(0);
-    }
-
-    /// @dev If `account` is the token owner, return the virtual owner. 
-    function _remapVirtualOwner(address account) internal view returns (address) {
-        address parent = address(_parentRegistry); // virtual owner
-        return
-            parent != address(0) && account == PermissionedRegistry(parent).findOwner(_childLabel)
-                ? parent
-                : account;
     }
 }

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -213,8 +213,7 @@ contract WrapperRegistry is
         override(IContractNamer, PermissionedRegistry)
         returns (bool)
     {
-        return
-            hasRootRoles(RegistryRolesLib.ROLE_CAN_NAME, _getUnderlyingAccount(ROOT_RESOURCE, namer));
+        return hasRootRoles(RegistryRolesLib.ROLE_CAN_NAME, _remapVirtualOwner(namer));
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -261,20 +260,17 @@ contract WrapperRegistry is
     ///
     /// * if root and operator is token owner, remap to virtual owner.
     ///
-    function _getUnderlyingAccount(uint256 resource, address operator)
+    function _checkedRoles(uint256 resource, address operator)
         internal
         view
         override
-        returns (address account)
+        returns (uint256 roleBitmap)
     {
-        account = super._getUnderlyingAccount(resource, operator);
+        roleBitmap = super._checkedRoles(resource, operator);
         if (resource == ROOT_RESOURCE) {
-            address parent = address(_parentRegistry); // virtual owner
-            if (
-                parent != address(0) &&
-                account == PermissionedRegistry(parent).findOwner(_childLabel)
-            ) {
-                account = parent;
+            address virtualOwner = _remapVirtualOwner(operator);
+            if (virtualOwner != operator) {
+                roleBitmap |= super._checkedRoles(resource, virtualOwner);
             }
         }
     }
@@ -310,5 +306,14 @@ contract WrapperRegistry is
         // and reserving the label would lock it forever; positive expiry on either
         // side marks a completed migration.
         return LibMigration.isEmancipatedChild(fuses) && _REGISTRY_V1.owner(node) != address(0);
+    }
+
+    /// @dev If `account` is the token owner, return the virtual owner. 
+    function _remapVirtualOwner(address account) internal view returns (address) {
+        address parent = address(_parentRegistry); // virtual owner
+        return
+            parent != address(0) && account == PermissionedRegistry(parent).findOwner(_childLabel)
+                ? parent
+                : account;
     }
 }

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -9,7 +9,6 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
-import {HCAContext} from "../hca/HCAContext.sol";
 import {IHCAFactoryBasic} from "../hca/interfaces/IHCAFactoryBasic.sol";
 import {AbstractWrapperReceiver} from "../migration/AbstractWrapperReceiver.sol";
 import {LibMigration} from "../migration/libraries/LibMigration.sol";
@@ -238,12 +237,6 @@ contract WrapperRegistry is
         return _register(label, owner, subregistry, resolver, roleBitmap, expiry, false);
     }
 
-    /// @inheritdoc HCAContext
-    /// @dev Respect virtual owner.
-    function _msgSender() internal view override returns (address) {
-        return _remapVirtualOwner(super._msgSender());
-    }
-
     /// @inheritdoc PermissionedRegistry
     /// @dev Override for token-dependent logic:
     ///
@@ -260,6 +253,23 @@ contract WrapperRegistry is
     {
         uint256 roleBitmap = super._getSettableRoles(resource, account);
         return resource == ROOT_RESOURCE ? roleBitmap >> 128 : roleBitmap;
+    }
+
+    /// @inheritdoc PermissionedRegistry
+    /// @dev Override for token-dependent logic:
+    ///
+    /// * if root, remap underlying account.
+    ///
+    function _getUnderlyingAccount(uint256 resource, address operator)
+        internal
+        view
+        override
+        returns (address account)
+    {
+        account = super._getUnderlyingAccount(resource, operator);
+        if (resource == ROOT_RESOURCE) {
+            account = _remapVirtualOwner(account);
+        }
     }
 
     /// @dev Requires `ROLE_UPGRADE` and approval for the target implementation.

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -583,8 +583,9 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         IWrapperRegistry registry = IWrapperRegistry(address(ethRegistry.getSubregistry(md.label)));
         address virtualOwner = address(ethRegistry);
 
-        assertEq(registry.roles(registry.ROOT_RESOURCE(), testOwner), 0, "old");
         uint256 rootRoles = registry.roles(registry.ROOT_RESOURCE(), virtualOwner);
+        assertEq(registry.roles(registry.ROOT_RESOURCE(), testOwner), rootRoles, "before:owner");
+        assertEq(registry.roles(registry.ROOT_RESOURCE(), friend), 0, "before:friend");
 
         // owner cannot grant admin
         vm.expectRevert(
@@ -592,7 +593,7 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
                 IEnhancedAccessControl.EACCannotGrantRoles.selector,
                 registry.ROOT_RESOURCE(),
                 rootRoles,
-                virtualOwner
+                testOwner
             )
         );
         vm.prank(testOwner);
@@ -603,8 +604,11 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         vm.prank(testOwner);
         ethRegistry.safeTransferFrom(testOwner, friend, tokenId, 1, "");
 
-        // new virtual owner but no roles have changed
-        assertEq(registry.roles(registry.ROOT_RESOURCE(), friend), 0, "new");
+        // effective roles have "transferred"
+        assertEq(registry.roles(registry.ROOT_RESOURCE(), testOwner), 0, "after:owner");
+        assertEq(registry.roles(registry.ROOT_RESOURCE(), friend), rootRoles, "after:friend");
+
+        // underlying virtual owner roles are unchanged
         assertEq(registry.roles(registry.ROOT_RESOURCE(), virtualOwner), rootRoles, "virtual");
     }
 

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -1283,6 +1283,27 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         registry.grantRoles(tokenId, testRoles, actor);
     }
 
+    function test_setApprovalForAll_blended() external {
+        testRoles = RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN;
+        uint256 tokenId = this._register();
+
+        // user2 has approved roles
+        vm.prank(testOwner);
+        registry.setApprovalForAll(user2, true);
+
+        // user2 also has root roles
+        registry.grantRootRoles(RegistryRolesLib.ROLE_SET_SUBREGISTRY_ADMIN, user2);
+
+        assertTrue(
+            registry.hasRoles(
+                tokenId,
+                RegistryRolesLib.ROLE_SET_RESOLVER_ADMIN |
+                RegistryRolesLib.ROLE_SET_SUBREGISTRY_ADMIN,
+                user2
+            )
+        );
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // IContractNamer
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -1240,15 +1240,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         uint256 tokenId = this._register();
         vm.warp(testExpiry);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IEnhancedAccessControl.EACCannotRevokeRoles.selector,
-                tokenId + 1, // next
-                testRoles,
-                address(this)
-            )
-        );
-        registry.revokeRoles(tokenId, testRoles, testOwner);
+        assertFalse(registry.revokeRoles(tokenId, testRoles, testOwner));
     }
 
     function test_revokeRoles_whileReserved(uint256) external {
@@ -1256,15 +1248,39 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
 
         uint256 tokenId = this._reserve();
 
+        assertFalse(registry.revokeRoles(tokenId, roleBitmap, testOwner));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // EAC + setApprovalForAll()
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_setApprovalForAll_roles() external {
+        testRoles = _randomRoleBitmap(true, false);
+        uint256 tokenId = this._register();
+        testRoles >>= 128; // convert to normal
+
+        vm.prank(testOwner);
+        registry.setApprovalForAll(user2, true);
+
+        vm.prank(user2);
+        registry.grantRoles(tokenId, testRoles, actor);
+        vm.prank(user2);
+        registry.revokeRoles(tokenId, testRoles, actor);
+
+        vm.prank(testOwner);
+        registry.setApprovalForAll(user2, false);
+
         vm.expectRevert(
             abi.encodeWithSelector(
-                IEnhancedAccessControl.EACCannotRevokeRoles.selector,
+                IEnhancedAccessControl.EACCannotGrantRoles.selector,
                 tokenId, // same as resource
-                roleBitmap,
-                address(this)
+                testRoles,
+                user2
             )
         );
-        registry.revokeRoles(tokenId, roleBitmap, testOwner);
+        vm.prank(user2);
+        registry.grantRoles(tokenId, testRoles, actor);
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -351,6 +351,7 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         uint256 tokenId = this._reserve();
         vm.warp(testExpiry);
         testExpiry += testExpiry;
+
         registry.renew(tokenId, testExpiry);
         assertEq(registry.getExpiry(tokenId), testExpiry);
     }


### PR DESCRIPTION
- changed `EnhancedAccessControl`
    * added virtual `_getRoles(resource, account): roles` which permits logic <ins>before</ins> permission checks
    * added private `_effectiveRoles(resource, account)` which is root + resource
    * refactored to utilize those functions
- changed `PermissionedRegistry`
    * overrode `_getRoles()` to account for token expiry and approval 
    * simplified `_getSettableRoles()` and `_getRevokableRoles()` since `_checkedRoles()` already handles expiry
- changed `WrapperRegistry`
    * removed `_msgSender()` hack
    * removed `IContractNamer` override
    * overrode `_getRoles()` to account for virtual owner — applies <ins>after</ins> expiry and approval checks, so approvals are not virtualized and do not survive transfer

---

* `EAC` reverts use the caller address
* `PermissionRegistry.roles()` returns the same roles for the token owner AND virtual owner AND approved
* `test_revokeRoles_whileReserved()` returns false instead of reverting
* `test_revokeRoles_whileExpired()` returns false instead of reverting