### PR TITLE
Replace HCA.owner with HCA.isOwner

### DIFF
--- a/contracts/deploy/02_DefaultReverseRegistrarAdapter.ts
+++ b/contracts/deploy/02_DefaultReverseRegistrarAdapter.ts
@@ -16,10 +16,19 @@ export default execute(
     const contractNamer =
       get<(typeof artifacts.IContractNamer)["abi"]>("ContractNamer");
 
+    const verifiableFactory =
+      get<(typeof artifacts.VerifiableFactory)["abi"]>("VerifiableFactory");
+
     const adapter = await deploy("DefaultReverseRegistrarAdapter", {
       account: deployer,
       artifact: artifacts.DefaultReverseRegistrarAdapter,
-      args: [defaultReverseRegistrar.address, contractNamer.address],
+      args: [
+        defaultReverseRegistrar.address,
+        contractNamer.address,
+        verifiableFactory.address,
+        owner,
+        [],
+      ],
     });
 
     if (network.name === "mainnet" && !network.tags?.tenderly) return;
@@ -39,6 +48,10 @@ export default execute(
   },
   {
     tags: ["DefaultReverseRegistrarAdapter", "v2"],
-    dependencies: ["DefaultReverseRegistrar", "ContractNamer"],
+    dependencies: [
+      "DefaultReverseRegistrar",
+      "ContractNamer",
+      "VerifiableFactory",
+    ],
   },
 );

--- a/contracts/deploy/02_ReverseRegistrarAdapter.ts
+++ b/contracts/deploy/02_ReverseRegistrarAdapter.ts
@@ -15,10 +15,19 @@ export default execute(
     const contractNamer =
       get<(typeof artifacts.IContractNamer)["abi"]>("ContractNamer");
 
+    const verifiableFactory =
+      get<(typeof artifacts.VerifiableFactory)["abi"]>("VerifiableFactory");
+
     const adapter = await deploy("ReverseRegistrarAdapter", {
       account: deployer,
       artifact: artifacts.ReverseRegistrarAdapter,
-      args: [reverseRegistrar.address, contractNamer.address],
+      args: [
+        reverseRegistrar.address,
+        contractNamer.address,
+        verifiableFactory.address,
+        owner,
+        [],
+      ],
     });
 
     if (network.name === "mainnet" && !network.tags?.tenderly) return;
@@ -38,6 +47,6 @@ export default execute(
   },
   {
     tags: ["ReverseRegistrarAdapter", "v2"],
-    dependencies: ["ReverseRegistrar", "ContractNamer"],
+    dependencies: ["ReverseRegistrar", "ContractNamer", "VerifiableFactory"],
   },
 );

--- a/contracts/foundry.lock
+++ b/contracts/foundry.lock
@@ -27,6 +27,6 @@
     "rev": "7426ac57509e2023a673956439eed29998d2e371"
   },
   "lib/verifiable-factory": {
-    "rev": "04ec76f4c211bff795235feae90ad01882477ca1"
+    "rev": "803cfde220c2df5f5397996716f0762875f51123"
   }
 }

--- a/contracts/src/reverse-registrar/DefaultReverseRegistrarAdapter.sol
+++ b/contracts/src/reverse-registrar/DefaultReverseRegistrarAdapter.sol
@@ -4,8 +4,10 @@ pragma solidity ^0.8.25;
 import {
     IDefaultReverseRegistrar
 } from "@ens/contracts/reverseRegistrar/IDefaultReverseRegistrar.sol";
+import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
 
 import {DelegatedContractNamer} from "../utils/DelegatedContractNamer.sol";
+import {HCAAuthorizer} from "../utils/HCAAuthorizer.sol";
 
 import {IContractNamer} from "./interfaces/IContractNamer.sol";
 import {AccountNamerLib} from "./libraries/AccountNamerLib.sol";
@@ -13,7 +15,7 @@ import {AccountNamerLib} from "./libraries/AccountNamerLib.sol";
 /// @title Default Reverse Registrar Adapter
 /// @notice Forwarder for v1 `default.reverse` registrar updates.
 /// @dev The adapter must be configured as a controller on the default reverse registrar.
