### PR TITLE
Fix `PermissionRegistry._getSettableRoles()` when expired

### DIFF
--- a/contracts/src/migration/LockedWrapperReceiver.sol
+++ b/contracts/src/migration/LockedWrapperReceiver.sol
@@ -136,7 +136,7 @@ abstract contract LockedWrapperReceiver is AbstractWrapperReceiver {
                     NAME_WRAPPER.setResolver(node, address(0)); // clear ENSv1 resolver
                 } else {
                     resolver = _REGISTRY_V1.resolver(node); // replace with ENSv1 resolver
-                    if (PUBLIC_RESOLVER_SET.includes(resolver)) {
+                    if (resolver != address(0) && PUBLIC_RESOLVER_SET.includes(resolver)) {
                         resolver = PUBLIC_RESOLVER; // replace with new PublicResolver
                     }
                 }

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -250,10 +250,7 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
     /// @inheritdoc IRegistry
     function getSubregistry(string calldata label) public view virtual returns (IRegistry) {
         Entry storage entry = _entry(LibLabel.id(label));
-        return
-            _isExpired(entry.expiry)
-                ? IRegistry(address(0))
-                : entry.subregistry;
+        return _isExpired(entry.expiry) ? IRegistry(address(0)) : entry.subregistry;
     }
 
     /// @inheritdoc IRegistry
@@ -568,10 +565,7 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
             return 0;
         }
         uint256 roleBitmap = super._getSettableRoles(resource, account);
-        return
-            resource == ROOT_RESOURCE
-                ? roleBitmap
-                : roleBitmap >> 128;
+        return resource == ROOT_RESOURCE ? roleBitmap : roleBitmap >> 128;
     }
 
     /// @inheritdoc EnhancedAccessControl

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -564,11 +564,14 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
         override
         returns (uint256)
     {
+        if (resource != ROOT_RESOURCE && getOwner(resource) == address(0)) {
+            return 0;
+        }
         uint256 roleBitmap = super._getSettableRoles(resource, account);
         return
             resource == ROOT_RESOURCE
                 ? roleBitmap
-                : getOwner(resource) == address(0) ? 0 : roleBitmap >> 128;
+                : roleBitmap >> 128;
     }
 
     /// @inheritdoc EnhancedAccessControl
