### PR TITLE
Add `WrapperRegistry._getRoles()` support for virtual owner approvals

### DIFF
--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -246,16 +246,16 @@ contract WrapperRegistry is
     /// @inheritdoc PermissionedRegistry
     /// @dev Override for token-dependent logic:
     ///
-    /// * if root and account is token owner, remap to virtual owner.
+    /// * if root and account is token owner or approved, remap to virtual owner.
     ///
     function _getRoles(uint256 resource, address account) internal view override returns (uint256) {
         if (resource == ROOT_RESOURCE) {
             address parent = address(_parentRegistry); // virtual owner
-            if (
-                parent != address(0) &&
-                account == PermissionedRegistry(parent).findOwner(_childLabel)
-            ) {
-                return super._getRoles(resource, parent); // replace, instead of OR
+            if (parent != address(0)) {
+                address owner = PermissionedRegistry(parent).findOwner(_childLabel);
+                if (account == owner || PermissionedRegistry(parent).isApprovedForAll(owner, account)) {
+                    return super._getRoles(resource, parent); // replace, instead of OR
+                }
             }
         }
         return super._getRoles(resource, account);

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -253,7 +253,10 @@ contract WrapperRegistry is
             address parent = address(_parentRegistry); // virtual owner
             if (parent != address(0)) {
                 address owner = PermissionedRegistry(parent).findOwner(_childLabel);
-                if (account == owner || PermissionedRegistry(parent).isApprovedForAll(owner, account)) {
+                if (
+                    account == owner ||
+                    PermissionedRegistry(parent).isApprovedForAll(owner, account)
+                ) {
                     return super._getRoles(resource, parent); // replace, instead of OR
                 }
             }

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -580,6 +580,49 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
+    function test_migrate_setApprovalForAll() external {
+        bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        bytes32 node = NameCoder.namehash(name, 0);
+        LibMigration.Data memory md = _lockedData(name);
+
+        vm.prank(testOwner);
+        nameWrapper.safeTransferFrom(
+            testOwner,
+            address(migrationController),
+            uint256(node),
+            1,
+            abi.encode(md)
+        );
+
+        IPermissionedRegistry registry =
+            IPermissionedRegistry(address(ethRegistry.getSubregistry(md.label)));
+        address virtualOwner = address(ethRegistry);
+
+        assertEq(registry.roles(registry.ROOT_RESOURCE(), actor), 0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                registry.ROOT_RESOURCE(),
+                RegistryRolesLib.ROLE_REGISTRAR,
+                actor
+            )
+        );
+        vm.prank(actor);
+        registry.register(testLabel, actor, testRegistry, testResolver, 0, _soon());
+
+        vm.prank(testOwner);
+        ethRegistry.setApprovalForAll(actor, true);
+
+        assertEq(
+            registry.roles(registry.ROOT_RESOURCE(), actor),
+            registry.roles(registry.ROOT_RESOURCE(), testOwner)
+        );
+
+        vm.prank(actor);
+        registry.register(testLabel, actor, testRegistry, testResolver, 0, _soon());
+    }
+
     function test_migrate_transferRegistryControl() external {
         bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         bytes32 node = NameCoder.namehash(name, 0);


### PR DESCRIPTION
Extend virtual owner permissions to token approvals.

---

- changed `WrapperRegistry._getRoles()` to check `parent.isApprovedForAll()`
- added test