-contract DefaultReverseRegistrarAdapter is DelegatedContractNamer {
+contract DefaultReverseRegistrarAdapter is DelegatedContractNamer, HCAAuthorizer {
     ////////////////////////////////////////////////////////////////////////
     // Immutables
     ////////////////////////////////////////////////////////////////////////
@@ -27,8 +29,18 @@ contract DefaultReverseRegistrarAdapter is DelegatedContractNamer {
 
     /// @param defaultReverseRegistrar The v1 default reverse registrar for `default.reverse`.
     /// @param contractNamer Delegated contract namer.
-    constructor(IDefaultReverseRegistrar defaultReverseRegistrar, IContractNamer contractNamer)
+    /// @param verifiableFactory The VerifiableFactory used to verify HCA callers.
+    /// @param owner_ The owner allowed to update trusted HCA implementations.
+    /// @param initialTrustedHCAImplementations HCA implementations trusted at deployment.
+    constructor(
+        IDefaultReverseRegistrar defaultReverseRegistrar,
+        IContractNamer contractNamer,
+        IVerifiableFactory verifiableFactory,
+        address owner_,
+        address[] memory initialTrustedHCAImplementations
+    )
         DelegatedContractNamer(contractNamer)
+        HCAAuthorizer(verifiableFactory, owner_, initialTrustedHCAImplementations)
     {
         DEFAULT_REVERSE_REGISTRAR = defaultReverseRegistrar;
     }
@@ -42,6 +54,14 @@ contract DefaultReverseRegistrarAdapter is DelegatedContractNamer {
     /// @param name The primary name to store.
     function setName(address account, string calldata name) external {
         AccountNamerLib.requireNamer(account, msg.sender);
+        DEFAULT_REVERSE_REGISTRAR.setNameForAddr(account, name);
+    }
+
+    /// @notice Sets account's `default.reverse` primary name through an HCA caller.
+    /// @param account The account to name.
+    /// @param name The primary name to store.
+    function setNameWithHCA(address account, string calldata name) external {
+        _requireHCAForAccount(account);
         DEFAULT_REVERSE_REGISTRAR.setNameForAddr(account, name);
     }
 }

--- a/contracts/src/reverse-registrar/ReverseRegistrarAdapter.sol
+++ b/contracts/src/reverse-registrar/ReverseRegistrarAdapter.sol
@@ -2,8 +2,10 @@
 pragma solidity ^0.8.25;
 
 import {IReverseRegistrar} from "@ens/contracts/reverseRegistrar/IReverseRegistrar.sol";
+import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
 
 import {DelegatedContractNamer} from "../utils/DelegatedContractNamer.sol";
+import {HCAAuthorizer} from "../utils/HCAAuthorizer.sol";
 
 import {IContractNamer} from "./interfaces/IContractNamer.sol";
 import {AccountNamerLib} from "./libraries/AccountNamerLib.sol";
@@ -11,7 +13,7 @@ import {AccountNamerLib} from "./libraries/AccountNamerLib.sol";
 /// @title Reverse Registrar Adapter
 /// @notice Forwarder for v1 `addr.reverse` registrar updates.
 /// @dev The adapter must be configured as a controller on the reverse registrar.
-contract ReverseRegistrarAdapter is DelegatedContractNamer {
+contract ReverseRegistrarAdapter is DelegatedContractNamer, HCAAuthorizer {
     ////////////////////////////////////////////////////////////////////////
     // Immutables
     ////////////////////////////////////////////////////////////////////////
@@ -25,8 +27,18 @@ contract ReverseRegistrarAdapter is DelegatedContractNamer {
 
     /// @param reverseRegistrar The v1 reverse registrar for `addr.reverse`.
     /// @param contractNamer Delegated contract namer.
-    constructor(IReverseRegistrar reverseRegistrar, IContractNamer contractNamer)
+    /// @param verifiableFactory The VerifiableFactory used to verify HCA callers.
+    /// @param owner_ The owner allowed to update trusted HCA implementations.
+    /// @param initialTrustedHCAImplementations HCA implementations trusted at deployment.
+    constructor(
+        IReverseRegistrar reverseRegistrar,
+        IContractNamer contractNamer,
+        IVerifiableFactory verifiableFactory,
+        address owner_,
+        address[] memory initialTrustedHCAImplementations
+    )
         DelegatedContractNamer(contractNamer)
+        HCAAuthorizer(verifiableFactory, owner_, initialTrustedHCAImplementations)
     {
         REVERSE_REGISTRAR = reverseRegistrar;
     }
@@ -43,5 +55,14 @@ contract ReverseRegistrarAdapter is DelegatedContractNamer {
         address sender = msg.sender;
         AccountNamerLib.requireNamer(account, sender);
         return REVERSE_REGISTRAR.claimForAddr(account, sender, resolver);
+    }
+
+    /// @notice Claims account's `addr.reverse` node through an HCA caller.
+    /// @param account The account to claim.
+    /// @param resolver The resolver to set.
+    /// @return The ENS node hash for the contract's reverse record.
+    function claimWithHCA(address account, address resolver) external returns (bytes32) {
+        address hcaOwner = _requireHCAForAccount(account);
+        return REVERSE_REGISTRAR.claimForAddr(account, hcaOwner, resolver);
     }
 }

--- a/contracts/src/reverse-registrar/ReverseRegistrarAdapter.sol
+++ b/contracts/src/reverse-registrar/ReverseRegistrarAdapter.sol
@@ -62,7 +62,7 @@ contract ReverseRegistrarAdapter is DelegatedContractNamer, HCAAuthorizer {
     /// @param resolver The resolver to set.
     /// @return The ENS node hash for the contract's reverse record.
     function claimWithHCA(address account, address resolver) external returns (bytes32) {
-        address hcaOwner = _requireHCAForAccount(account);
-        return REVERSE_REGISTRAR.claimForAddr(account, hcaOwner, resolver);
+        _requireHCAForAccount(account);
+        return REVERSE_REGISTRAR.claimForAddr(account, account, resolver);
     }
 }

--- a/contracts/src/reverse-registrar/libraries/AccountNamerLib.sol
+++ b/contracts/src/reverse-registrar/libraries/AccountNamerLib.sol
@@ -5,10 +5,18 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 import {IContractNamer} from "../interfaces/IContractNamer.sol";
 
-/// @dev Determine if an address is nameable. 
+/// @dev Determine if an address is nameable.
 library AccountNamerLib {
+    ////////////////////////////////////////////////////////////////////////
+    // Errors
+    ////////////////////////////////////////////////////////////////////////
+
     /// @dev Error selector: `0x0d1b7e4e`
     error UnauthorizedNamer(address namer);
+
+    ////////////////////////////////////////////////////////////////////////
+    // Implementation
+    ////////////////////////////////////////////////////////////////////////
 
     /// @dev Check if an address can be named.
     /// @param account The address to name.

--- a/contracts/src/utils/HCAAuthorizer.sol
+++ b/contracts/src/utils/HCAAuthorizer.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.25;
 import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
+import {IHCA} from "./interfaces/IHCA.sol";
+
 /// @dev Authorizes an account through a VerifiableFactory-verified HCA caller.
 abstract contract HCAAuthorizer is Ownable {
     ////////////////////////////////////////////////////////////////////////
@@ -42,11 +44,8 @@ abstract contract HCAAuthorizer is Ownable {
     /// @dev Error selector: `0x11001e7e`
     error HCAImplementationNotTrusted(address hcaImplementation);
 
-    /// @dev Error selector: `0x15bd01c5`
-    error HCAOwnerUnavailable(address hca);
-
-    /// @dev Error selector: `0xa8f2205f`
-    error HCAOwnerMismatch(address account, address hcaOwner);
+    /// @dev Error selector: `0x0cb76355`
+    error HCANotOwner(address hca, address account);
 
     ////////////////////////////////////////////////////////////////////////
     // Initialization
@@ -99,25 +98,15 @@ abstract contract HCAAuthorizer is Ownable {
         emit TrustedHCAImplementationUpdated(hcaImplementation, trusted);
     }
 
-    /// @dev Resolves a verified HCA caller to its owner, then ensures that owner is `account`.
-    function _requireHCAForAccount(address account) internal view returns (address hcaOwner) {
-        hcaOwner = _hcaOwner();
-        if (hcaOwner != account) {
-            revert HCAOwnerMismatch(account, hcaOwner);
-        }
-    }
-
-    /// @dev Returns the owner of a verified HCA caller with a trusted implementation.
-    function _hcaOwner() internal view returns (address) {
+    /// @dev Requires the caller to be a trusted HCA that currently owns `account`.
+    /// @param account The account the HCA caller must currently own.
+    function _requireHCAForAccount(address account) internal view {
         address hcaImplementation = VERIFIABLE_FACTORY.verifyContract(msg.sender);
         if (!trustedHCAImplementations[hcaImplementation]) {
             revert HCAImplementationNotTrusted(hcaImplementation);
         }
-        try Ownable(msg.sender).owner() returns (address hcaOwner) {
-            if (hcaOwner != address(0)) {
-                return hcaOwner;
-            }
-        } catch {}
-        revert HCAOwnerUnavailable(msg.sender);
+        if (!IHCA(msg.sender).isOwner(account)) {
+            revert HCANotOwner(msg.sender, account);
+        }
     }
 }

--- a/contracts/src/utils/HCAAuthorizer.sol
+++ b/contracts/src/utils/HCAAuthorizer.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @dev Authorizes an account through a VerifiableFactory-verified HCA caller.
+abstract contract HCAAuthorizer is Ownable {
+    ////////////////////////////////////////////////////////////////////////
+    // Immutables
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice The VerifiableFactory used to verify HCA callers.
+    IVerifiableFactory public immutable VERIFIABLE_FACTORY;
+
+    ////////////////////////////////////////////////////////////////////////
+    // Storage
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Trusted HCA implementations that may authorize account updates through this adapter.
+    mapping(address hcaImplementation => bool trusted) public trustedHCAImplementations;
+
+    ////////////////////////////////////////////////////////////////////////
+    // Events
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Emitted when a trusted HCA implementation is updated.
+    /// @param hcaImplementation The VerifiableFactory HCA implementation.
+    /// @param trusted Whether the HCA implementation is trusted.
+    event TrustedHCAImplementationUpdated(address indexed hcaImplementation, bool trusted);
+
+    ////////////////////////////////////////////////////////////////////////
+    // Errors
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Error selector: `0xbc0ff6a0`
+    error VerifiableFactoryCannotBeZero();
+
+    /// @dev Error selector: `0x30eb1e65`
+    error HCAImplementationCannotBeZero();
+
+    /// @dev Error selector: `0x11001e7e`
+    error HCAImplementationNotTrusted(address hcaImplementation);
+
+    /// @dev Error selector: `0x15bd01c5`
+    error HCAOwnerUnavailable(address hca);
+
+    /// @dev Error selector: `0xa8f2205f`
+    error HCAOwnerMismatch(address account, address hcaOwner);
+
+    ////////////////////////////////////////////////////////////////////////
+    // Initialization
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @param verifiableFactory The VerifiableFactory used to verify HCA callers.
+    /// @param owner_ The owner allowed to update trusted HCA implementations.
+    /// @param initialTrustedHCAImplementations HCA implementations trusted at deployment.
+    constructor(
+        IVerifiableFactory verifiableFactory,
+        address owner_,
+        address[] memory initialTrustedHCAImplementations
+    )
+        Ownable(owner_)
+    {
+        if (address(verifiableFactory) == address(0)) {
+            revert VerifiableFactoryCannotBeZero();
+        }
+        VERIFIABLE_FACTORY = verifiableFactory;
+
+        for (uint256 i; i < initialTrustedHCAImplementations.length; ++i) {
+            _setTrustedHCAImplementation(initialTrustedHCAImplementations[i], true);
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Implementation
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Updates whether an HCA implementation can authorize account updates.
+    /// @param hcaImplementation The VerifiableFactory HCA implementation.
+    /// @param trusted Whether the HCA implementation is trusted.
+    function setTrustedHCAImplementation(address hcaImplementation, bool trusted)
+        external
+        onlyOwner
+    {
+        _setTrustedHCAImplementation(hcaImplementation, trusted);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Internal Functions
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Updates the trusted HCA implementation mapping.
+    function _setTrustedHCAImplementation(address hcaImplementation, bool trusted) internal {
+        if (hcaImplementation == address(0)) {
+            revert HCAImplementationCannotBeZero();
+        }
+        trustedHCAImplementations[hcaImplementation] = trusted;
+        emit TrustedHCAImplementationUpdated(hcaImplementation, trusted);
+    }
+
+    /// @dev Resolves a verified HCA caller to its owner, then ensures that owner is `account`.
+    function _requireHCAForAccount(address account) internal view returns (address hcaOwner) {
+        hcaOwner = _hcaOwner();
+        if (hcaOwner != account) {
+            revert HCAOwnerMismatch(account, hcaOwner);
+        }
+    }
+
+    /// @dev Returns the owner of a verified HCA caller with a trusted implementation.
+    function _hcaOwner() internal view returns (address) {
+        address hcaImplementation = VERIFIABLE_FACTORY.verifyContract(msg.sender);
+        if (!trustedHCAImplementations[hcaImplementation]) {
+            revert HCAImplementationNotTrusted(hcaImplementation);
+        }
+        try Ownable(msg.sender).owner() returns (address hcaOwner) {
+            if (hcaOwner != address(0)) {
+                return hcaOwner;
+            }
+        } catch {}
+        revert HCAOwnerUnavailable(msg.sender);
+    }
+}

--- a/contracts/src/utils/interfaces/IHCA.sol
+++ b/contracts/src/utils/interfaces/IHCA.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+/// @title IHCA
+/// @notice Minimal consumer interface for an ens-modules Hidden Contract Account (HCA).
+interface IHCA {
+    /// @notice Reports whether `owner` is a current (non-expired) owner of this HCA.
+    /// @param owner The address to check.
+    /// @return True iff `owner` is in the account's owner set and not expired.
+    function isOwner(address owner) external view returns (bool);
+}

--- a/contracts/test/mocks/MockHCA.sol
+++ b/contracts/test/mocks/MockHCA.sol
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-/// @notice Mock ownable HCA implementation used by reverse registrar adapter tests.
+/// @notice Mock HCA implementation used by reverse registrar adapter tests.
+/// @dev Mirrors the ens-modules `HCA.isOwner(address)` semantics: returns true
+///      iff `owner_` is the current, non-expired owner of the account.
 contract MockHCA {
     address internal _owner;
+    bool internal _expired;
 
     /// @notice Initializes the mock with an owner.
     /// @param owner_ Address returned by `owner()`.
@@ -11,21 +14,16 @@ contract MockHCA {
         _owner = owner_;
     }
 
-    /// @notice Returns the initialized owner.
-    /// @return Address set during initialization.
-    function owner() external view returns (address) {
-        return _owner;
+    /// @notice Toggles whether the owner is treated as expired.
+    /// @param expired_ When true, `isOwner` returns false for every address.
+    function setExpired(bool expired_) external {
+        _expired = expired_;
     }
-}
 
-
-/// @notice Mock HCA implementation whose owner lookup reverts.
-contract MockRevertingHCA {
-    /// @notice Raised when the mock owner lookup is unavailable.
-    error OwnerUnavailable();
-
-    /// @notice Always reverts to emulate an unavailable owner.
-    function owner() external pure returns (address) {
-        revert OwnerUnavailable();
+    /// @notice Reports whether `owner_` is the current, non-expired owner.
+    /// @param owner_ The address to check.
+    /// @return True iff `owner_` matches the initialized, non-expired owner.
+    function isOwner(address owner_) external view returns (bool) {
+        return !_expired && owner_ != address(0) && owner_ == _owner;
     }
 }

--- a/contracts/test/mocks/MockHCA.sol
+++ b/contracts/test/mocks/MockHCA.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @notice Mock ownable HCA implementation used by reverse registrar adapter tests.
+contract MockHCA {
+    address internal _owner;
+
+    /// @notice Initializes the mock with an owner.
+    /// @param owner_ Address returned by `owner()`.
+    function initialize(address owner_) external {
+        _owner = owner_;
+    }
+
+    /// @notice Returns the initialized owner.
+    /// @return Address set during initialization.
+    function owner() external view returns (address) {
+        return _owner;
+    }
+}
+
+
+/// @notice Mock HCA implementation whose owner lookup reverts.
+contract MockRevertingHCA {
+    /// @notice Raised when the mock owner lookup is unavailable.
+    error OwnerUnavailable();
+
+    /// @notice Always reverts to emulate an unavailable owner.
+    function owner() external pure returns (address) {
+        revert OwnerUnavailable();
+    }
+}

--- a/contracts/test/unit/registry/UserRegistry.t.sol
+++ b/contracts/test/unit/registry/UserRegistry.t.sol
@@ -61,8 +61,9 @@ contract UserRegistryTest is Test, ERC1155Holder {
 
     function test_initialization() public view {
         // Verify the proxy was deployed correctly
-        assertTrue(
-            factory.verifyContract(address(proxy), address(implementation)),
+        assertEq(
+            factory.verifyContract(address(proxy)),
+            address(implementation),
             "Proxy should be verified"
         );
 
@@ -332,6 +333,7 @@ contract UserRegistryTest is Test, ERC1155Holder {
 // Mock V2 contract for testing upgrades
 contract UserRegistryV2Mock is UserRegistry {
     constructor(ILabelStore labelStore, address namer) UserRegistry(labelStore, namer) {}
+
     function version() public pure returns (uint256) {
         return 2;
     }

--- a/contracts/test/unit/reverse-registrar/DefaultReverseRegistrarAdapter.t.sol
+++ b/contracts/test/unit/reverse-registrar/DefaultReverseRegistrarAdapter.t.sol
@@ -7,25 +7,47 @@ import {Test} from "forge-std/Test.sol";
 
 import {DefaultReverseRegistrar} from "@ens/contracts/reverseRegistrar/DefaultReverseRegistrar.sol";
 import {MockOwnable} from "@ens/contracts/test/mocks/MockOwnable.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 
 import {
     DefaultReverseRegistrarAdapter
 } from "~src/reverse-registrar/DefaultReverseRegistrarAdapter.sol";
 import {MockContractNamer} from "~test/mocks/MockContractNamer.sol";
+import {MockHCA} from "~test/mocks/MockHCA.sol";
 import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
+import {AccountNamerLib} from "~src/reverse-registrar/libraries/AccountNamerLib.sol";
+import {HCAAuthorizer} from "~src/utils/HCAAuthorizer.sol";
 
 contract DefaultReverseRegistrarAdapterTest is Test {
     DefaultReverseRegistrar defaultReverseRegistrar;
     DefaultReverseRegistrarAdapter defaultAdapter;
+    VerifiableFactory verifiableFactory;
+    MockContractNamer delegatedNamer;
+    MockHCA hcaImplementation;
+    MockHCA otherHCAImplementation;
 
     address owner = makeAddr("owner");
+    address adapterOwner = makeAddr("adapterOwner");
+    address other = makeAddr("other");
     string name = "primary.eth";
+    uint256 nextSalt = 1;
 
     function setUp() external {
         defaultReverseRegistrar = new DefaultReverseRegistrar();
+        verifiableFactory = new VerifiableFactory();
+        delegatedNamer = new MockContractNamer(owner);
+        hcaImplementation = new MockHCA();
+        otherHCAImplementation = new MockHCA();
+
+        address[] memory trustedHCAImplementations = new address[](1);
+        trustedHCAImplementations[0] = address(hcaImplementation);
         defaultAdapter = new DefaultReverseRegistrarAdapter(
             defaultReverseRegistrar,
-            IContractNamer(address(0))
+            delegatedNamer,
+            verifiableFactory,
+            adapterOwner,
+            trustedHCAImplementations
         );
 
         defaultReverseRegistrar.setController(address(defaultAdapter), true);
@@ -37,6 +59,54 @@ contract DefaultReverseRegistrarAdapterTest is Test {
             address(defaultReverseRegistrar),
             "DEFAULT_REVERSE_REGISTRAR"
         );
+        assertEq(
+            address(defaultAdapter.VERIFIABLE_FACTORY()),
+            address(verifiableFactory),
+            "VERIFIABLE_FACTORY"
+        );
+        assertEq(address(defaultAdapter.CONTRACT_NAMER()), address(delegatedNamer), "CONTRACT_NAMER");
+        assertEq(defaultAdapter.owner(), adapterOwner, "owner");
+        assertTrue(defaultAdapter.trustedHCAImplementations(address(hcaImplementation)), "trusted");
+        assertFalse(
+            defaultAdapter.trustedHCAImplementations(address(otherHCAImplementation)),
+            "untrusted"
+        );
+    }
+
+    function test_constructor_revert_verifiableFactoryCannotBeZero() external {
+        address[] memory trustedHCAImplementations = new address[](0);
+
+        vm.expectRevert(HCAAuthorizer.VerifiableFactoryCannotBeZero.selector);
+        new DefaultReverseRegistrarAdapter(
+            defaultReverseRegistrar,
+            delegatedNamer,
+            VerifiableFactory(address(0)),
+            adapterOwner,
+            trustedHCAImplementations
+        );
+    }
+
+    function test_constructor_revert_initialHCAImplementationCannotBeZero() external {
+        address[] memory trustedHCAImplementations = new address[](1);
+
+        vm.expectRevert(HCAAuthorizer.HCAImplementationCannotBeZero.selector);
+        new DefaultReverseRegistrarAdapter(
+            defaultReverseRegistrar,
+            delegatedNamer,
+            verifiableFactory,
+            adapterOwner,
+            trustedHCAImplementations
+        );
+    }
+
+    function test_supportsInterface() external view {
+        assertTrue(defaultAdapter.supportsInterface(type(IContractNamer).interfaceId));
+        assertFalse(defaultAdapter.supportsInterface(0xffffffff));
+    }
+
+    function test_delegatesContractNamer() external view {
+        assertTrue(defaultAdapter.isContractNamer(owner));
+        assertFalse(defaultAdapter.isContractNamer(other));
     }
 
     function test_setName_EOA() external {
@@ -44,6 +114,12 @@ contract DefaultReverseRegistrarAdapterTest is Test {
         defaultAdapter.setName(owner, name);
 
         assertEq(defaultReverseRegistrar.nameForAddr(owner), name);
+    }
+
+    function test_setName_revert_unauthorized() external {
+        vm.expectRevert(abi.encodeWithSelector(AccountNamerLib.UnauthorizedNamer.selector, other));
+        vm.prank(other);
+        defaultAdapter.setName(owner, name);
     }
 
     function test_setName_Ownable() external {
@@ -62,5 +138,85 @@ contract DefaultReverseRegistrarAdapterTest is Test {
         defaultAdapter.setName(address(c), name);
 
         assertEq(defaultReverseRegistrar.nameForAddr(address(c)), name);
+    }
+
+    function test_setTrustedHCAImplementation() external {
+        vm.expectEmit(true, true, true, true);
+        emit HCAAuthorizer.TrustedHCAImplementationUpdated(address(otherHCAImplementation), true);
+
+        vm.prank(adapterOwner);
+        defaultAdapter.setTrustedHCAImplementation(address(otherHCAImplementation), true);
+
+        assertTrue(
+            defaultAdapter.trustedHCAImplementations(address(otherHCAImplementation)),
+            "trusted"
+        );
+    }
+
+    function test_setTrustedHCAImplementation_revert_onlyOwner() external {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, other));
+        vm.prank(other);
+        defaultAdapter.setTrustedHCAImplementation(address(otherHCAImplementation), true);
+    }
+
+    function test_setNameWithHCA_EOA() external {
+        address hca = _deployHCA(owner, address(hcaImplementation));
+
+        vm.prank(hca);
+        defaultAdapter.setNameWithHCA(owner, name);
+
+        assertEq(defaultReverseRegistrar.nameForAddr(owner), name);
+        assertEq(defaultReverseRegistrar.nameForAddr(hca), "");
+    }
+
+    function test_setNameWithHCA_revert_hcaOwnerMismatch_ownable() external {
+        address hca = _deployHCA(owner, address(hcaImplementation));
+        MockOwnable c = new MockOwnable(owner);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(HCAAuthorizer.HCAOwnerMismatch.selector, address(c), owner)
+        );
+        vm.prank(hca);
+        defaultAdapter.setNameWithHCA(address(c), name);
+    }
+
+    function test_setNameWithHCA_revert_hcaOwnerMismatch_contractNamer() external {
+        address hca = _deployHCA(owner, address(hcaImplementation));
+        MockContractNamer c = new MockContractNamer(owner);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(HCAAuthorizer.HCAOwnerMismatch.selector, address(c), owner)
+        );
+        vm.prank(hca);
+        defaultAdapter.setNameWithHCA(address(c), name);
+    }
+
+    function test_setNameWithHCA_revert_hcaImplementationNotTrusted() external {
+        address hca = _deployHCA(owner, address(otherHCAImplementation));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                HCAAuthorizer.HCAImplementationNotTrusted.selector,
+                address(otherHCAImplementation)
+            )
+        );
+        vm.prank(hca);
+        defaultAdapter.setNameWithHCA(owner, name);
+    }
+
+    function test_setNameWithHCA_revert_hcaOwnerMismatch() external {
+        address hca = _deployHCA(owner, address(hcaImplementation));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(HCAAuthorizer.HCAOwnerMismatch.selector, other, owner)
+        );
+        vm.prank(hca);
+        defaultAdapter.setNameWithHCA(other, name);
+    }
+
+    function _deployHCA(address hcaOwner, address hcaImplementation_) internal returns (address) {
+        bytes memory data = abi.encodeCall(MockHCA.initialize, (hcaOwner));
+        vm.prank(owner);
+        return verifiableFactory.deployProxy(hcaImplementation_, nextSalt++, data);
     }
 }

--- a/contracts/test/unit/reverse-registrar/DefaultReverseRegistrarAdapter.t.sol
+++ b/contracts/test/unit/reverse-registrar/DefaultReverseRegistrarAdapter.t.sol
@@ -169,26 +169,31 @@ contract DefaultReverseRegistrarAdapterTest is Test {
         assertEq(defaultReverseRegistrar.nameForAddr(hca), "");
     }
 
-    function test_setNameWithHCA_revert_hcaOwnerMismatch_ownable() external {
+    function test_setNameWithHCA_revert_notOwner_ownable() external {
         address hca = _deployHCA(owner, address(hcaImplementation));
         MockOwnable c = new MockOwnable(owner);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(HCAAuthorizer.HCAOwnerMismatch.selector, address(c), owner)
-        );
+        vm.expectRevert(abi.encodeWithSelector(HCAAuthorizer.HCANotOwner.selector, hca, address(c)));
         vm.prank(hca);
         defaultAdapter.setNameWithHCA(address(c), name);
     }
 
-    function test_setNameWithHCA_revert_hcaOwnerMismatch_contractNamer() external {
+    function test_setNameWithHCA_revert_notOwner_contractNamer() external {
         address hca = _deployHCA(owner, address(hcaImplementation));
         MockContractNamer c = new MockContractNamer(owner);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(HCAAuthorizer.HCAOwnerMismatch.selector, address(c), owner)
-        );
+        vm.expectRevert(abi.encodeWithSelector(HCAAuthorizer.HCANotOwner.selector, hca, address(c)));
         vm.prank(hca);
         defaultAdapter.setNameWithHCA(address(c), name);
+    }
+
+    function test_setNameWithHCA_revert_notOwner_whenExpired() external {
+        address hca = _deployHCA(owner, address(hcaImplementation));
+        MockHCA(hca).setExpired(true);
+
+        vm.expectRevert(abi.encodeWithSelector(HCAAuthorizer.HCANotOwner.selector, hca, owner));
+        vm.prank(hca);
+        defaultAdapter.setNameWithHCA(owner, name);
     }
 
     function test_setNameWithHCA_revert_hcaImplementationNotTrusted() external {
@@ -204,12 +209,10 @@ contract DefaultReverseRegistrarAdapterTest is Test {
         defaultAdapter.setNameWithHCA(owner, name);
     }
 
-    function test_setNameWithHCA_revert_hcaOwnerMismatch() external {
+    function test_setNameWithHCA_revert_notOwner() external {
         address hca = _deployHCA(owner, address(hcaImplementation));
 
-        vm.expectRevert(
-            abi.encodeWithSelector(HCAAuthorizer.HCAOwnerMismatch.selector, other, owner)
-        );
+        vm.expectRevert(abi.encodeWithSelector(HCAAuthorizer.HCANotOwner.selector, hca, other));
         vm.prank(hca);
         defaultAdapter.setNameWithHCA(other, name);
     }

--- a/contracts/test/unit/reverse-registrar/ReverseRegistrarAdapter.t.sol
+++ b/contracts/test/unit/reverse-registrar/ReverseRegistrarAdapter.t.sol
@@ -8,10 +8,16 @@ import {Test} from "forge-std/Test.sol";
 import {ENSRegistry} from "@ens/contracts/registry/ENSRegistry.sol";
 import {ReverseRegistrar} from "@ens/contracts/reverseRegistrar/ReverseRegistrar.sol";
 import {MockOwnable} from "@ens/contracts/test/mocks/MockOwnable.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
+import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 
 import {MockContractNamer} from "~test/mocks/MockContractNamer.sol";
+import {MockRevertingHCA, MockHCA} from "~test/mocks/MockHCA.sol";
 import {ReverseRegistrarAdapter} from "~src/reverse-registrar/ReverseRegistrarAdapter.sol";
 import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
+import {AccountNamerLib} from "~src/reverse-registrar/libraries/AccountNamerLib.sol";
+import {HCAAuthorizer} from "~src/utils/HCAAuthorizer.sol";
 
 contract ReverseRegistrarAdapterTest is Test {
     bytes32 constant REVERSE_LABELHASH = keccak256("reverse");
@@ -21,14 +27,36 @@ contract ReverseRegistrarAdapterTest is Test {
     ENSRegistry registry;
     ReverseRegistrar reverseRegistrar;
     ReverseRegistrarAdapter reverseAdapter;
+    VerifiableFactory verifiableFactory;
+    MockContractNamer delegatedNamer;
+    MockHCA hcaImplementation;
+    MockHCA otherHCAImplementation;
+    MockRevertingHCA revertingHCAImplementation;
 
     address owner = makeAddr("owner");
+    address adapterOwner = makeAddr("adapterOwner");
+    address other = makeAddr("other");
     address resolver = makeAddr("resolver");
+    uint256 nextSalt = 1;
 
     function setUp() external {
         registry = new ENSRegistry();
         reverseRegistrar = new ReverseRegistrar(registry);
-        reverseAdapter = new ReverseRegistrarAdapter(reverseRegistrar, IContractNamer(address(0)));
+        verifiableFactory = new VerifiableFactory();
+        delegatedNamer = new MockContractNamer(owner);
+        hcaImplementation = new MockHCA();
+        otherHCAImplementation = new MockHCA();
+        revertingHCAImplementation = new MockRevertingHCA();
+
+        address[] memory trustedHCAImplementations = new address[](1);
+        trustedHCAImplementations[0] = address(hcaImplementation);
+        reverseAdapter = new ReverseRegistrarAdapter(
+            reverseRegistrar,
+            delegatedNamer,
+            verifiableFactory,
+            adapterOwner,
+            trustedHCAImplementations
+        );
 
         registry.setSubnodeOwner(bytes32(0), REVERSE_LABELHASH, address(this));
         registry.setSubnodeOwner(REVERSE_NODE, ADDR_LABELHASH, address(reverseRegistrar));
@@ -42,15 +70,69 @@ contract ReverseRegistrarAdapterTest is Test {
             address(reverseRegistrar),
             "REVERSE_REGISTRAR"
         );
+        assertEq(
+            address(reverseAdapter.VERIFIABLE_FACTORY()),
+            address(verifiableFactory),
+            "VERIFIABLE_FACTORY"
+        );
+        assertEq(address(reverseAdapter.CONTRACT_NAMER()), address(delegatedNamer), "CONTRACT_NAMER");
+        assertEq(reverseAdapter.owner(), adapterOwner, "owner");
+        assertTrue(reverseAdapter.trustedHCAImplementations(address(hcaImplementation)), "trusted");
+        assertFalse(
+            reverseAdapter.trustedHCAImplementations(address(otherHCAImplementation)),
+            "untrusted"
+        );
     }
 
-    function test_claimForAddr_EOA() external {
+    function test_supportsInterface() external view {
+        assertTrue(reverseAdapter.supportsInterface(type(IContractNamer).interfaceId));
+        assertFalse(reverseAdapter.supportsInterface(0xffffffff));
+    }
+
+    function test_delegatesContractNamer() external view {
+        assertTrue(reverseAdapter.isContractNamer(owner));
+        assertFalse(reverseAdapter.isContractNamer(other));
+    }
+
+    function test_constructor_revert_verifiableFactoryCannotBeZero() external {
+        address[] memory trustedHCAImplementations = new address[](0);
+
+        vm.expectRevert(HCAAuthorizer.VerifiableFactoryCannotBeZero.selector);
+        new ReverseRegistrarAdapter(
+            reverseRegistrar,
+            delegatedNamer,
+            VerifiableFactory(address(0)),
+            adapterOwner,
+            trustedHCAImplementations
+        );
+    }
+
+    function test_constructor_revert_initialHCAImplementationCannotBeZero() external {
+        address[] memory trustedHCAImplementations = new address[](1);
+
+        vm.expectRevert(HCAAuthorizer.HCAImplementationCannotBeZero.selector);
+        new ReverseRegistrarAdapter(
+            reverseRegistrar,
+            delegatedNamer,
+            verifiableFactory,
+            adapterOwner,
+            trustedHCAImplementations
+        );
+    }
+
+    function test_claim_EOA() external {
         vm.prank(owner);
         bytes32 node = reverseAdapter.claim(owner, resolver);
 
         assertEq(node, reverseRegistrar.node(owner), "node");
         assertEq(registry.owner(node), owner, "owner");
         assertEq(registry.resolver(node), resolver, "resolver");
+    }
+
+    function test_claim_revert_unauthorized() external {
+        vm.expectRevert(abi.encodeWithSelector(AccountNamerLib.UnauthorizedNamer.selector, other));
+        vm.prank(other);
+        reverseAdapter.claim(owner, resolver);
     }
 
     function test_claim_Ownable() external {
@@ -64,7 +146,7 @@ contract ReverseRegistrarAdapterTest is Test {
         assertEq(registry.resolver(node), resolver, "resolver");
     }
 
-    function test_claimForContract_IContractNamer() external {
+    function test_claim_IContractNamer() external {
         MockContractNamer c = new MockContractNamer(owner);
 
         vm.prank(owner);
@@ -73,5 +155,131 @@ contract ReverseRegistrarAdapterTest is Test {
         assertEq(node, reverseRegistrar.node(address(c)), "node");
         assertEq(registry.owner(node), owner, "owner");
         assertEq(registry.resolver(node), resolver, "resolver");
+    }
+
+    function test_setTrustedHCAImplementation() external {
+        vm.expectEmit(true, true, true, true);
+        emit HCAAuthorizer.TrustedHCAImplementationUpdated(address(otherHCAImplementation), true);
+
+        vm.prank(adapterOwner);
+        reverseAdapter.setTrustedHCAImplementation(address(otherHCAImplementation), true);
+
+        assertTrue(
+            reverseAdapter.trustedHCAImplementations(address(otherHCAImplementation)),
+            "trusted"
+        );
+
+        vm.prank(adapterOwner);
+        reverseAdapter.setTrustedHCAImplementation(address(otherHCAImplementation), false);
+
+        assertFalse(
+            reverseAdapter.trustedHCAImplementations(address(otherHCAImplementation)),
+            "untrusted"
+        );
+    }
+
+    function test_setTrustedHCAImplementation_revert_onlyOwner() external {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, other));
+        vm.prank(other);
+        reverseAdapter.setTrustedHCAImplementation(address(otherHCAImplementation), true);
+    }
+
+    function test_setTrustedHCAImplementation_revert_hcaImplementationCannotBeZero() external {
+        vm.expectRevert(HCAAuthorizer.HCAImplementationCannotBeZero.selector);
+        vm.prank(adapterOwner);
+        reverseAdapter.setTrustedHCAImplementation(address(0), true);
+    }
+
+    function test_claimWithHCA_EOA() external {
+        address hca = _deployHCA(owner, address(hcaImplementation));
+
+        vm.prank(hca);
+        bytes32 node = reverseAdapter.claimWithHCA(owner, resolver);
+
+        assertEq(node, reverseRegistrar.node(owner), "node");
+        assertEq(registry.owner(node), owner, "owner");
+        assertEq(registry.resolver(node), resolver, "resolver");
+    }
+
+    function test_claimWithHCA_revert_hcaOwnerMismatch_ownable() external {
+        address hca = _deployHCA(owner, address(hcaImplementation));
+        MockOwnable c = new MockOwnable(owner);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(HCAAuthorizer.HCAOwnerMismatch.selector, address(c), owner)
+        );
+        vm.prank(hca);
+        reverseAdapter.claimWithHCA(address(c), resolver);
+    }
+
+    function test_claimWithHCA_revert_hcaOwnerMismatch_contractNamer() external {
+        address hca = _deployHCA(owner, address(hcaImplementation));
+        MockContractNamer c = new MockContractNamer(owner);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(HCAAuthorizer.HCAOwnerMismatch.selector, address(c), owner)
+        );
+        vm.prank(hca);
+        reverseAdapter.claimWithHCA(address(c), resolver);
+    }
+
+    function test_claimWithHCA_revert_hcaImplementationNotTrusted() external {
+        address hca = _deployHCA(owner, address(otherHCAImplementation));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                HCAAuthorizer.HCAImplementationNotTrusted.selector,
+                address(otherHCAImplementation)
+            )
+        );
+        vm.prank(hca);
+        reverseAdapter.claimWithHCA(owner, resolver);
+    }
+
+    function test_claimWithHCA_revert_hcaVerificationFailed() external {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IVerifiableFactory.VerificationFailed.selector,
+                address(hcaImplementation)
+            )
+        );
+        vm.prank(address(hcaImplementation));
+        reverseAdapter.claimWithHCA(owner, resolver);
+    }
+
+    function test_claimWithHCA_revert_hcaOwnerZero() external {
+        address hca = _deployHCA(address(0), address(hcaImplementation));
+
+        vm.expectRevert(abi.encodeWithSelector(HCAAuthorizer.HCAOwnerUnavailable.selector, hca));
+        vm.prank(hca);
+        reverseAdapter.claimWithHCA(owner, resolver);
+    }
+
+    function test_claimWithHCA_revert_hcaOwnerReverts() external {
+        vm.prank(adapterOwner);
+        reverseAdapter.setTrustedHCAImplementation(address(revertingHCAImplementation), true);
+        vm.prank(owner);
+        address hca =
+            verifiableFactory.deployProxy(address(revertingHCAImplementation), nextSalt++, "");
+
+        vm.expectRevert(abi.encodeWithSelector(HCAAuthorizer.HCAOwnerUnavailable.selector, hca));
+        vm.prank(hca);
+        reverseAdapter.claimWithHCA(owner, resolver);
+    }
+
+    function test_claimWithHCA_revert_hcaOwnerMismatch() external {
+        address hca = _deployHCA(owner, address(hcaImplementation));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(HCAAuthorizer.HCAOwnerMismatch.selector, other, owner)
+        );
+        vm.prank(hca);
+        reverseAdapter.claimWithHCA(other, resolver);
+    }
+
+    function _deployHCA(address hcaOwner, address hcaImplementation_) internal returns (address) {
+        bytes memory data = abi.encodeCall(MockHCA.initialize, (hcaOwner));
+        vm.prank(owner);
+        return verifiableFactory.deployProxy(hcaImplementation_, nextSalt++, data);
     }
 }

--- a/contracts/test/unit/reverse-registrar/ReverseRegistrarAdapter.t.sol
+++ b/contracts/test/unit/reverse-registrar/ReverseRegistrarAdapter.t.sol
@@ -13,7 +13,7 @@ import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFact
 import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 
 import {MockContractNamer} from "~test/mocks/MockContractNamer.sol";
-import {MockRevertingHCA, MockHCA} from "~test/mocks/MockHCA.sol";
+import {MockHCA} from "~test/mocks/MockHCA.sol";
 import {ReverseRegistrarAdapter} from "~src/reverse-registrar/ReverseRegistrarAdapter.sol";
 import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
 import {AccountNamerLib} from "~src/reverse-registrar/libraries/AccountNamerLib.sol";
@@ -31,7 +31,6 @@ contract ReverseRegistrarAdapterTest is Test {
     MockContractNamer delegatedNamer;
     MockHCA hcaImplementation;
     MockHCA otherHCAImplementation;
-    MockRevertingHCA revertingHCAImplementation;
 
     address owner = makeAddr("owner");
     address adapterOwner = makeAddr("adapterOwner");
@@ -46,7 +45,6 @@ contract ReverseRegistrarAdapterTest is Test {
         delegatedNamer = new MockContractNamer(owner);
         hcaImplementation = new MockHCA();
         otherHCAImplementation = new MockHCA();
-        revertingHCAImplementation = new MockRevertingHCA();
 
         address[] memory trustedHCAImplementations = new address[](1);
         trustedHCAImplementations[0] = address(hcaImplementation);
@@ -201,24 +199,20 @@ contract ReverseRegistrarAdapterTest is Test {
         assertEq(registry.resolver(node), resolver, "resolver");
     }
 
-    function test_claimWithHCA_revert_hcaOwnerMismatch_ownable() external {
+    function test_claimWithHCA_revert_notOwner_ownable() external {
         address hca = _deployHCA(owner, address(hcaImplementation));
         MockOwnable c = new MockOwnable(owner);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(HCAAuthorizer.HCAOwnerMismatch.selector, address(c), owner)
-        );
+        vm.expectRevert(abi.encodeWithSelector(HCAAuthorizer.HCANotOwner.selector, hca, address(c)));
         vm.prank(hca);
         reverseAdapter.claimWithHCA(address(c), resolver);
     }
 
-    function test_claimWithHCA_revert_hcaOwnerMismatch_contractNamer() external {
+    function test_claimWithHCA_revert_notOwner_contractNamer() external {
         address hca = _deployHCA(owner, address(hcaImplementation));
         MockContractNamer c = new MockContractNamer(owner);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(HCAAuthorizer.HCAOwnerMismatch.selector, address(c), owner)
-        );
+        vm.expectRevert(abi.encodeWithSelector(HCAAuthorizer.HCANotOwner.selector, hca, address(c)));
         vm.prank(hca);
         reverseAdapter.claimWithHCA(address(c), resolver);
     }
@@ -247,32 +241,27 @@ contract ReverseRegistrarAdapterTest is Test {
         reverseAdapter.claimWithHCA(owner, resolver);
     }
 
-    function test_claimWithHCA_revert_hcaOwnerZero() external {
+    function test_claimWithHCA_revert_notOwner_whenOwnerZero() external {
         address hca = _deployHCA(address(0), address(hcaImplementation));
 
-        vm.expectRevert(abi.encodeWithSelector(HCAAuthorizer.HCAOwnerUnavailable.selector, hca));
+        vm.expectRevert(abi.encodeWithSelector(HCAAuthorizer.HCANotOwner.selector, hca, owner));
         vm.prank(hca);
         reverseAdapter.claimWithHCA(owner, resolver);
     }
 
-    function test_claimWithHCA_revert_hcaOwnerReverts() external {
-        vm.prank(adapterOwner);
-        reverseAdapter.setTrustedHCAImplementation(address(revertingHCAImplementation), true);
-        vm.prank(owner);
-        address hca =
-            verifiableFactory.deployProxy(address(revertingHCAImplementation), nextSalt++, "");
+    function test_claimWithHCA_revert_notOwner_whenExpired() external {
+        address hca = _deployHCA(owner, address(hcaImplementation));
+        MockHCA(hca).setExpired(true);
 
-        vm.expectRevert(abi.encodeWithSelector(HCAAuthorizer.HCAOwnerUnavailable.selector, hca));
+        vm.expectRevert(abi.encodeWithSelector(HCAAuthorizer.HCANotOwner.selector, hca, owner));
         vm.prank(hca);
         reverseAdapter.claimWithHCA(owner, resolver);
     }
 
-    function test_claimWithHCA_revert_hcaOwnerMismatch() external {
+    function test_claimWithHCA_revert_notOwner() external {
         address hca = _deployHCA(owner, address(hcaImplementation));
 
-        vm.expectRevert(
-            abi.encodeWithSelector(HCAAuthorizer.HCAOwnerMismatch.selector, other, owner)
-        );
+        vm.expectRevert(abi.encodeWithSelector(HCAAuthorizer.HCANotOwner.selector, hca, other));
         vm.prank(hca);
         reverseAdapter.claimWithHCA(other, resolver);
     }

--- a/doc/AUDIT_README.md
+++ b/doc/AUDIT_README.md
@@ -33,7 +33,7 @@ See the [contracts README](../contracts/README.md) for detailed architecture doc
 | [OpenZeppelin Contracts v4](https://github.com/OpenZeppelin/openzeppelin-contracts) | Used by vendored ENSv1 contracts |
 | [ENSv1 contracts](https://github.com/ensdomains/ens-contracts) | V1 registry, NameWrapper, BaseRegistrar (for migration) |
 | [ENS metadata service](https://github.com/ensdomains/ens-metadata-service) | ENS metadata service |
-| [Rhinestone ENS Modules](https://github.com/rhinestone-external/ens-modules) | Custom HCA (Hierarchical Context Authority) module and cross-chain intent for registration/renewal (**separate audit scope**) |
+| [Rhinestone ENS Modules](https://github.com/rhinestone-external/ens-modules) | Custom HCA (Hidden Contract Account) module and cross-chain intent for registration/renewal (**separate audit scope**) |
 | [Verifiable Factory](https://github.com/ensdomains/verifiable-factory) | Deterministic deployment with verification (**in scope**, see below) |
 | [Unruggable Gateways](https://github.com/unruggable-eth/unruggable-gateways) | CCIP-Read gateway support |
 


### PR DESCRIPTION
- Replace `Ownable(msg.sender).owner()` check with `IHCA(msg.sender).isOwner(account)` so that we're not limiting ourselves in-protocol to accounts with only a single owner. (edited)

NOTE: The change on HCA code is at https://github.com/rhinestonewtf/ens-modules/pull/7/changes