@@ -586,7 +589,7 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
         roleBitmap = super._getRoles(resource, account);
         if (resource != ROOT_RESOURCE) {
             address owner = getOwner(resource);
-            if (owner != address(0) && isApprovedForAll(owner, account)) {
+            if (owner != address(0) && owner != account && isApprovedForAll(owner, account)) {
                 roleBitmap |= super._getRoles(resource, owner);
             }
         }

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -574,8 +574,7 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
     /// @inheritdoc EnhancedAccessControl
     /// @dev Override for token-dependent logic:
     ///
-    /// * if token is expired (available or reserved), return null.
-    /// * if caller is approved by token owner, OR the caller's roles with the owner's roles
+    /// * if caller is approved by token owner, combine the caller's roles with the owner's roles
     ///
     function _getRoles(uint256 resource, address account)
         internal

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -279,7 +279,7 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
 
     /// @inheritdoc IOwnedRegistry
     function findOwner(string calldata label) public view returns (address) {
-        return ownerOf(findTokenId(label));
+        return getOwner(LibLabel.id(label));
     }
 
     /// @inheritdoc ITokenizedRegistry
@@ -308,6 +308,11 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
     /// @inheritdoc IPermissionedRegistry
     function getTokenId(uint256 anyId) public view returns (uint256) {
         return _constructTokenId(anyId, _entry(anyId));
+    }
+
+    /// @inheritdoc IPermissionedRegistry
+    function getOwner(uint256 anyId) public view returns (address) {
+        return _isExpired(getExpiry(anyId)) ? address(0) : super.ownerOf(getTokenId(anyId));
     }
 
     /// @inheritdoc IPermissionedRegistry
@@ -560,7 +565,10 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
         returns (uint256)
     {
         uint256 roleBitmap = super._getSettableRoles(resource, account);
-        return resource == ROOT_RESOURCE ? roleBitmap : roleBitmap >> 128;
+        return
+            resource == ROOT_RESOURCE
+                ? roleBitmap
+                : getOwner(resource) == address(0) ? 0 : roleBitmap >> 128;
     }
 
     /// @inheritdoc EnhancedAccessControl
@@ -578,7 +586,7 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
     {
         roleBitmap = super._getRoles(resource, account);
         if (resource != ROOT_RESOURCE) {
-            address owner = ownerOf(_constructTokenId(resource, _entry(resource)));
+            address owner = getOwner(resource);
             if (owner != address(0) && isApprovedForAll(owner, account)) {
                 roleBitmap |= super._getRoles(resource, owner);
             }

--- a/contracts/src/registry/interfaces/IPermissionedRegistry.sol
+++ b/contracts/src/registry/interfaces/IPermissionedRegistry.sol
@@ -6,7 +6,7 @@ import {IContractNamer} from "../../reverse-registrar/interfaces/IContractNamer.
 
 import {IStandardRegistry} from "./IStandardRegistry.sol";
 
-/// @dev Interface selector: `0xafff3a63`
+/// @dev Interface selector: `0x6be50c69`
 interface IPermissionedRegistry is IStandardRegistry, IEnhancedAccessControl, IContractNamer {
     ////////////////////////////////////////////////////////////////////////
     // Types
@@ -74,4 +74,9 @@ interface IPermissionedRegistry is IStandardRegistry, IEnhancedAccessControl, IC
     /// @param anyId The labelhash, token ID, or resource.
     /// @return tokenId The token ID.
     function getTokenId(uint256 anyId) external view returns (uint256 tokenId);
+
+    /// @notice Get token owner from `anyId`.
+    /// @param anyId The labelhash, token ID, or resource.
+    /// @return owner The token owner.
+    function getOwner(uint256 anyId) external view returns (address owner);
 }

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -995,6 +995,11 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         assertEq(registry.getExpiry(LibLabel.withVersion(tokenId, version)), testExpiry);
     }
 
+    function test_getOwner_anyId(uint32 version) external {
+        uint256 tokenId = this._register();
+        assertEq(registry.getOwner(LibLabel.withVersion(tokenId, version)), testOwner);
+    }
+
     function test_getStatus_anyId(uint32 version) external {
         uint256 tokenId = this._register();
         uint256 anyId = LibLabel.withVersion(tokenId, version);

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -639,6 +639,8 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         uint256 tokenId = this._register();
         assertEq(registry.ownerOf(tokenId), testOwner, "exact");
         assertEq(registry.ownerOf(tokenId + 1), address(0), "+1");
+        vm.warp(testExpiry);
+        assertEq(registry.ownerOf(tokenId), address(0), "expired");
     }
 
     // cleared after burn
@@ -1234,6 +1236,20 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         registry.grantRoles(tokenId, roleBitmap, user2);
     }
 
+    function test_grantRoles_whileUnregistered(uint256 anyId) external {
+        vm.assume(anyId > 0);
+        uint256 roleBitmap = _randomRoleBitmap(true, true);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACCannotGrantRoles.selector,
+                LibLabel.withVersion(anyId, 1), // next
+                roleBitmap,
+                address(this)
+            )
+        );
+        registry.grantRoles(anyId, roleBitmap, user2);
+    }
+
     function test_grantRoles_whileExpired(uint256) external {
         uint256 roleBitmap = _randomRoleBitmap(true, true);
 
@@ -1762,18 +1778,20 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         }
     }
 
+    /// @dev Randomly pick a role corresponding to the enable regions.
+    //       If both regions are enabled, pick 1-2 roles.
     function _randomRoleBitmap(bool admin, bool normal) internal returns (uint256 roleBitmap) {
-        uint256 bits;
-        if (normal) {
-            bits |= vm.randomUint(1, (1 << 32) - 1); // 1+ bits 0-31
-        }
-        if (admin) {
-            bits |= vm.randomUint((1 << 32), (1 << 64) - 1); // 1+ bits 32-63
-        }
-        for (uint256 i; i < 64; ++i) {
-            if ((bits & (1 << i)) != 0) {
-                roleBitmap |= 1 << (i << 2);
+        if (admin && normal) {
+            roleBitmap = 1 << (vm.randomUint(0, 63) << 2);
+            if (vm.randomBool()) {
+                roleBitmap |= 1 << (vm.randomUint(0, 63) << 2);
             }
+        } else if (normal) {
+            roleBitmap = 1 << (vm.randomUint(0, 31) << 2);
+        } else if (admin) {
+            roleBitmap = 1 << (vm.randomUint(32, 63) << 2);
+        } else {
+            revert("bug");
         }
     }
 }


### PR DESCRIPTION
- added `getOwner(anyId): owner`
- refactored `findOwner(label): owner` to use `getOwner(...)`
- changed `_getSettableRoles(...)` to check if registered
- fixed `_randomRoleBitmap(...)` for better fuzzing — a typical iteration wouldn't set a single bit and `(true, true)` would always set 2+ bits

---

- avoid checking `PUBLIC_RESOLVER_SET.includes(...)` if `resolver` is unset
- avoid checking `isApprovedForAll()` if `owner == account`