### PR TITLE
Add `ETHRenewerV1.setRegistrarResolver()`

### DIFF
--- a/contracts/src/registrar/ETHRenewerV1.sol
+++ b/contracts/src/registrar/ETHRenewerV1.sol
@@ -88,9 +88,17 @@ contract ETHRenewerV1 is AbstractETHRegistrar {
     ////////////////////////////////////////////////////////////////////////
 
     /// @notice Transfers ownership of the registrar.
+    /// @dev Same as `RegistrarSecurityController`.
     /// @param newOwner The new owner for the registrar.
     function transferRegistrarOwnership(address newOwner) external onlyOwner {
         BASE_REGISTRAR.transferOwnership(newOwner);
+    }
+
+    /// @notice Sets the registrar's resolver for the base node.
+    /// @dev Same as `RegistrarSecurityController`.
+    /// @param resolver The resolver address to set.
+    function setRegistrarResolver(address resolver) external onlyOwner {
+        BASE_REGISTRAR.setResolver(resolver);
     }
 
     /// @notice Sync `NameWrapper` expiry with `BaseRegistrarImplementation` expiry.

--- a/contracts/test/unit/registrar/ETHRenewerV1.t.sol
+++ b/contracts/test/unit/registrar/ETHRenewerV1.t.sol
@@ -5,6 +5,7 @@ import {console} from "forge-std/Test.sol";
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {IBaseRegistrar} from "@ens/contracts/ethregistrar/IBaseRegistrar.sol";
 
 import {LibLabel} from "~src/utils/LibLabel.sol";
@@ -89,6 +90,20 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, actor));
         vm.prank(actor);
         ethRenewerV1.transferRegistrarOwnership(actor);
+    }
+
+    function test_setRegistrarResolver() external {
+        assertEq(registryV1.resolver(NameCoder.ETH_NODE), address(ensV2Resolver));
+
+        ethRenewerV1.setRegistrarResolver(address(1));
+
+        assertEq(registryV1.resolver(NameCoder.ETH_NODE), address(1));
+    }
+
+    function test_setRegistrarResolver_notAuthorized() external {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, actor));
+        vm.prank(actor);
+        ethRenewerV1.setRegistrarResolver(address(1));
     }
 
     ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In ENSv2, `ETHRenewer` <ins>must</ins> own the ENSv1 `BaseRegistrar` to perform the controller juggle, see: `syncWrapper()`.

`BaseRegistrar.setResolver()` uses `onlyOwner` instead of `onlyController` so only the singular owner can call this function.

Effectively, `ETHRenewerV1` is a [RegistrarSecurityController](https://github.com/ensdomains/ens-contracts/blob/staging/contracts/ethregistrar/RegistrarSecurityController.sol) without any `BaseRegistrar` controller management (since ENSv1 is disabled.)

---

`ETHRenewerV1` already has `transferRegistrarOwnership()`, this PR adds `setRegistrarResolver()`, which makes changing the ENSv1 resolver for "eth" simple.  Without this change, the following steps would be required:
1. `ETHRenewerV1.transferRegistrarOwnership(DAO)`
1. `BaseRegistrar.setResolver(<resolver>)`
1. `BaseRegistrar.transferOwnership(ETHRenewerV1)`

---

**Usage**: the ENSv1 "eth" resolver should be set to the `ENSV2Resolver` at launch, and cleared (via this function) once the initial migration period is over (TBD).