### PR TITLE
fix(migration): preserve CAN_EXTEND_EXPIRY when migrating emancipated names [NM-0919]

### DIFF
--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -177,15 +177,15 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
                 NAME_WRAPPER.setResolver(node, address(0)); // clear ENSv1 resolver
                 NAME_WRAPPER.unwrap(parentNode, labelHash, GRAVEYARD); // unwrap and transfer to graveyard
 
-                // add name to ENSv2 (same as UnlockedMigrationController)
-                _inject(
-                    md.label,
-                    md.owner,
-                    md.subregistry,
-                    resolver,
-                    REGISTRATION_ROLE_BITMAP,
-                    expiry
-                );
+                // add name to ENSv2 (same as UnlockedMigrationController, plus
+                // renewal rights when the name could extend its own expiry in v1)
+                uint256 roleBitmap = REGISTRATION_ROLE_BITMAP;
+                if ((fuses & CAN_EXTEND_EXPIRY) != 0) {
+                    roleBitmap |=
+                        RegistryRolesLib.ROLE_RENEW |
+                        RegistryRolesLib.ROLE_RENEW_ADMIN;
+                }
+                _inject(md.label, md.owner, md.subregistry, resolver, roleBitmap, expiry);
             } else {
                 revert LibMigration.NameNotLocked(uint256(node));
             }

--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -181,9 +181,7 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
                 // renewal rights when the name could extend its own expiry in v1)
                 uint256 roleBitmap = REGISTRATION_ROLE_BITMAP;
                 if ((fuses & CAN_EXTEND_EXPIRY) != 0) {
-                    roleBitmap |=
-                        RegistryRolesLib.ROLE_RENEW |
-                        RegistryRolesLib.ROLE_RENEW_ADMIN;
+                    roleBitmap |= RegistryRolesLib.ROLE_RENEW | RegistryRolesLib.ROLE_RENEW_ADMIN;
                 }
                 _inject(md.label, md.owner, md.subregistry, resolver, roleBitmap, expiry);
             } else {

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -806,6 +806,70 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         registry2.renew(tokenId, expiry + 1);
     }
 
+    function test_migrate_emancipated_canExtendExpiry() external {
+        bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        vm.prank(friend);
+        bytes memory name3 =
+            this.createWrappedChild(name2, "sub", PARENT_CANNOT_CONTROL | CAN_EXTEND_EXPIRY);
+        vm.prank(friend);
+        bytes memory name3plain = this.createWrappedChild(name2, "plain", PARENT_CANNOT_CONTROL);
+
+        // migrate 2LD
+        LibMigration.Data memory data2 = _lockedData(name2);
+        vm.prank(testOwner);
+        nameWrapper.safeTransferFrom(
+            testOwner,
+            address(migrationController),
+            uint256(NameCoder.namehash(name2, 0)),
+            1,
+            abi.encode(data2)
+        );
+        IWrapperRegistry registry2 =
+            IWrapperRegistry(address(ethRegistry.getSubregistry(data2.label)));
+
+        // migrate emancipated 3LD with CAN_EXTEND_EXPIRY
+        LibMigration.Data memory data3 = _lockedData(name3);
+        vm.prank(friend);
+        nameWrapper.safeTransferFrom(
+            friend,
+            address(registry2),
+            uint256(NameCoder.namehash(name3, 0)),
+            1,
+            abi.encode(data3)
+        );
+
+        uint256 tokenId = registry2.getTokenId(LibLabel.id(data3.label));
+        assertTrue(
+            registry2.hasRoles(
+                tokenId,
+                RegistryRolesLib.ROLE_RENEW | RegistryRolesLib.ROLE_RENEW_ADMIN,
+                friend
+            ),
+            "ROLE_RENEW + ROLE_RENEW_ADMIN"
+        );
+
+        uint64 expiry = registry2.getExpiry(tokenId);
+        vm.prank(friend);
+        registry2.renew(tokenId, expiry + 1);
+
+        // migrate emancipated 3LD without CAN_EXTEND_EXPIRY
+        LibMigration.Data memory data3plain = _lockedData(name3plain);
+        vm.prank(friend);
+        nameWrapper.safeTransferFrom(
+            friend,
+            address(registry2),
+            uint256(NameCoder.namehash(name3plain, 0)),
+            1,
+            abi.encode(data3plain)
+        );
+
+        uint256 tokenIdPlain = registry2.getTokenId(LibLabel.id(data3plain.label));
+        assertFalse(
+            registry2.hasRoles(tokenIdPlain, RegistryRolesLib.ROLE_RENEW, friend),
+            "no ROLE_RENEW"
+        );
+    }
+
     function test_migrate_lockedChildren() external {
         bytes memory name2 = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         vm.prank(friend);


### PR DESCRIPTION
Fixes NM-0919 finding: "Migrating an emancipated non-locked name drops the CAN_EXTEND_EXPIRY permission".
  
