### PR TITLE
Improved Coverage

### DIFF
--- a/contracts/foundry.lock
+++ b/contracts/foundry.lock
@@ -3,7 +3,7 @@
     "rev": "82cc81935de1d1a82e021cf1030d902c5248982b"
   },
   "lib/ens-contracts": {
-    "rev": "5787a5fd9eaff6cdba3d9d23d3ce4ec2b50d4e4d"
+    "rev": "eaedc777fdf0510af7beb76efecde54d06458457"
   },
   "lib/forge-std": {
     "rev": "77041d2ce690e692d6e03cc812b57d1ddaa4d505"

--- a/contracts/script/deploy-constants.ts
+++ b/contracts/script/deploy-constants.ts
@@ -43,6 +43,11 @@ const FLAGS = {
     DISABLE_TOKEN: 1n << 4n,
     CAN_NAME: 1n << 8n,
   },
+  // see: PermissionedAddressSet.sol
+  ADDRESS_SET: {
+    APPROVE: 1n << 0n,
+    CAN_NAME: 1n << 4n,
+  },
 } as const satisfies Flags;
 
 function adminify(flags: Flags): Flags {

--- a/contracts/script/deploy-constants.ts
+++ b/contracts/script/deploy-constants.ts
@@ -41,6 +41,7 @@ const FLAGS = {
   ORACLE: {
     UPDATE_TOKEN: 1n << 0n,
     DISABLE_TOKEN: 1n << 4n,
+    CAN_NAME: 1n << 8n,
   },
 } as const satisfies Flags;
 
@@ -133,8 +134,8 @@ export const FUSE_MASKS = {
 } as const;
 
 // see: StandardRegistrar.sol
-export const SEC_PER_YEAR = 31_557_600n;
 export const SEC_PER_DAY = 86400n;
+export const SEC_PER_YEAR = 365n * SEC_PER_DAY;
 
 export const MIN_COMMITMENT_AGE = 60n; // 1 minute
 export const MAX_COMMITMENT_AGE = SEC_PER_DAY;

--- a/contracts/script/solVersions.ts
+++ b/contracts/script/solVersions.ts
@@ -10,34 +10,34 @@ type Contract = { spec: string; file: string };
 const specs: string[] = [];
 
 function uniqueColor(spec: string) {
-	let i = specs.indexOf(spec);
-	if (i < 0) {
-		i = specs.length;
-		specs.push(spec);
-	}
-	return `\x1b[${91 + (i % 6)}m${spec}\x1b[0m`;
+  let i = specs.indexOf(spec);
+  if (i < 0) {
+    i = specs.length;
+    specs.push(spec);
+  }
+  return `\x1b[${91 + (i % 6)}m${spec}\x1b[0m`;
 }
 
-find(fileURLToPath(new URL("../src/", import.meta.url)))
-	.sort(
-		(a, b) => a.spec.localeCompare(b.spec) || a.file.localeCompare(b.file)
-	)
-	.forEach((x) => console.log(uniqueColor(x.spec.padEnd(10)), x.file));
+const rootDir = fileURLToPath(new URL("../", import.meta.url));
+["src", "test"]
+  .flatMap((x) => find(join(rootDir, x), rootDir.length))
+  .sort((a, b) => a.spec.localeCompare(b.spec) || a.file.localeCompare(b.file))
+  .forEach((x) => console.log(uniqueColor(x.spec.padEnd(10)), x.file));
 
-function find(dir: string, found: Contract[] = [], skip = dir.length) {
-	for (const x of readdirSync(dir, { withFileTypes: true })) {
-		const path = join(dir, x.name);
-		if (x.isDirectory()) {
-			find(path, found, skip);
-		} else if (x.name.endsWith(".sol")) {
-			const code = readFileSync(path, { encoding: "utf-8" });
-			const match = code.match(/^pragma solidity (.*?);/m);
-			if (!match) throw new Error(`expected pragma: ${path}`);
-			found.push({
-				spec: match[1].trim(),
-				file: path.slice(skip),
-			});
-		}
-	}
-	return found;
+function find(dir: string, skip = dir.length, found: Contract[] = []) {
+  for (const x of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, x.name);
+    if (x.isDirectory()) {
+      find(path, skip, found);
+    } else if (x.name.endsWith(".sol")) {
+      const code = readFileSync(path, { encoding: "utf-8" });
+      const match = code.match(/^pragma solidity (.*?);/m);
+      if (!match) throw new Error(`expected pragma: ${path}`);
+      found.push({
+        spec: match[1].trim(),
+        file: path.slice(skip),
+      });
+    }
+  }
+  return found;
 }

--- a/contracts/src/erc1155/ERC1155Singleton.sol
+++ b/contracts/src/erc1155/ERC1155Singleton.sol
@@ -131,7 +131,7 @@ abstract contract ERC1155Singleton is
     /// @param id The token ID.
     /// @return balance The balance of the token for the account. This will only ever be 1 or 0.
     function balanceOf(address account, uint256 id) public view virtual returns (uint256) {
-        return ownerOf(id) == account ? 1 : 0;
+        return account != address(0) && ownerOf(id) == account ? 1 : 0;
     }
 
     /// @notice Returns the balances of a batch of tokens for an account.

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -55,8 +55,13 @@ contract Graveyard is ERC721Holder, ERC1155Holder, DelegatedContractNamer {
     // Errors
     ////////////////////////////////////////////////////////////////////////
 
+    /// @notice Name cannot be cleared.
     /// @dev Error selector: `0xacae6b3b`
     error NameNotClearable();
+
+    /// @notice Wrapped names require preimage. 
+    /// @dev Error selector: `0xa3f28cee`
+    error NameRequiresPreimage();
 
     ////////////////////////////////////////////////////////////////////////
     // Initialization
@@ -177,6 +182,9 @@ contract Graveyard is ERC721Holder, ERC1155Holder, DelegatedContractNamer {
                 }
                 // resolver is cleared by migration
             } else {
+                if (uint8(name[offset]) == 0) {
+                    revert NameRequiresPreimage();
+                }
                 NAME_WRAPPER.setSubnodeRecord(
                     parentNode,
                     string(name[offset + 1:nextOffset]),

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -165,20 +165,23 @@ contract Graveyard is ERC721Holder, ERC1155Holder, DelegatedContractNamer {
             return (node, State.OWNED);
         } else {
             (address owner, uint32 fuses, ) = NAME_WRAPPER.getData(uint256(node));
-            if (owner == address(this)) {
-                // resolver is cleared by migration
-                if (LibMigration.isLocked(fuses)) {
-                    return (node, State.LOCKED);
+            if (LibMigration.isLocked(fuses)) {
+                if (owner != address(this)) {
+                    revert NameNotClearable();
                 }
-                // } else if (LibMigration.isEmancipatedChild(fuses)) {
-                //    return (node, State.OWNED);
-                // }
-            } else if (owner != address(0)) {
+                // resolver is cleared by migration
+                return (node, State.LOCKED);
+            } else if (LibMigration.isEmancipatedChild(fuses)) {
+                if (owner != address(0) || _REGISTRY_V1.owner(node) != address(this)) {
+                    revert NameNotClearable();
+                }
+                // resolver is cleared by migration
+            } else {
                 NAME_WRAPPER.setSubnodeRecord(
                     parentNode,
                     string(name[offset + 1:nextOffset]),
                     address(this), // owner
-                    address(0), // resolver
+                    address(0), // resolver is cleared
                     0, // ttl
                     0, // fuses
                     0 // expiry (uses min)

--- a/contracts/src/registrar/StandardRentPriceOracle.sol
+++ b/contracts/src/registrar/StandardRentPriceOracle.sol
@@ -25,10 +25,10 @@ uint256 constant ROLE_DISABLE_TOKEN = 1 << 4;
 uint256 constant ROLE_DISABLE_TOKEN_ADMIN = ROLE_DISABLE_TOKEN << 128;
 
 /// @dev Nybble 2: authorizes contract naming. Root only.
-uint256 constant ROLE_SET_NAME = 1 << 8;
+uint256 constant ROLE_CAN_NAME = 1 << 8;
 
-/// @dev Nybble 34: authorizes setting `ROLE_SET_NAME`.
-uint256 constant ROLE_SET_NAME_ADMIN = ROLE_SET_NAME << 128;
+/// @dev Nybble 34: authorizes setting `ROLE_CAN_NAME`.
+uint256 constant ROLE_CAN_NAME_ADMIN = ROLE_CAN_NAME << 128;
 
 /// @dev Default root roles assigned at construction.
 uint256 constant DEFAULT_ROLE_BITMAP =
@@ -36,8 +36,8 @@ uint256 constant DEFAULT_ROLE_BITMAP =
     ROLE_UPDATE_TOKEN_ADMIN |
     ROLE_DISABLE_TOKEN |
     ROLE_DISABLE_TOKEN_ADMIN |
-    ROLE_SET_NAME |
-    ROLE_SET_NAME_ADMIN;
+    ROLE_CAN_NAME |
+    ROLE_CAN_NAME_ADMIN;
 
 /// @dev Initialization-time structure for a discount point.
 /// @param duration Duration threshold, in seconds.
@@ -256,7 +256,7 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
 
     /// @inheritdoc IContractNamer
     function isContractNamer(address namer) external view returns (bool) {
-        return hasRootRoles(ROLE_SET_NAME, namer);
+        return hasRootRoles(ROLE_CAN_NAME, namer);
     }
 
     /// @notice Get all base rates, in standard units per second.

--- a/contracts/src/resolver/PublicResolverV2.sol
+++ b/contracts/src/resolver/PublicResolverV2.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {Multicallable} from "@ens/contracts/resolvers/Multicallable.sol";
 import {ABIResolver} from "@ens/contracts/resolvers/profiles/ABIResolver.sol";
 import {AddrResolver} from "@ens/contracts/resolvers/profiles/AddrResolver.sol";
@@ -13,6 +12,7 @@ import {NameResolver} from "@ens/contracts/resolvers/profiles/NameResolver.sol";
 import {PubkeyResolver} from "@ens/contracts/resolvers/profiles/PubkeyResolver.sol";
 import {TextResolver} from "@ens/contracts/resolvers/profiles/TextResolver.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
 import {IContractNamer} from "../reverse-registrar/interfaces/IContractNamer.sol";
@@ -20,7 +20,8 @@ import {LibRegistry} from "../universalResolver/libraries/LibRegistry.sol";
 import {DelegatedContractNamer} from "../utils/DelegatedContractNamer.sol";
 
 /// @notice PublicResolver that respects the ENSv2 registry.
-contract PublicResolverV2 is ERC165,
+contract PublicResolverV2 is
+    ERC165,
     Multicallable,
     ABIResolver,
     AddrResolver,

--- a/contracts/src/resolver/PublicResolverV2.sol
+++ b/contracts/src/resolver/PublicResolverV2.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {Multicallable} from "@ens/contracts/resolvers/Multicallable.sol";
 import {ABIResolver} from "@ens/contracts/resolvers/profiles/ABIResolver.sol";
 import {AddrResolver} from "@ens/contracts/resolvers/profiles/AddrResolver.sol";
@@ -19,7 +20,7 @@ import {LibRegistry} from "../universalResolver/libraries/LibRegistry.sol";
 import {DelegatedContractNamer} from "../utils/DelegatedContractNamer.sol";
 
 /// @notice PublicResolver that respects the ENSv2 registry.
-contract PublicResolverV2 is
+contract PublicResolverV2 is ERC165,
     Multicallable,
     ABIResolver,
     AddrResolver,
@@ -101,6 +102,7 @@ contract PublicResolverV2 is
         public
         view
         override(
+            ERC165,
             Multicallable,
             ABIResolver,
             AddrResolver,

--- a/contracts/src/utils/PermissionedAddressSet.sol
+++ b/contracts/src/utils/PermissionedAddressSet.sol
@@ -13,14 +13,14 @@ uint256 constant ROLE_APPROVE = 1 << 0;
 uint256 constant ROLE_APPROVE_ADMIN = ROLE_APPROVE << 128;
 
 /// @dev Nybble 1: authorizes contract naming. Root only.
-uint256 constant ROLE_SET_NAME = 1 << 4;
+uint256 constant ROLE_CAN_NAME = 1 << 4;
 
-/// @dev Nybble 33: authorizes setting `ROLE_SET_NAME`.
-uint256 constant ROLE_SET_NAME_ADMIN = ROLE_SET_NAME << 128;
+/// @dev Nybble 33: authorizes setting `ROLE_CAN_NAME`.
+uint256 constant ROLE_CAN_NAME_ADMIN = ROLE_CAN_NAME << 128;
 
 /// @dev Default root roles assigned at construction.
 uint256 constant DEFAULT_ROLE_BITMAP =
-    ROLE_APPROVE | ROLE_APPROVE_ADMIN | ROLE_SET_NAME | ROLE_SET_NAME_ADMIN;
+    ROLE_APPROVE | ROLE_APPROVE_ADMIN | ROLE_CAN_NAME | ROLE_CAN_NAME_ADMIN;
 
 /// @notice An arbitrary set of addresses managed by EAC.
 contract PermissionedAddressSet is EnhancedAccessControl, IAddressSet, IContractNamer {
@@ -78,6 +78,6 @@ contract PermissionedAddressSet is EnhancedAccessControl, IAddressSet, IContract
 
     /// @inheritdoc IContractNamer
     function isContractNamer(address namer) external view returns (bool) {
-        return hasRootRoles(ROLE_SET_NAME, namer);
+        return hasRootRoles(ROLE_CAN_NAME, namer);
     }
 }

--- a/contracts/test/StandardRegistrar.sol
+++ b/contracts/test/StandardRegistrar.sol
@@ -5,7 +5,7 @@ import {PaymentRatio, DiscountPoint} from "~src/registrar/StandardRentPriceOracl
 import {MockERC20} from "~test/mocks/MockERC20.sol";
 
 library StandardRegistrar {
-    uint64 internal constant SEC_PER_YEAR = 31_557_600; // 365.25
+    uint64 internal constant SEC_PER_YEAR = 365 * 1 days; // 31536000
 
     uint64 internal constant MIN_COMMITMENT_AGE = 60; // 1 minute
     uint64 internal constant MAX_COMMITMENT_AGE = 1 days;
@@ -27,9 +27,9 @@ library StandardRegistrar {
     // ┌───┬────┬───────────┬────────┐
     // │   │ cp │ rate      │ yearly │
     // ├───┼────┼───────────┼────────┤
-    // │ 0 │ 5  │ 253505n   │ 8.00   │
-    // │ 1 │ 4  │ 5070095n  │ 160.00 │
-    // │ 2 │ 3  │ 20280377n │ 640.00 │
+    // │ 0 │ 5  │ 253679n   │ 8.00   │
+    // │ 1 │ 4  │ 5073567n  │ 160.00 │
+    // │ 2 │ 3  │ 20294267n │ 640.00 │
     // └───┴────┴───────────┴────────┘
 
     uint256 internal constant RATE_1CP = 0;
@@ -69,7 +69,7 @@ library StandardRegistrar {
 
     function getDiscountPoints() internal pure returns (DiscountPoint[] memory v) {
         v = new DiscountPoint[](3);
-        v[0] = DiscountPoint(SEC_PER_YEAR * 2, _discountNumer(7, 8)); //////// 1 - 14/16 = 12.50%
+        v[0] = DiscountPoint(SEC_PER_YEAR * 2, _discountNumer(7, 8)); //// 1 - 14/16 = 12.50%
         v[1] = DiscountPoint(SEC_PER_YEAR * 3, _discountNumer(11, 16)); // 1 - 11/16 = 31.25%
         v[2] = DiscountPoint(SEC_PER_YEAR * 6, _discountNumer(9, 16)); /// 1 -  9/16 = 43.75%
     }

--- a/contracts/test/unit/access-control/EnhancedAccessControl.t.sol
+++ b/contracts/test/unit/access-control/EnhancedAccessControl.t.sol
@@ -57,6 +57,13 @@ contract MockEnhancedAccessControl is EnhancedAccessControl {
         lastRevokedCount = 0;
     }
 
+    function callOnlyRoles(uint256 resource, uint256 roleBitmap)
+        external
+        onlyRoles(resource, roleBitmap)
+    {
+        // Function that will revert if caller doesn't have the roles in resource
+    }
+
     function callOnlyRootRoles(uint256 roleBitmap) external onlyRootRoles(roleBitmap) {
         // Function that will revert if caller doesn't have the roles in root resource
     }
@@ -340,6 +347,33 @@ contract EnhancedAccessControlTest is Test {
         );
         vm.prank(user2);
         access.callOnlyRootRoles(ROLE_A);
+    }
+
+    function test_only_roles() external {
+        // Grant role in root resource to user1
+        access.grantRootRoles(ROLE_A, user1);
+
+        // User1 should be able to call function with onlyRoles modifier
+        vm.prank(user1);
+        access.callOnlyRoles(RESOURCE_1, ROLE_A);
+
+        // User2 doesn't have the role, should revert
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                RESOURCE_1,
+                ROLE_A,
+                user2
+            )
+        );
+        vm.prank(user2);
+        access.callOnlyRoles(RESOURCE_1, ROLE_A);
+
+        // Having the role in a specific resource does satisfy onlyRoles
+        access.grantRoles(RESOURCE_1, ROLE_A, user2);
+
+        vm.prank(user2);
+        access.callOnlyRoles(RESOURCE_1, ROLE_A);
     }
 
     function test_has_roles_requires_all_roles() external {
@@ -1734,6 +1768,10 @@ contract EnhancedAccessControlTest is Test {
 
         vm.stopPrank();
     }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Helpers
+    ////////////////////////////////////////////////////////////////////////
 
     /// @dev Grant roles then require event and check getter.
     function _grant(uint256 resource, uint256 roles, address account) public {

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -9,7 +9,9 @@ import {
 } from "@ens/contracts/wrapper/INameWrapper.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {HexUtils} from "@ens/contracts/utils/HexUtils.sol";
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
+import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
 import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixture.sol";
 
 contract GraveyardTest is MigrationControllerFixture {
@@ -17,6 +19,13 @@ contract GraveyardTest is MigrationControllerFixture {
 
     function setUp() external {
         deployMigrationControllerFixture();
+    }
+
+    function test_supportsInterface() external view {
+        assertTrue(
+            ERC165Checker.supportsInterface(address(graveyard), type(IContractNamer).interfaceId),
+            "IContractNamer"
+        );
     }
 
     function test_clear_root() external {
@@ -245,6 +254,27 @@ contract GraveyardTest is MigrationControllerFixture {
         assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
     }
 
+    function test_clear_nestedLocked_migrateParent_unwrappedChild() external {
+        bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        bytes memory name3 = NameCoder.addLabel(name2, testLabel);
+
+        // claim 3LD ownership without wrapping
+        _claimNodes(name3, 0, testOwner);
+
+        // set resolvers
+        vm.startPrank(testOwner);
+        nameWrapper.setResolver(NameCoder.namehash(name2, 0), address(1));
+        registryV1.setResolver(NameCoder.namehash(name3, 0), address(1));
+        vm.stopPrank();
+
+        _simulateMigration(name2);
+
+        graveyard.clear(_oneName(name3));
+
+        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0), "2");
+        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
+    }
+
     function test_clear_nestedLocked_bothExpired() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         bytes memory name3 =
@@ -343,7 +373,7 @@ contract GraveyardTest is MigrationControllerFixture {
         nameWrapper.unwrap(
             NameCoder.namehash(name3, 0),
             keccak256(bytes(NameCoder.firstLabel(name4))),
-            address(graveyard)
+            address(testOwner)
         );
 
         // name2 = locked
@@ -355,10 +385,14 @@ contract GraveyardTest is MigrationControllerFixture {
 
         graveyard.clear(_oneName(name4));
 
-        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "2");
+        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0), "2");
         assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
         assertEq(registryV1.resolver(NameCoder.namehash(name4, 0)), address(0), "4");
     }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Helpers
+    ////////////////////////////////////////////////////////////////////////
 
     /// @dev Clear resolver if possible and transfer to graveyard.
     function _simulateMigration(bytes memory name) internal {

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -11,6 +11,7 @@ import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {HexUtils} from "@ens/contracts/utils/HexUtils.sol";
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
+import {Graveyard} from "~src/migration/Graveyard.sol";
 import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
 import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixture.sol";
 
@@ -37,7 +38,7 @@ contract GraveyardTest is MigrationControllerFixture {
     }
 
     function test_clear_xyz() external {
-        vm.expectRevert();
+        vm.expectRevert(abi.encodeWithSelector(Graveyard.NameNotClearable.selector));
         graveyard.clear(_oneName(NameCoder.encode("xyz")));
         vm.expectRevert();
         graveyard.clear(_oneName(NameCoder.encode("test.xyz")));
@@ -299,6 +300,9 @@ contract GraveyardTest is MigrationControllerFixture {
         vm.stopPrank();
 
         _simulateMigration(name2);
+
+        vm.expectRevert(abi.encodeWithSelector(Graveyard.NameRequiresPreimage.selector));
+        graveyard.clear(_oneName(abi.encodePacked(uint8(0), keccak256(bytes(testLabel)), name2)));
 
         graveyard.clear(_oneName(name3));
 

--- a/contracts/test/unit/migration/Graveyard.t.sol
+++ b/contracts/test/unit/migration/Graveyard.t.sol
@@ -254,27 +254,6 @@ contract GraveyardTest is MigrationControllerFixture {
         assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
     }
 
-    function test_clear_nestedLocked_migrateParent_unwrappedChild() external {
-        bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
-        bytes memory name3 = NameCoder.addLabel(name2, testLabel);
-
-        // claim 3LD ownership without wrapping
-        _claimNodes(name3, 0, testOwner);
-
-        // set resolvers
-        vm.startPrank(testOwner);
-        nameWrapper.setResolver(NameCoder.namehash(name2, 0), address(1));
-        registryV1.setResolver(NameCoder.namehash(name3, 0), address(1));
-        vm.stopPrank();
-
-        _simulateMigration(name2);
-
-        graveyard.clear(_oneName(name3));
-
-        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0), "2");
-        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
-    }
-
     function test_clear_nestedLocked_bothExpired() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         bytes memory name3 =
@@ -306,7 +285,53 @@ contract GraveyardTest is MigrationControllerFixture {
         assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
     }
 
-    function test_clear_detached(bool unwrapped) external {
+    function test_clear_migrateParent_unwrappedChild() external {
+        bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        bytes memory name3 = NameCoder.addLabel(name2, testLabel);
+
+        // claim 3LD ownership without wrapping
+        _claimNodes(name3, 0, testOwner);
+
+        // set resolvers
+        vm.startPrank(testOwner);
+        nameWrapper.setResolver(NameCoder.namehash(name2, 0), address(1));
+        registryV1.setResolver(NameCoder.namehash(name3, 0), address(1));
+        vm.stopPrank();
+
+        _simulateMigration(name2);
+
+        graveyard.clear(_oneName(name3));
+
+        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0), "2");
+        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
+    }
+
+    function test_clear_detachedAndUnmigrated() external {
+        bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        bytes memory name3 = createWrappedChild(name2, testLabel, PARENT_CANNOT_CONTROL);
+
+        // set resolvers
+        vm.startPrank(testOwner);
+        nameWrapper.setResolver(NameCoder.namehash(name2, 0), address(1));
+        nameWrapper.setResolver(NameCoder.namehash(name3, 0), address(1));
+        vm.stopPrank();
+
+        _simulateMigration(name2);
+
+        vm.expectRevert();
+        graveyard.clear(_oneName(name3));
+
+        graveyard.clear(_oneName(name2));
+
+        _simulateMigration(name3);
+
+        graveyard.clear(_oneName(name3));
+
+        assertEq(registryV1.resolver(NameCoder.namehash(name2, 0)), address(0), "2");
+        assertEq(registryV1.resolver(NameCoder.namehash(name3, 0)), address(0), "3");
+    }
+
+    function test_clear_detachedAndExpired(bool unwrapped) external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         bytes memory name3 = createWrappedChild(name2, testLabel, PARENT_CANNOT_CONTROL);
 
@@ -321,7 +346,7 @@ contract GraveyardTest is MigrationControllerFixture {
             nameWrapper.unwrap(
                 NameCoder.namehash(name2, 0),
                 keccak256(bytes(NameCoder.firstLabel(name3))),
-                address(graveyard)
+                address(testOwner)
             );
         }
 

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -222,6 +222,22 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         dummy1155.safeTransferFrom(actor, address(migrationController), tokenId, 1, ""); // wrong
     }
 
+    function test_onERC1155Received_unauthorizedCaller() external {
+        vm.expectRevert(
+            WrappedErrorLib.wrap(abi.encodeWithSelector(UnauthorizedCaller.selector, actor))
+        );
+        vm.prank(actor);
+        migrationController.onERC1155Received(address(0), address(0), 1, 1, "");
+    }
+
+    function test_onERC1155Received_invalidData() external {
+        vm.expectRevert(
+            WrappedErrorLib.wrap(abi.encodeWithSelector(LibMigration.InvalidData.selector))
+        );
+        vm.prank(address(nameWrapper));
+        migrationController.onERC1155Received(address(0), address(0), 1, 1, "");
+    }
+
     function test_migrate_invalidData(bytes calldata v) external {
         vm.assume(v.length < LibMigration.MIN_DATA_SIZE);
         bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);

--- a/contracts/test/unit/migration/UnlockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/UnlockedMigrationController.t.sol
@@ -73,6 +73,34 @@ contract UnlockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
+    function test_onERC721Received_unauthorizedCaller() external {
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedCaller.selector, actor));
+        vm.prank(actor);
+        migrationController.onERC721Received(address(0), address(0), 1, "");
+    }
+
+    function test_onERC721Received_invalidData() external {
+        vm.expectRevert(abi.encodeWithSelector(LibMigration.InvalidData.selector));
+        vm.prank(address(baseRegistrar));
+        migrationController.onERC721Received(address(0), address(0), 1, "");
+    }
+
+    function test_onERC1155Received_unauthorizedCaller() external {
+        vm.expectRevert(
+            WrappedErrorLib.wrap(abi.encodeWithSelector(UnauthorizedCaller.selector, actor))
+        );
+        vm.prank(actor);
+        migrationController.onERC1155Received(address(0), address(0), 1, 1, "");
+    }
+
+    function test_onERC1155Received_invalidData() external {
+        vm.expectRevert(
+            WrappedErrorLib.wrap(abi.encodeWithSelector(LibMigration.InvalidData.selector))
+        );
+        vm.prank(address(nameWrapper));
+        migrationController.onERC1155Received(address(0), address(0), 1, 1, "");
+    }
+
     function test_finishERC1155Migration_unauthorizedCaller() external {
         vm.expectRevert(abi.encodeWithSelector(UnauthorizedCaller.selector, actor));
         vm.prank(actor);

--- a/contracts/test/unit/registrar/BatchRegistrar.t.sol
+++ b/contracts/test/unit/registrar/BatchRegistrar.t.sol
@@ -30,6 +30,16 @@ contract BatchRegistrarTest is V2Fixture {
         );
     }
 
+    function test_batchRegister_lengthMismatch() external {
+        vm.expectRevert(abi.encodeWithSelector(BatchRegistrar.InputLengthMismatch.selector));
+        batchRegistrar.batchRegister(
+            IRegistry(address(0)),
+            resolver,
+            new string[](0),
+            new uint64[](1)
+        );
+    }
+
     function test_batchRegister_new_names() public {
         string[] memory labels = new string[](3);
         uint64[] memory expires = new uint64[](3);

--- a/contracts/test/unit/registrar/StandardRentPriceOracle.t.sol
+++ b/contracts/test/unit/registrar/StandardRentPriceOracle.t.sol
@@ -7,6 +7,7 @@ import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165C
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
+import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
 import {IEnhancedAccessControl} from "~src/access-control/interfaces/IEnhancedAccessControl.sol";
 import {IRentPriceOracle} from "~src/registrar/interfaces/IRentPriceOracle.sol";
 import {
@@ -15,7 +16,11 @@ import {
     DiscountPoint,
     DEFAULT_ROLE_BITMAP,
     ROLE_UPDATE_TOKEN,
-    ROLE_DISABLE_TOKEN
+    ROLE_UPDATE_TOKEN_ADMIN,
+    ROLE_DISABLE_TOKEN,
+    ROLE_DISABLE_TOKEN_ADMIN,
+    ROLE_CAN_NAME,
+    ROLE_CAN_NAME_ADMIN
 } from "~src/registrar/StandardRentPriceOracle.sol";
 import {StandardRentPriceOracleFixture} from "~test/fixtures/StandardRentPriceOracleFixture.sol";
 import {StandardRegistrar} from "~test/StandardRegistrar.sol";
@@ -36,6 +41,24 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
                 address(rentPriceOracle),
                 type(IRentPriceOracle).interfaceId
             )
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(rentPriceOracle),
+                type(IContractNamer).interfaceId
+            )
+        );
+    }
+
+    function test_DEFAULT_ROLE_BITMAP() external pure {
+        assertEq(
+            DEFAULT_ROLE_BITMAP,
+            ROLE_UPDATE_TOKEN |
+            ROLE_UPDATE_TOKEN_ADMIN |
+            ROLE_DISABLE_TOKEN |
+            ROLE_DISABLE_TOKEN_ADMIN |
+            ROLE_CAN_NAME |
+            ROLE_CAN_NAME_ADMIN
         );
     }
 
@@ -505,5 +528,15 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
             )
         );
         rentPriceOracle.convertUnits(0, invalidPaymentToken);
+    }
+
+    function test_isContractNamer() external {
+        assertTrue(rentPriceOracle.isContractNamer(address(this)));
+
+        assertFalse(rentPriceOracle.isContractNamer(actor), "before");
+        rentPriceOracle.grantRootRoles(ROLE_CAN_NAME, actor);
+        assertTrue(rentPriceOracle.isContractNamer(actor), "granted");
+        rentPriceOracle.revokeRootRoles(ROLE_CAN_NAME, actor);
+        assertFalse(rentPriceOracle.isContractNamer(actor), "revoked");
     }
 }

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -744,6 +744,19 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         registry.__safeTransferFrom(from, user2, tokenId, 1, "");
     }
 
