### PR TITLE
Fix `ETHRenewerV1.syncWrapper()` juggle

### DIFF
--- a/contracts/deploy/03_ETHRenewerV1.ts
+++ b/contracts/deploy/03_ETHRenewerV1.ts
@@ -19,9 +19,8 @@ export default execute(
       "StandardRentPriceOracle",
     );
 
-    const baseRegistrar = get<
-      (typeof artifacts.BaseRegistrarImplementation)["abi"]
-    >("BaseRegistrarImplementation");
+    const nameWrapper =
+      get<(typeof artifacts.NameWrapper)["abi"]>("NameWrapper");
 
     const wrappedController = get<
       (typeof artifacts.IWrappedETHRegistrarController)["abi"]
@@ -37,7 +36,7 @@ export default execute(
         rentPriceOracle.address,
         GRACE_PERIOD_V2,
         PREMIGRATION_BONUS_PERIOD,
-        baseRegistrar.address,
+        nameWrapper.address,
         wrappedController.address,
       ],
     });
@@ -53,7 +52,7 @@ export default execute(
     dependencies: [
       "ETHRegistry",
       "StandardRentPriceOracle",
-      "BaseRegistrarImplementation",
+      "NameWrapper",
       "WrappedETHRegistrarController",
     ],
   },

--- a/contracts/foundry.lock
+++ b/contracts/foundry.lock
@@ -3,7 +3,7 @@
     "rev": "82cc81935de1d1a82e021cf1030d902c5248982b"
   },
   "lib/ens-contracts": {
-    "rev": "5787a5fd9eaff6cdba3d9d23d3ce4ec2b50d4e4d"
+    "rev": "3b1cc225ccdf64581d5fdc81db574f51ba5c8c09"
   },
   "lib/forge-std": {
     "rev": "77041d2ce690e692d6e03cc812b57d1ddaa4d505"

--- a/contracts/script/setup.ts
+++ b/contracts/script/setup.ts
@@ -335,6 +335,11 @@ export async function setupDevnet({
         address: rocketh.get("NameWrapper").address,
         client,
       }),
+      // WrappedETHRegistrarController: getContract({
+      //   abi: artifacts.IWrappedETHRegistrarController.abi,
+      //   address: rocketh.get("WrappedETHRegistrarController").address,
+      //   client,
+      // }),
       RegistrarSecurityController: getContract({
         abi: artifacts.RegistrarSecurityController.abi,
         address: rocketh.get("RegistrarSecurityController").address,
@@ -801,6 +806,7 @@ export async function setupDevnet({
         ? ENS_DAO_MULTISIG
         : namedAccounts.owner;
       // lock NameWrapper if still owned (idempotent across fork + synthetic)
+
       if ((await v1.NameWrapper.read.owner()) !== zeroAddress) {
         await v1.NameWrapper.write.renounceOwnership({ account });
       }
@@ -822,7 +828,6 @@ export async function setupDevnet({
       // in synthetic-devnet mode.
       const v1ControllerNames = [
         "ETHRegistrarController",
-        "WrappedETHRegistrarController",
         "LegacyETHRegistrarController",
         "NameWrapper",
       ] as const;

--- a/contracts/src/registrar/ETHRenewerV1.sol
+++ b/contracts/src/registrar/ETHRenewerV1.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.13;
 import {
     BaseRegistrarImplementation
 } from "@ens/contracts/ethregistrar/BaseRegistrarImplementation.sol";
+import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
 
 import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
 import {LibLabel} from "../utils/LibLabel.sol";
@@ -13,6 +14,8 @@ import {IETHRenewer} from "./interfaces/IETHRenewer.sol";
 import {IRentPriceOracle} from "./interfaces/IRentPriceOracle.sol";
 
 /// @notice `ETHRegistrarController.renew()` stub interface.
+/// @dev Interface selector: `0xacf1a841`
+// https://github.com/ensdomains/ens-contracts/blob/staging/deployments/mainnet/WrappedETHRegistrarController.json
 /// @dev Interface selector: `0xacf1a841`
 interface IWrappedETHRegistrarController {
     /// @notice Renew an ENSv1 name.
@@ -40,6 +43,9 @@ contract ETHRenewerV1 is AbstractETHRegistrar {
     /// @dev ENSv2 `GRACE_PERIOD`.
     uint64 internal immutable _GRACE_PERIOD_V2;
 
+    /// @notice The ENSv1 `NameWrapper` contract.
+    INameWrapper public immutable NAME_WRAPPER;
+
     /// @notice ENSv1 `BaseRegistrarImplementation` contract.
     BaseRegistrarImplementation public immutable BASE_REGISTRAR;
 
@@ -56,7 +62,7 @@ contract ETHRenewerV1 is AbstractETHRegistrar {
     /// @param oracle Initial oracle for registration and renewal costs.
     /// @param gracePeriod Post-expiry period where renewable and not available, in seconds.
     /// @param bonusPeriod Duration added by premigration, in seconds.
-    /// @param baseRegistrar ENSv1 `BaseRegistrarImplementation` contract.
+    /// @param nameWrapper ENSv1 `NameWrapper` contract.
     /// @param wrappedController ENSv1 `ETHRegistrarController` that is a `NameWrapper` controller.
     constructor(
         address owner_,
@@ -65,14 +71,15 @@ contract ETHRenewerV1 is AbstractETHRegistrar {
         IRentPriceOracle oracle,
         uint64 gracePeriod,
         uint64 bonusPeriod,
-        BaseRegistrarImplementation baseRegistrar,
+        INameWrapper nameWrapper,
         address wrappedController
     )
         AbstractETHRegistrar(owner_, ethRegistry, beneficiary, oracle)
     {
         GRACE_PERIOD = bonusPeriod + gracePeriod;
         _GRACE_PERIOD_V2 = gracePeriod;
-        BASE_REGISTRAR = baseRegistrar;
+        NAME_WRAPPER = nameWrapper;
+        BASE_REGISTRAR = BaseRegistrarImplementation(address(nameWrapper.registrar()));
         WRAPPED_CONTROLLER = IWrappedETHRegistrarController(wrappedController);
     }
 
@@ -89,11 +96,11 @@ contract ETHRenewerV1 is AbstractETHRegistrar {
     /// @notice Sync `NameWrapper` expiry with `BaseRegistrarImplementation` expiry.
     /// @param labels The labels to sync.
     function syncWrapper(string[] calldata labels) external {
-        BASE_REGISTRAR.addController(address(WRAPPED_CONTROLLER));
+        BASE_REGISTRAR.addController(address(NAME_WRAPPER));
         for (uint256 i; i < labels.length; ++i) {
             WRAPPED_CONTROLLER.renew(labels[i], 0);
         }
-        BASE_REGISTRAR.removeController(address(WRAPPED_CONTROLLER));
+        BASE_REGISTRAR.removeController(address(NAME_WRAPPER));
     }
 
     /// @inheritdoc IETHRenewer

--- a/contracts/test/e2e/migration.test.ts
+++ b/contracts/test/e2e/migration.test.ts
@@ -444,6 +444,12 @@ describe("Migration", () => {
         "NameNotRenewable",
       );
     });
+
+    it("syncWrapper", async () => {
+      const unlocked = await registerWrapped();
+      await env.activateV2();
+      await env.v2.ETHRenewerV1.write.syncWrapper([[unlocked.label]]);
+    });
   });
 
   describe("unwrapped", () => {

--- a/contracts/test/unit/registrar/ETHRenewerV1.t.sol
+++ b/contracts/test/unit/registrar/ETHRenewerV1.t.sol
@@ -46,7 +46,7 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
             rentPriceOracle,
             StandardRegistrar.GRACE_PERIOD_V2,
             StandardRegistrar.BONUS_PERIOD,
-            baseRegistrar,
+            nameWrapper,
             address(wrappedController)
         );
 
@@ -55,6 +55,8 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
         baseRegistrar.addController(address(ethRenewerV1));
         baseRegistrar.transferOwnership(address(ethRenewerV1));
         nameWrapper.renounceOwnership();
+
+        // note: nameWrapper is still baseRegistrar controller, see: _activateV2()
 
         setupPaymentTokens(testOwner, address(ethRenewerV1));
         testPaymentToken = tokenUSDC;
@@ -69,6 +71,7 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
 
     function test_constructor() external view {
         assertEq(ethRenewerV1.GRACE_PERIOD(), gracePeriodV1, "GRACE_PERIOD");
+        assertEq(address(ethRenewerV1.NAME_WRAPPER()), address(nameWrapper), "NAME_WRAPPER");
         assertEq(address(ethRenewerV1.BASE_REGISTRAR()), address(baseRegistrar), "BASE_REGISTRAR");
         assertEq(
             address(ethRenewerV1.WRAPPED_CONTROLLER()),
@@ -285,6 +288,7 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
 
     function test_syncWrapper_unwrapped() external {
         registerUnwrapped(testLabel);
+        _activateV2(true);
         string[] memory labels = new string[](1);
         labels[0] = testLabel;
         uint256 g = gasleft();
@@ -298,16 +302,27 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
         console.log("N | Gas");
         for (uint256 n; n <= 5; ++n) {
             string[] memory labels = new string[](n);
+            _activateV2(false);
             for (uint256 i; i < n; ++i) {
                 string memory label = labels[i] = _label(k++);
                 registerWrappedETH2LD(label, 0);
                 vm.prank(address(ethControllerV1));
                 baseRegistrar.renew(LibLabel.id(label), 1);
             }
+            _activateV2(true);
             uint256 g = gasleft();
             ethRenewerV1.syncWrapper(labels);
             g -= gasleft();
             console.log("%s | %s", n, g);
+        }
+    }
+
+    function _activateV2(bool on) internal {
+        vm.prank(address(ethRenewerV1));
+        if (on) {
+            baseRegistrar.removeController(address(nameWrapper));
+        } else {
+            baseRegistrar.addController(address(nameWrapper));
         }
     }
 }


### PR DESCRIPTION
- bumped `lib/ens-contracts` (deploy fix)
- changed `ETHRenewerV1`
     * takes `NameWapper` instead of `BaseRegistrar`
     * juggles `NameWrapper` instead of `WrappedController`
     * fixed `syncWrapper()` test
- added test to `migration.test.ts` for `syncWrapper()`