+    function test_safeTransferFrom_missingApproval() external {
+        uint256 tokenId = this._register();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IERC1155Errors.ERC1155MissingApprovalForAll.selector,
+                user2,
+                user1
+            )
+        );
+        vm.prank(user2);
+        registry.safeTransferFrom(user1, user2, tokenId, 1, "");
+    }
+
     function test_safeTransferFrom_notAuthorized() external {
         uint256 tokenId = this._register();
         vm.expectRevert(

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -653,6 +653,39 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         assertEq(registry.latestOwnerOf(tokenId), testOwner, "expired");
     }
 
+    function test_balanceOf() external {
+        assertEq(registry.balanceOf(address(0), 0), 0, "zero");
+        assertEq(
+            registry.balanceOf(testOwner, LibLabel.withVersion(LibLabel.id(testLabel), 0)),
+            0,
+            "available"
+        );
+        uint256 tokenId = this._register();
+        assertEq(registry.balanceOf(testOwner, tokenId), 1, "registered");
+        assertEq(registry.balanceOf(testOwner, LibLabel.withVersion(tokenId, 1)), 0, "next");
+        registry.unregister(tokenId);
+        assertEq(registry.balanceOf(testOwner, tokenId), 0, "unregistered");
+    }
+
+    function test_balanceOfBatch() external {
+        address[] memory acs = new address[](3);
+        uint256[] memory ids = new uint256[](3);
+        ids[0] = ids[1] = this._register();
+        ids[2] = ids[0] + 1;
+        acs[0] = acs[2] = testOwner;
+        uint256[] memory bals = registry.balanceOfBatch(acs, ids);
+        assertEq(bals[0], 1);
+        assertEq(bals[1], 0, "wrong owner");
+        assertEq(bals[2], 0, "wrong token");
+    }
+
+    function test_balanceOfBatch_arrayLength() external {
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC1155Errors.ERC1155InvalidArrayLength.selector, 1, 0)
+        );
+        registry.balanceOfBatch(new address[](0), new uint256[](1));
+    }
+
     function test_safeTransferFrom() external {
         testRoles = RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN;
         uint256 tokenId = this._register();
@@ -693,6 +726,22 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         );
         vm.prank(user1);
         registry.safeTransferFrom(user1, user2, tokenId, amount, "");
+    }
+
+    function test_safeTransferFrom_invalidReceiver() external {
+        uint256 tokenId = this._register();
+        address to; // wrong
+        vm.expectRevert(abi.encodeWithSelector(IERC1155Errors.ERC1155InvalidReceiver.selector, to));
+        vm.prank(user1);
+        registry.safeTransferFrom(user1, to, tokenId, 1, "");
+    }
+
+    function test_safeTransferFrom_invalidSender() external {
+        uint256 tokenId = this._register();
+        address from; // wrong
+        vm.expectRevert(abi.encodeWithSelector(IERC1155Errors.ERC1155InvalidSender.selector, from));
+        vm.prank(user1);
+        registry.__safeTransferFrom(from, user2, tokenId, 1, "");
     }
 
     function test_safeTransferFrom_notAuthorized() external {
@@ -810,6 +859,24 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         );
         vm.prank(user1);
         registry.safeBatchTransferFrom(user1, user2, tokenIds, amounts, "");
+    }
+
+    function test_safeBatchTransferFrom_invalidReceiver() external {
+        uint256 tokenId = this._register();
+        uint256[] memory v;
+        address to; // wrong
+        vm.expectRevert(abi.encodeWithSelector(IERC1155Errors.ERC1155InvalidReceiver.selector, to));
+        vm.prank(user1);
+        registry.safeBatchTransferFrom(user1, to, v, v, "");
+    }
+
+    function test_safeBatchTransferFrom_invalidSender() external {
+        uint256 tokenId = this._register();
+        uint256[] memory v;
+        address from; // wrong
+        vm.expectRevert(abi.encodeWithSelector(IERC1155Errors.ERC1155InvalidSender.selector, from));
+        vm.prank(user1);
+        registry.__safeBatchTransferFrom(from, user2, v, v, "");
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -1046,6 +1113,12 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
     // Token Regeneration
     ////////////////////////////////////////////////////////////////////////
 
+    function test_burn_invalidSender() external {
+        address from; // wrong
+        vm.expectRevert(abi.encodeWithSelector(IERC1155Errors.ERC1155InvalidSender.selector, from));
+        registry.__burn(from, 0, 0);
+    }
+
     function test_regenerate_mintBurn() external {
         IPermissionedRegistry.State memory s0 = registry.getState(this._register());
         registry.unregister(s0.tokenId);
@@ -1244,6 +1317,12 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
     ////////////////////////////////////////////////////////////////////////
     // EAC Override: setApprovalForAll()
     ////////////////////////////////////////////////////////////////////////
+
+    function test_setApprovalForAll_invalidOperator() external {
+        address to; // wrong
+        vm.expectRevert(abi.encodeWithSelector(IERC1155Errors.ERC1155InvalidOperator.selector, to));
+        registry.setApprovalForAll(to, true);
+    }
 
     function test_setApprovalForAll_roles(uint256) external {
         testRoles = _randomRoleBitmap(true, false);
@@ -1693,6 +1772,31 @@ contract MockPermissionedRegistry is PermissionedRegistry {
     {}
     function getEntry(uint256 anyId) external view returns (PermissionedRegistry.Entry memory) {
         return _entry(anyId);
+    }
+    function __safeTransferFrom(
+        address from,
+        address to,
+        uint256 id,
+        uint256 value,
+        bytes memory data
+    )
+        external
+    {
+        _safeTransferFrom(from, to, id, value, data);
+    }
+    function __safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory values,
+        bytes memory data
+    )
+        external
+    {
+        _safeBatchTransferFrom(from, to, ids, values, data);
+    }
+    function __burn(address from, uint256 id, uint256 value) external {
+        _burn(from, id, value);
     }
 }
 

--- a/contracts/test/unit/registry/UserRegistry.t.sol
+++ b/contracts/test/unit/registry/UserRegistry.t.sol
@@ -8,6 +8,7 @@ import {Test} from "forge-std/Test.sol";
 import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
 
+import {InvalidOwner} from "~src/CommonErrors.sol";
 import {EACBaseRolesLib} from "~src/access-control/EnhancedAccessControl.sol";
 import {IEnhancedAccessControl} from "~src/access-control/interfaces/IEnhancedAccessControl.sol";
 import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
@@ -57,6 +58,15 @@ contract UserRegistryTest is Test, ERC1155Holder {
 
     function test_implementationIsNameable() external view {
         assertTrue(implementation.isContractNamer(address(this)));
+    }
+
+    function test_initialize_invalidOwner() external {
+        vm.expectRevert(abi.encodeWithSelector(InvalidOwner.selector));
+        factory.deployProxy(
+            address(implementation),
+            SALT,
+            abi.encodeCall(UserRegistry.initialize, (address(0), EACBaseRolesLib.ALL_ROLES))
+        );
     }
 
     function test_initialization() public view {

--- a/contracts/test/unit/resolver/PermissionedResolver.t.sol
+++ b/contracts/test/unit/resolver/PermissionedResolver.t.sol
@@ -6,10 +6,8 @@ import {Test} from "forge-std/Test.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-
 import {IProxyAuthorization} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
 import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
-
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {ResolverFeatures} from "@ens/contracts/resolvers/ResolverFeatures.sol";
 import {ENSIP19, COIN_TYPE_ETH, COIN_TYPE_DEFAULT} from "@ens/contracts/utils/ENSIP19.sol";

--- a/contracts/test/unit/resolver/PermissionedResolver.t.sol
+++ b/contracts/test/unit/resolver/PermissionedResolver.t.sol
@@ -3,37 +3,36 @@ pragma solidity ^0.8.13;
 
 import {Test} from "forge-std/Test.sol";
 
-import {IProxyAuthorization} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
-import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
+import {IProxyAuthorization} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
+import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
+
+import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
+import {ResolverFeatures} from "@ens/contracts/resolvers/ResolverFeatures.sol";
+import {ENSIP19, COIN_TYPE_ETH, COIN_TYPE_DEFAULT} from "@ens/contracts/utils/ENSIP19.sol";
+import {IERC7996} from "@ens/contracts/utils/IERC7996.sol";
+import {IMulticallable} from "@ens/contracts/resolvers/IMulticallable.sol";
+import {IABIResolver} from "@ens/contracts/resolvers/profiles/IABIResolver.sol";
+import {IAddressResolver} from "@ens/contracts/resolvers/profiles/IAddressResolver.sol";
+import {IAddrResolver} from "@ens/contracts/resolvers/profiles/IAddrResolver.sol";
+import {IContentHashResolver} from "@ens/contracts/resolvers/profiles/IContentHashResolver.sol";
+import {IDataResolver} from "@ens/contracts/resolvers/profiles/IDataResolver.sol";
+import {IHasAddressResolver} from "@ens/contracts/resolvers/profiles/IHasAddressResolver.sol";
+import {IInterfaceResolver} from "@ens/contracts/resolvers/profiles/IInterfaceResolver.sol";
+import {INameResolver} from "@ens/contracts/resolvers/profiles/INameResolver.sol";
+import {IPubkeyResolver} from "@ens/contracts/resolvers/profiles/IPubkeyResolver.sol";
+import {ITextResolver} from "@ens/contracts/resolvers/profiles/ITextResolver.sol";
+import {IVersionableResolver} from "@ens/contracts/resolvers/profiles/IVersionableResolver.sol";
+
 import {IEnhancedAccessControl} from "~src/access-control/interfaces/IEnhancedAccessControl.sol";
 import {EACBaseRolesLib} from "~src/access-control/libraries/EACBaseRolesLib.sol";
-import {
-    PermissionedResolver,
-    IPermissionedResolver,
-    PermissionedResolverLib,
-    IMulticallable,
-    IABIResolver,
-    IAddrResolver,
-    IAddressResolver,
-    IContentHashResolver,
-    IDataResolver,
-    IHasAddressResolver,
-    IInterfaceResolver,
-    INameResolver,
-    IPubkeyResolver,
-    ITextResolver,
-    IVersionableResolver,
-    NameCoder,
-    ResolverFeatures,
-    IERC7996,
-    ENSIP19,
-    COIN_TYPE_ETH,
-    COIN_TYPE_DEFAULT
-} from "~src/resolver/PermissionedResolver.sol";
+import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
+import {IPermissionedResolver} from "~src/resolver/interfaces/IPermissionedResolver.sol";
+import {PermissionedResolverLib} from "~src/resolver/libraries/PermissionedResolverLib.sol";
+import {PermissionedResolver} from "~src/resolver/PermissionedResolver.sol";
 
 bytes4 constant TEST_SELECTOR = 0x12345678;
 
@@ -123,44 +122,86 @@ contract PermissionedResolverTest is Test {
     }
 
     function test_supportsInterface() external view {
-        assertTrue(ERC165Checker.supportsERC165(address(resolver)));
         assertTrue(
-            resolver.supportsInterface(type(IPermissionedResolver).interfaceId),
+            ERC165Checker.supportsInterface(
+                address(resolver),
+                type(IPermissionedResolver).interfaceId
+            ),
             "IPermissionedResolver"
         );
         assertTrue(
-            resolver.supportsInterface(type(IEnhancedAccessControl).interfaceId),
+            ERC165Checker.supportsInterface(
+                address(resolver),
+                type(IEnhancedAccessControl).interfaceId
+            ),
             "IEnhancedAccessControl"
         );
-        assertTrue(resolver.supportsInterface(type(IMulticallable).interfaceId), "IMulticallable");
-        assertTrue(resolver.supportsInterface(type(IERC7996).interfaceId), "IERC7996");
-        assertTrue(resolver.supportsInterface(type(UUPSUpgradeable).interfaceId), "UUPSUpgradeable");
+        assertTrue(
+            ERC165Checker.supportsInterface(address(resolver), type(IContractNamer).interfaceId),
+            "IContractNamer"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(resolver), type(IMulticallable).interfaceId),
+            "IMulticallable"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(resolver), type(IERC7996).interfaceId),
+            "IERC7996"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(resolver), type(UUPSUpgradeable).interfaceId),
+            "UUPSUpgradeable"
+        );
 
         // profiles
-        assertTrue(resolver.supportsInterface(type(IABIResolver).interfaceId), "IABIResolver");
-        assertTrue(resolver.supportsInterface(type(IAddrResolver).interfaceId), "IAddrResolver");
         assertTrue(
-            resolver.supportsInterface(type(IAddressResolver).interfaceId),
+            ERC165Checker.supportsInterface(address(resolver), type(IABIResolver).interfaceId),
+            "IABIResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(resolver), type(IAddrResolver).interfaceId),
+            "IAddrResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(resolver), type(IAddressResolver).interfaceId),
             "IAddressResolver"
         );
         assertTrue(
-            resolver.supportsInterface(type(IContentHashResolver).interfaceId),
+            ERC165Checker.supportsInterface(
+                address(resolver),
+                type(IContentHashResolver).interfaceId
+            ),
             "IContentHashResolver"
         );
-        assertTrue(resolver.supportsInterface(type(IDataResolver).interfaceId), "IDataResolver");
         assertTrue(
-            resolver.supportsInterface(type(IHasAddressResolver).interfaceId),
+            ERC165Checker.supportsInterface(address(resolver), type(IDataResolver).interfaceId),
+            "IDataResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(resolver), type(IHasAddressResolver).interfaceId),
             "IHasAddressResolver"
         );
         assertTrue(
-            resolver.supportsInterface(type(IInterfaceResolver).interfaceId),
+            ERC165Checker.supportsInterface(address(resolver), type(IInterfaceResolver).interfaceId),
             "IInterfaceResolver"
         );
-        assertTrue(resolver.supportsInterface(type(INameResolver).interfaceId), "INameResolver");
-        assertTrue(resolver.supportsInterface(type(IPubkeyResolver).interfaceId), "IPubkeyResolver");
-        assertTrue(resolver.supportsInterface(type(ITextResolver).interfaceId), "ITextResolver");
         assertTrue(
-            resolver.supportsInterface(type(IVersionableResolver).interfaceId),
+            ERC165Checker.supportsInterface(address(resolver), type(INameResolver).interfaceId),
+            "INameResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(resolver), type(IPubkeyResolver).interfaceId),
+            "IPubkeyResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(resolver), type(ITextResolver).interfaceId),
+            "ITextResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(resolver),
+                type(IVersionableResolver).interfaceId
+            ),
             "IVersionableResolver"
         );
     }
@@ -683,7 +724,7 @@ contract PermissionedResolverTest is Test {
     }
 
     function test_setInterface(bytes4 interfaceId, address impl) external {
-        vm.assume(!resolver.supportsInterface(interfaceId));
+        vm.assume(!ERC165Checker.supportsInterface(address(resolver), interfaceId));
 
         vm.expectEmit();
         emit IInterfaceResolver.InterfaceChanged(testNode, interfaceId, impl);
@@ -1015,10 +1056,9 @@ contract PermissionedResolverTest is Test {
 
     function test_isContractNamer() external {
         assertTrue(resolver.isContractNamer(owner));
-
         assertFalse(resolver.isContractNamer(friend), "before");
-        vm.prank(owner);
 
+        vm.prank(owner);
         resolver.grantRootRoles(PermissionedResolverLib.ROLE_CAN_NAME, friend);
         assertTrue(resolver.isContractNamer(friend), "granted");
 

--- a/contracts/test/unit/resolver/PermissionedResolver.t.sol
+++ b/contracts/test/unit/resolver/PermissionedResolver.t.sol
@@ -98,6 +98,11 @@ contract PermissionedResolverTest is Test {
         assertEq(r.contenthash(testNode), testAddress, "contenthash()");
     }
 
+    function test_canUpgradeFrom() external view {
+        assertTrue(resolver.canUpgradeFrom(address(0))); // accepts
+        assertTrue(resolver.canUpgradeFrom(address(1))); // any address
+    }
+
     function test_upgrade() external {
         MockUpgrade upgrade = new MockUpgrade();
         vm.prank(owner);
@@ -107,6 +112,7 @@ contract PermissionedResolverTest is Test {
 
     function test_upgrade_notAuthorized() external {
         MockUpgrade upgrade = new MockUpgrade();
+        assertTrue(resolver.canUpgradeFrom(address(upgrade)));
         vm.expectRevert(
             abi.encodeWithSelector(
                 IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
@@ -298,6 +304,21 @@ contract PermissionedResolverTest is Test {
             )
         );
         resolver.grantRoles(resource, roleBitmap, account);
+    }
+
+    function test_revokeRoles_disabled(uint256 resource, address account) external {
+        vm.assume(resource > 0);
+        uint256 roleBitmap = EACBaseRolesLib.ALL_ROLES;
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACCannotRevokeRoles.selector,
+                resource,
+                roleBitmap,
+                account
+            )
+        );
+        resolver.revokeRoles(resource, roleBitmap, account);
     }
 
     function test_authorizeNameRoles() external {
@@ -629,6 +650,31 @@ contract PermissionedResolverTest is Test {
         resolver.setAddr(testNode, COIN_TYPE_ETH, "");
     }
 
+    function test_setData(string calldata key, bytes calldata value) external {
+        vm.expectEmit();
+        emit IDataResolver.DataChanged(testNode, key, key, value);
+        vm.prank(owner);
+        resolver.setData(testNode, key, value);
+
+        assertEq(resolver.data(testNode, key), value, "immediate");
+
+        bytes memory result =
+            resolver.resolve(testName, abi.encodeCall(IDataResolver.data, (bytes32(0), key)));
+        assertEq(result, abi.encode(value), "extended");
+    }
+
+    function test_setData_notAuthorized() external {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                PermissionedResolverLib.resource(testNode, 0),
+                PermissionedResolverLib.ROLE_SET_DATA,
+                address(this)
+            )
+        );
+        resolver.setData(testNode, testString, "");
+    }
+
     function test_setText(string calldata key, string calldata value) external {
         vm.expectEmit();
         emit ITextResolver.TextChanged(testNode, key, key, value);
@@ -776,7 +822,7 @@ contract PermissionedResolverTest is Test {
     }
 
     function test_setInterface(bytes4 interfaceId, address impl) external {
-        vm.assume(!ERC165Checker.supportsInterface(address(resolver), interfaceId));
+        vm.assume(!resolver.supportsInterface(interfaceId));
 
         vm.expectEmit();
         emit IInterfaceResolver.InterfaceChanged(testNode, interfaceId, impl);

--- a/contracts/test/unit/resolver/PermissionedResolver.t.sol
+++ b/contracts/test/unit/resolver/PermissionedResolver.t.sol
@@ -341,28 +341,23 @@ contract PermissionedResolverTest is Test {
     }
 
     ////////////////////////////////////////////////////////////////////////
-    // authorizeTextRoles() and authorizeAddrRoles()
+    // authorizeTextRoles()
     ////////////////////////////////////////////////////////////////////////
 
-    function test_authorizeTextRoles() external {
+    function test_authorizeTextRoles(string calldata key) external {
         uint256 resource =
             PermissionedResolverLib.resource(
                 NameCoder.namehash(testName, 0),
-                PermissionedResolverLib.partHash(testString)
+                PermissionedResolverLib.partHash(key)
             );
         vm.expectEmit();
-        emit PermissionedResolver.NamedTextResource(
-            resource,
-            testName,
-            keccak256(bytes(testString)),
-            testString
-        );
+        emit PermissionedResolver.NamedTextResource(resource, testName, keccak256(bytes(key)), key);
         vm.prank(owner);
-        resolver.authorizeTextRoles(testName, testString, friend, true);
+        resolver.authorizeTextRoles(testName, key, friend, true);
         assertTrue(resolver.hasRoles(resource, PermissionedResolverLib.ROLE_SET_TEXT, friend));
 
         vm.prank(owner);
-        resolver.authorizeTextRoles(testName, testString, friend, false);
+        resolver.authorizeTextRoles(testName, key, friend, false);
         assertFalse(resolver.hasRoles(resource, PermissionedResolverLib.ROLE_SET_TEXT, friend));
     }
 
@@ -399,6 +394,10 @@ contract PermissionedResolverTest is Test {
         vm.prank(friend);
         resolver.authorizeTextRoles(testName, testString, owner, true);
     }
+
+    ////////////////////////////////////////////////////////////////////////
+    // authorizeAddrRoles(), and authorizeDataRoles()
+    ////////////////////////////////////////////////////////////////////////
 
     function test_authorizeAddrRoles(uint256 coinType) external {
         uint256 resource =
@@ -451,6 +450,61 @@ contract PermissionedResolverTest is Test {
         );
         vm.prank(friend);
         resolver.authorizeAddrRoles(testName, 0, owner, true);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // authorizeDataRoles()
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_authorizeDataRoles(string calldata key) external {
+        uint256 resource =
+            PermissionedResolverLib.resource(
+                NameCoder.namehash(testName, 0),
+                PermissionedResolverLib.partHash(key)
+            );
+        vm.expectEmit();
+        emit PermissionedResolver.NamedDataResource(resource, testName, keccak256(bytes(key)), key);
+        vm.prank(owner);
+        resolver.authorizeDataRoles(testName, key, friend, true);
+        assertTrue(resolver.hasRoles(resource, PermissionedResolverLib.ROLE_SET_DATA, friend));
+
+        vm.prank(owner);
+        resolver.authorizeDataRoles(testName, key, friend, false);
+        assertFalse(resolver.hasRoles(resource, PermissionedResolverLib.ROLE_SET_DATA, friend));
+    }
+
+    function test_authorizeDataRoles_anyName() external {
+        vm.prank(owner);
+        resolver.authorizeDataRoles(NameCoder.encode(""), testString, friend, true);
+        vm.prank(owner);
+        resolver.authorizeDataRoles(NameCoder.encode(""), testString, friend, false);
+    }
+
+    function test_authorizeDataRoles_notRoot() external {
+        vm.prank(owner);
+        resolver.authorizeNameRoles(
+            testName,
+            PermissionedResolverLib.ROLE_SET_DATA_ADMIN,
+            actor,
+            true
+        );
+        vm.prank(actor);
+        resolver.authorizeDataRoles(testName, testString, friend, true);
+        vm.prank(actor);
+        resolver.authorizeDataRoles(testName, testString, friend, false);
+    }
+
+    function test_authorizeDataRoles_notAuthorized() external {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACCannotGrantRoles.selector,
+                PermissionedResolverLib.resource(NameCoder.namehash(testName, 0), 0),
+                PermissionedResolverLib.ROLE_SET_DATA,
+                friend
+            )
+        );
+        vm.prank(friend);
+        resolver.authorizeDataRoles(testName, testString, owner, true);
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/test/unit/resolver/PublicResolverV2.t.sol
+++ b/contracts/test/unit/resolver/PublicResolverV2.t.sol
@@ -167,6 +167,39 @@ contract PublicResolverV2Test is V1Fixture, V2Fixture {
         publicResolver.setAddr(node, testOwner);
     }
 
+    ////////////////////////////////////////////////////////////////////////
+    // Approval
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_isApprovedForAll() external {
+        assertFalse(publicResolver.isApprovedForAll(testOwner, friend));
+
+        vm.expectEmit();
+        emit PublicResolverV2.ApprovalForAll(testOwner, friend, true);
+        vm.prank(testOwner);
+        publicResolver.setApprovalForAll(friend, true);
+
+        assertTrue(publicResolver.isApprovedForAll(testOwner, friend), "friend");
+        assertFalse(publicResolver.isApprovedForAll(testOwner, actor), "actor");
+    }
+
+    function test_isApprovedFor(bytes32 node) external {
+        assertFalse(publicResolver.isApprovedFor(testOwner, node, friend));
+
+        vm.expectEmit();
+        emit PublicResolverV2.Approved(testOwner, node, friend, true);
+        vm.prank(testOwner);
+        publicResolver.approve(node, friend, true);
+
+        assertTrue(publicResolver.isApprovedFor(testOwner, node, friend), "friend");
+        assertFalse(publicResolver.isApprovedFor(testOwner, ~node, friend), "other node");
+        assertFalse(publicResolver.isApprovedFor(testOwner, node, actor), "other actor");
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Helpers
+    ////////////////////////////////////////////////////////////////////////
+
     function _register(string memory label) internal returns (bytes32 node) {
         // register wrapped name in v1
         bytes memory name = registerWrappedETH2LD(label, 0);

--- a/contracts/test/unit/resolver/PublicResolverV2.t.sol
+++ b/contracts/test/unit/resolver/PublicResolverV2.t.sol
@@ -1,9 +1,24 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
+import {IMulticallable} from "@ens/contracts/resolvers/IMulticallable.sol";
+import {IABIResolver} from "@ens/contracts/resolvers/profiles/IABIResolver.sol";
+import {IAddressResolver} from "@ens/contracts/resolvers/profiles/IAddressResolver.sol";
+import {IAddrResolver} from "@ens/contracts/resolvers/profiles/IAddrResolver.sol";
+import {IContentHashResolver} from "@ens/contracts/resolvers/profiles/IContentHashResolver.sol";
+import {IDNSRecordResolver} from "@ens/contracts/resolvers/profiles/IDNSRecordResolver.sol";
+import {IDNSZoneResolver} from "@ens/contracts/resolvers/profiles/IDNSZoneResolver.sol";
+import {IDataResolver} from "@ens/contracts/resolvers/profiles/IDataResolver.sol";
+import {IHasAddressResolver} from "@ens/contracts/resolvers/profiles/IHasAddressResolver.sol";
+import {IInterfaceResolver} from "@ens/contracts/resolvers/profiles/IInterfaceResolver.sol";
+import {INameResolver} from "@ens/contracts/resolvers/profiles/INameResolver.sol";
+import {IPubkeyResolver} from "@ens/contracts/resolvers/profiles/IPubkeyResolver.sol";
+import {ITextResolver} from "@ens/contracts/resolvers/profiles/ITextResolver.sol";
 
 import {PublicResolverV2} from "~src/resolver/PublicResolverV2.sol";
+import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
 import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
 import {V1Fixture} from "~test/fixtures/V1Fixture.sol";
 import {V2Fixture} from "~test/fixtures/V2Fixture.sol";
@@ -18,6 +33,94 @@ contract PublicResolverV2Test is V1Fixture, V2Fixture {
         deployV1Fixture();
         deployV2Fixture();
         publicResolver = new PublicResolverV2(nameWrapper, rootRegistry, contractNamer);
+    }
+
+    function test_supportsInterface() external view {
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(publicResolver),
+                type(IMulticallable).interfaceId
+            ),
+            "IMulticallable"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(publicResolver),
+                type(IContractNamer).interfaceId
+            ),
+            "IContractNamer"
+        );
+
+        // profiles
+        assertTrue(
+            ERC165Checker.supportsInterface(address(publicResolver), type(IABIResolver).interfaceId),
+            "IABIResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(publicResolver), type(IAddrResolver).interfaceId),
+            "IAddrResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(publicResolver),
+                type(IAddressResolver).interfaceId
+            ),
+            "IAddressResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(publicResolver),
+                type(IContentHashResolver).interfaceId
+            ),
+            "IContentHashResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(publicResolver), type(IDataResolver).interfaceId),
+            "IDataResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(publicResolver),
+                type(IDNSRecordResolver).interfaceId
+            ),
+            "IDNSRecordResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(publicResolver),
+                type(IDNSZoneResolver).interfaceId
+            ),
+            "IDNSZoneResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(publicResolver),
+                type(IHasAddressResolver).interfaceId
+            ),
+            "IHasAddressResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(publicResolver),
+                type(IInterfaceResolver).interfaceId
+            ),
+            "IInterfaceResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(publicResolver), type(INameResolver).interfaceId),
+            "INameResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(publicResolver),
+                type(IPubkeyResolver).interfaceId
+            ),
+            "IPubkeyResolver"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(publicResolver), type(ITextResolver).interfaceId),
+            "ITextResolver"
+        );
     }
 
     function test_canModifyName() external {

--- a/contracts/test/unit/universalResolver/libraries/LibRegistry.t.sol
+++ b/contracts/test/unit/universalResolver/libraries/LibRegistry.t.sol
@@ -264,6 +264,20 @@ contract LibRegistryTest is Test, ERC1155Holder {
         );
     }
 
+    function test_findCanonical_wrongChild() external {
+        PermissionedRegistry ethRegistry = _createRegistry();
+        PermissionedRegistry testRegistry = _createRegistry();
+        _register(rootRegistry, "eth", ethRegistry, address(0));
+        uint256 tokenId = _register(ethRegistry, "test", testRegistry, address(0));
+        ethRegistry.setSubregistry(tokenId, IRegistry(address(0))); // wrong
+        assertEq(LibRegistry.findCanonicalName(rootRegistry, testRegistry), "", "findCanonicalName");
+        assertEq(
+            address(LibRegistry.findCanonicalRegistry(rootRegistry, NameCoder.encode("test.eth"))),
+            address(0),
+            "findCanonicalRegistry"
+        );
+    }
+
     function test_findCanonical_aliased() external {
         PermissionedRegistry ethRegistry = _createRegistry();
         PermissionedRegistry testRegistry = _createRegistry();
@@ -328,8 +342,9 @@ contract LibRegistryTest is Test, ERC1155Holder {
         address resolver
     )
         internal
+        returns (uint256 tokenId)
     {
-        parentRegistry.register(
+        tokenId = parentRegistry.register(
             label,
             address(this),
             registry,

--- a/contracts/test/unit/utils/ContactNamer.t.sol
+++ b/contracts/test/unit/utils/ContactNamer.t.sol
@@ -5,12 +5,16 @@ import {Test} from "forge-std/Test.sol";
 
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
 import {ContractNamer} from "~src/utils/ContractNamer.sol";
+import {DelegatedContractNamer} from "~src/utils/DelegatedContractNamer.sol";
 import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
 
 contract ContractNamerTest is Test {
     ContractNamer contractNamer;
+    MockDelegated delegated;
+
     address owner = makeAddr("owner");
 
     function setUp() external {
@@ -22,11 +26,26 @@ contract ContractNamerTest is Test {
                 )
             )
         );
+        delegated = new MockDelegated(contractNamer);
+    }
+
+    function test_supportsInterface() external view {
+        assertTrue(
+            ERC165Checker.supportsInterface(address(contractNamer), type(IContractNamer).interfaceId),
+            "IContractNamer"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(delegated), type(IContractNamer).interfaceId),
+            "IContractNamer"
+        );
     }
 
     function test_isContractNamer() external view {
         assertFalse(contractNamer.isContractNamer(address(0)));
         assertTrue(contractNamer.isContractNamer(owner));
+
+        assertFalse(delegated.isContractNamer(address(0)));
+        assertTrue(delegated.isContractNamer(owner));
     }
 
     function test_upgrade() external {
@@ -49,4 +68,9 @@ contract MockUpgrade is UUPSUpgradeable, IContractNamer {
         return namer == address(1);
     }
     function _authorizeUpgrade(address) internal override {}
+}
+
+
+contract MockDelegated is DelegatedContractNamer {
+    constructor(IContractNamer namer) DelegatedContractNamer(namer) {}
 }

--- a/contracts/test/unit/utils/ContactNamer.t.sol
+++ b/contracts/test/unit/utils/ContactNamer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity >=0.8.13;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/contracts/test/unit/utils/ContactNamer.t.sol
+++ b/contracts/test/unit/utils/ContactNamer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity ^0.8.13;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/contracts/test/unit/utils/LabelStore.t.sol
+++ b/contracts/test/unit/utils/LabelStore.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import {Test, Vm} from "forge-std/Test.sol";
 
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
 import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
 import {ILabelStore} from "~src/utils/interfaces/ILabelStore.sol";
@@ -15,6 +16,13 @@ contract LabelStoreTest is Test {
 
     function setUp() external {
         labelStore = new LabelStore(IContractNamer(address(0)));
+    }
+
+    function test_supportsInterface() external view {
+        assertTrue(
+            ERC165Checker.supportsInterface(address(labelStore), type(ILabelStore).interfaceId),
+            "ILabelStore"
+        );
     }
 
     function test_setLabel(string calldata label, uint32 version) external {

--- a/contracts/test/unit/utils/LibMem.t.sol
+++ b/contracts/test/unit/utils/LibMem.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {LibMem} from "~src/utils/LibMem.sol";
+
+contract LibMemTest is Test {
+    function test_ptr() external view {
+        for (uint256 i; i < 100; ++i) {
+            bytes memory v = new bytes(i);
+            uint256 ptr;
+            assembly {
+                ptr := add(v, 32)
+            }
+            assertEq(ptr, LibMem.ptr(v));
+        }
+    }
+
+    function test_load() external view {
+        for (uint256 i; i < 100; ++i) {
+            bytes memory v = new bytes(i);
+            uint256 value;
+            assembly {
+                value := mload(add(v, 32))
+            }
+            assertEq(value, LibMem.load(LibMem.ptr(v)));
+        }
+    }
+
+    function test_copy(bytes memory v0) external view {
+        bytes memory v = new bytes(v0.length);
+        LibMem.copy(LibMem.ptr(v), LibMem.ptr(v0), v0.length);
+        assertEq(v, v0);
+    }
+}

--- a/contracts/test/unit/utils/PermissionedAddressSet.t.sol
+++ b/contracts/test/unit/utils/PermissionedAddressSet.t.sol
@@ -3,8 +3,16 @@ pragma solidity ^0.8.13;
 
 import {Test} from "forge-std/Test.sol";
 
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+
 import {IEnhancedAccessControl} from "~src/access-control/interfaces/IEnhancedAccessControl.sol";
-import {PermissionedAddressSet, ROLE_APPROVE} from "~src/utils/PermissionedAddressSet.sol";
+import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
+import {IAddressSet} from "~src/utils/interfaces/IAddressSet.sol";
+import {
+    PermissionedAddressSet,
+    ROLE_APPROVE,
+    ROLE_CAN_NAME
+} from "~src/utils/PermissionedAddressSet.sol";
 
 contract PermissionedAddressSetTest is Test {
     PermissionedAddressSet set;
@@ -14,6 +22,17 @@ contract PermissionedAddressSetTest is Test {
 
     function setUp() external {
         set = new PermissionedAddressSet(address(this));
+    }
+
+    function test_supportsInterface() external view {
+        assertTrue(
+            ERC165Checker.supportsInterface(address(set), type(IAddressSet).interfaceId),
+            "IAddressSet"
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(address(set), type(IContractNamer).interfaceId),
+            "IContractNamer"
+        );
     }
 
     function test_approve_notAuthorized() external {
@@ -70,5 +89,17 @@ contract PermissionedAddressSetTest is Test {
 
         vm.prank(friend);
         set.approve(testAddr, true);
+    }
+
+    function test_isContractNamer() external {
+        assertTrue(set.isContractNamer(address(this)));
+
+        assertFalse(set.isContractNamer(friend), "before");
+
+        set.grantRootRoles(ROLE_CAN_NAME, friend);
+        assertTrue(set.isContractNamer(friend), "granted");
+
+        set.revokeRootRoles(ROLE_CAN_NAME, friend);
+        assertFalse(set.isContractNamer(friend), "revoked");
     }
 }


### PR DESCRIPTION
- changed from `365.25 days` to `365 days` for pricing
- ~~bumped `lib/ens-contracts`~~
- canonicalized `ROLE_CAN_NAME` for `IContractNamer` (some were `ROLE_SET_NAME`)
- changed `Graveyard`
     * fixed `clear()` logic for locked parent 
     * added `error NameRequiresPreimage()`
- changed `ERC1155Singleton`
     * fixed `balanceOf(address(0), *) == 1`
- improved test coverage: `97.88%` &rarr; `99.92%`
     * `Graveyard`
     * `PublicResolverV2` 
     * `PermissionedAddressSet`
     * `EnhancedAccessControl`
     * `LabelStore`
     * `ContractNamer`
     * `DelegatedContractNamer`
     * `ERC1155Singleton`
     * `PermissionedRegistry`
     * `UserRegistry`
     * `LibMem`
     * `LibRegistry`