### PR TITLE
feat(migration): persist pre-migration metadata to deployments/

### DIFF
--- a/contracts/deployments/README.md
+++ b/contracts/deployments/README.md
@@ -17,6 +17,7 @@ deployments/
     .chain                # { chainId, genesisHash } the set was deployed against
     .migrations.json      # rocketh's record of completed deploy scripts (id → unix-epoch-seconds)
     .deployment.json      # { environment, chainId, deployedAt } — when this set was first deployed
+    .premigration.json    # pre-migration counts sidecar (names reserved/renewed/skipped/…), no label strings
     <Contract>.json       # one file per deployed contract (address, abi, bytecode, receipt, …)
   v1/
     <network>/            # local v1-reference overrides (searched before the bundled set)
@@ -24,12 +25,22 @@ deployments/
       <Contract>.json
 ```
 
-The `.chain`, `.migrations.json`, and `.deployment.json` dotfiles are metadata;
-rocketh loads only `.migrations.json` and the `<Contract>.json` artifacts and
-ignores every other dotfile, so `.deployment.json` is never mistaken for a
-contract. `.deployment.json` is written once, on the first deploy into a
-namespace, so its `deployedAt` records the original deployment time and survives
-idempotent re-runs.
+The `.chain`, `.migrations.json`, `.deployment.json`, and `.premigration.json`
+dotfiles are metadata; rocketh loads only `.migrations.json` and the
+`<Contract>.json` artifacts and ignores every other dotfile, so none of them are
+mistaken for a contract. `.deployment.json` is written once, on the first deploy
+into a namespace, so its `deployedAt` records the original deployment time and
+survives idempotent re-runs.
+
+`.premigration.json` is the durable record of the v1→v2 pre-migration run(s) that
+targeted this namespace. It holds counts only — never the reserved label strings
+(the corpus is large) — with one entry per logical run (`initial`, `final-sync`,
+or a standalone `run`, upserted by label) plus a `resolved` roll-up of the final
+numbers: names pre-migrated, expiry re-syncs, names skipped because they were
+never registered on v1 or lapsed past the v1 grace period, invalid labels, names
+already on v2, and failures. It is written by the pre-migration command whenever
+the target namespace persists (so `fork full` rehearsals without
+`--save-deployments` leave it untouched).
 
 A namespace is addressed by two inputs on every migration command:
 

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -41,7 +41,7 @@ Several steps require a v1-owner signature: pointing the v1 `.eth` resolver at `
 
 ### Phase 2: initial pre-migration
 
-Seeds every active or in-grace v1 `.eth` 2LD into the v2 registry as a **reserved** entry via `BatchRegistrar`, driven by a registration CSV — see [premigration.md](./premigration.md) for the CSV format, the bonus-period expiry rule, checkpointing, and verification. Each reservation's v2 expiry is the name's v1 expiry plus the configurable `--bonus-period-days` (default 62).
+Seeds every active or in-grace v1 `.eth` 2LD into the v2 registry as a **reserved** entry via `BatchRegistrar`, driven by a registration CSV — see [premigration.md](./premigration.md) for the CSV format, the bonus-period expiry rule, checkpointing, and verification. Each reservation's v2 expiry is the name's v1 expiry plus the configurable `--bonus-period-days` (default 62). This run's counts are persisted to the namespace's `.premigration.json` (see [Deployment artifacts](#deployment-artifacts)).
 
 ### Phase 3: disable v1 registrars
 
@@ -57,7 +57,7 @@ Because `ETHRenewerV1` can only renew names that are already `RESERVED` on v2, t
 
 ### Phase 5: final pre-migration sync
 
-After the freeze, export a fresh registration CSV (Dune for Sepolia, BigQuery for mainnet — see [premigration.md](./premigration.md#cli-reference)) and re-run pre-migration so names registered or renewed since phase 2 are caught up. Names already reserved on v2 are re-reserved with their bonus-adjusted expiry — picking up any expiry extensions from renewals performed via `ETHRenewerV1` since phase 4 — and newly eligible names are reserved for the first time.
+After the freeze, export a fresh registration CSV (Dune for Sepolia, BigQuery for mainnet — see [premigration.md](./premigration.md#cli-reference)) and re-run pre-migration so names registered or renewed since phase 2 are caught up. Names already reserved on v2 are re-reserved with their bonus-adjusted expiry — picking up any expiry extensions from renewals performed via `ETHRenewerV1` since phase 4 — and newly eligible names are reserved for the first time. Being the final pass over the whole corpus, this run's counts (recorded to `.premigration.json`) drive the sidecar's `resolved` roll-up (see [Deployment artifacts](#deployment-artifacts)).
 
 ### Phase 6: enable the v2 controller
 
@@ -79,6 +79,8 @@ The resolution cutover, run last so public resolution flips to v2 only once ever
 Phase 1 reads and writes rocketh deployment artifacts under [`deployments/`](../deployments/README.md), grouped into per-deployment **namespace** directories selected with `--deployments-dir` / `--deployment-network` (v1 references via `--v1-deployments-dir` / `--v1-deployment-network`).
 
 `phase deploy-v2` **deploys fresh by default** — it archives the current namespace to `deployments/<env>-<YYYYMMDD>-r<N>` and deploys into a clean one. Since phase 1 sends many transactions and can be interrupted, re-run with `--resume` to continue into the existing namespace instead (rocketh is idempotent, sending only the not-yet-deployed contracts). See [`deployments/README.md`](../deployments/README.md) for the namespace layout, archiving, git-tracking, and idempotency rules.
+
+The pre-migration phases (2 and 5) additionally write a durable `.premigration.json` counts sidecar into the same namespace: a per-run array upserted by a run label, plus a `resolved` roll-up (the most recently finished run) of the final numbers — names pre-migrated, expiry re-syncs, skips split by reason (never registered on v1 / lapsed past v1's grace), names already on v2, and failures. The `fork full` / `clean-testnet` orchestrator labels its two passes `initial` and `final-sync`, so both survive in one file; the standalone `premigration run` / `resume` commands (used by the live runbook below) both label their entry `run`, so the phase-5 sync upserts over the phase-2 entry and the file keeps the latest counts. It holds counts only, never label strings, and is written whenever the namespace persists (so a `fork full` rehearsal without `--save-deployments` leaves it untouched). Names already fully owned on v2 are tallied in their own counter rather than as failures, so a run reporting zero failures is the normal, healthy case even when some names were already migrated. See [`deployments/README.md`](../deployments/README.md) for the file's shape.
 
 ## CLI reference
 

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -59,6 +59,15 @@ Phase numbering matches the console output of the `fork full` orchestrator in
 | 6 | Enable the v2 controller | `disable-batch-registrar` → `activate-v1-handoff-controllers` → `activate-v1-renewer` → `enable-v2-registrar` (+ `verify-*`) | live + clean-testnet | registry root-role admin + v1 owner |
 | 7 | Switch Universal Resolver to v2 (cutover) | `phase upgrade-managed-urp` (+ `switch-urp-to-managed` on bootstrap) (+ `verify-urp`) | live + clean-testnet (bootstrap step mainnet/fresh only) | `urManager` (+ top URP owner on bootstrap) |
 
+> **Re-deploying fresh onto an already-migrated network.** "Re-deploying fresh" means deploying a
+> brand-new v2 set onto a network whose v1 a previous deployment already migrated — the earlier v2 set
+> is archived (see [Deployment artifacts](#deployment-artifacts)) and left orphaned on-chain. Phase 1
+> is where the fresh deploy happens; the later phases re-seed and re-wire v1 to the **new** contract
+> addresses rather than the archived ones. Phases below carry a **Re-deploying fresh** note wherever
+> that changes what you run — most importantly, phase 1 needs a `reclaim-v1-registrar-ownership` prep
+> step and phase 3 becomes a no-op. The one-command shortcut is [`fork full`](#fork-full), which
+> detects an already-migrated chain and adjusts automatically.
+
 ### Phase 0: deploy fresh v1 (clean-testnet only)
 
 - **Applies to:** clean-testnet only. Skipped for live deployments — sepolia/mainnet already have v1.
@@ -87,9 +96,6 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   Add `--include-testnet-premigration-registrar` on testnet/clean runs to also deploy
   `TestnetV1PremigrationRegistrar`. Re-run with `--resume` to continue an interrupted deploy.
 - **Prerequisites:** `bun run compile`; a freshly funded deployer (phase 1 sends many transactions).
-  Re-deploying onto an **already-migrated** chain first requires `phase
-  reclaim-v1-registrar-ownership` (the v1 `BaseRegistrar` is still owned by the prior `ETHRenewerV1`,
-  and one deferred tx is an owner-gated `setResolver`).
 - **Env / args:** `DEPLOYER_KEY` (also the `owner`/`urManager` fallback and the BatchRegistrar owner);
   `SEPOLIA_V1_OWNER_KEY` / `V1_OWNER_KEY` for the deferred v1-owner replay. `phase deploy-v2` cannot
   sign v1-owner transactions itself, hence the defer-then-replay flow above.
@@ -99,6 +105,13 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   (see [universalResolver.md](./universalResolver.md)); the v2 reverse-registrar adapters are deployed
   and authorized as controllers on the v1 reverse registrars; artifacts written to
   `deployments/<network>/` (deploys fresh by default — see [Deployment artifacts](#deployment-artifacts)).
+- **Re-deploying fresh:** `deploy-v2` archives the existing `deployments/<network>/` namespace and
+  deploys a brand-new v2 set with new addresses (`--resume` is only for continuing an *interrupted*
+  deploy into the same namespace, not for a fresh redeploy). First run
+  [`phase reclaim-v1-registrar-ownership`](#cli-commands): the v1 `BaseRegistrar` is still owned by the
+  prior deployment's `ETHRenewerV1`, and one deferred phase-1 tx is an owner-gated `setResolver` the v1
+  owner must sign. Every later phase then seeds and wires v1 to this **new** set; the prior set stays
+  on-chain but orphaned.
 
 > External deployments on the migration timeline (e.g. an HCA component) live outside this repo and
 > are not driven by `phase deploy-v2`.
@@ -119,6 +132,9 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   or `DEPLOYER_KEY`); `--csv-file`, `--work-dir`, `--bonus-period-days` (default 62).
 - **Expected outcome:** every active or in-grace v1 `.eth` 2LD seeded as a **reserved** entry on v2,
   with v2 expiry = v1 expiry + bonus period. `premigration verify` confirms the reservations.
+- **Re-deploying fresh:** the new v2 registry is empty, so this seeds it from scratch exactly like a
+  first run. Reservations from the prior deployment lived on the now-archived registry and do **not**
+  carry over. Use a fresh `--work-dir` so no stale `preMigration-checkpoint.json` is picked up.
 
 ### Phase 3: disable v1 registrars
 
@@ -138,6 +154,10 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   `WrappedETHRegistrarController`, and `NameWrapper` removed as v1 `BaseRegistrar` controllers (via
   `RegistrarSecurityController` when deployed); new v1 registrations frozen.
   `verify-v1-registrars-disabled` confirms.
+- **Re-deploying fresh:** normally a **no-op you can skip** — the v1 registrars were removed by the
+  prior deployment and stay frozen (reclaiming v1 `BaseRegistrar` ownership in phase 1 does not
+  re-enable them). Re-running is harmless (each controller logs "already disabled"); prefer just
+  `verify-v1-registrars-disabled` to confirm the freeze is still in place.
 
 ### Phase 4: authorize ETHRenewerV1
 
@@ -155,6 +175,10 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   transaction. This does **not** reopen the phase 3 registration freeze. The final lock-down that
   transfers v1 `BaseRegistrar` ownership to `ETHRenewerV1` is deferred to
   [phase 6](#phase-6-enable-the-v2-controller).
+- **Re-deploying fresh:** authorizes the **newly-deployed** `ETHRenewerV1` (a new address) as a v1
+  controller — must be re-run. The prior deployment's `ETHRenewerV1` remains an authorized controller
+  (orphaned but harmless); the tooling does not deauthorize it, so remove it manually only if you want
+  a clean controller set.
 
 > **Mainnet renewal continuity.** Renewals are paused between phase 3 (freeze) and phase 4
 > (authorize), and the phase 5 sync can run for days. When the v1 owner is a DAO/multisig, execute
@@ -176,6 +200,8 @@ Phase numbering matches the console output of the `fork full` orchestrator in
 - **Expected outcome:** names already reserved on v2 are re-reserved with their bonus-adjusted expiry
   — picking up any expiry extensions from `ETHRenewerV1` renewals since phase 4 — and newly eligible
   names are reserved for the first time.
+- **Re-deploying fresh:** same as [phase 2](#phase-2-initial-pre-migration) — re-seeds the new
+  registry against a fresh post-freeze CSV and a fresh `--work-dir`.
 
 ### Phase 6: enable the v2 controller
 
@@ -202,6 +228,11 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   `ETHRenewerV1` (final lock-down); `ETHRegistrar` granted `REGISTRAR | RENEW` on the v2 `ETHRegistry`
   — live v2 registrations open. `verify-v2-registrar` confirms the grant. This bundle replaces the
   all-at-once role swap done by [prepareMigration.md](./prepareMigration.md).
+- **Re-deploying fresh:** re-points v1 at the new set and must be re-run —
+  `activate-v1-handoff-controllers` authorizes the new `Graveyard`, `activate-v1-renewer` transfers v1
+  `BaseRegistrar` ownership to the new `ETHRenewerV1` (the ownership you reclaimed in phase 1), and
+  `enable-v2-registrar` grants the new `ETHRegistrar`. The prior deployment's `Graveyard`/`ETHRenewerV1`
+  remain authorized as orphaned v1 controllers.
 
 ### Phase 7: switch the Universal Resolver to v2
 
@@ -227,6 +258,11 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   `UniversalResolverV2` and public resolution serves v2. `verify-urp` confirms both proxy
   implementations. See [universalResolver.md](./universalResolver.md) for the proxy chain and the
   optional post-cutover step.
+- **Re-deploying fresh:** on a reuse network (sepolia) the top **and** intermediate URPs are adopted by
+  address and never redeployed — phase 1 deploys a fresh `UniversalResolverV2` implementation and
+  `upgrade-managed-urp` re-points the reused intermediate URP at it, orphaning the prior
+  implementation. Bootstrap networks (mainnet/fresh) deploy a fresh intermediate URP instead. Must be
+  re-run to serve the new implementation.
 
 ## Live deployment (Sepolia)
 
@@ -284,6 +320,11 @@ prerequisites, and expected outcome:
 6. [Phase 6 — enable the v2 controller](#phase-6-enable-the-v2-controller).
 7. [Phase 7 — resolution cutover](#phase-7-switch-the-universal-resolver-to-v2): sepolia is a reuse
    network, so only `upgrade-managed-urp` + `verify-urp` run.
+
+> **Re-deploying onto an already-migrated Sepolia?** This runbook assumes a first migration. On a
+> repeat deploy the order is unchanged, but read each phase's **Re-deploying fresh** note first: run
+> [`phase reclaim-v1-registrar-ownership`](#cli-commands) before phase 1, skip phase 3 (v1 is already
+> frozen), and expect phases 2, 4, 5, 6, and 7 to re-seed and re-wire v1 to the new contract set.
 
 ### After
 

--- a/contracts/docs/premigration.md
+++ b/contracts/docs/premigration.md
@@ -82,8 +82,10 @@ Names stream from the CSV in batches of `--batch-size`. Each batch is verified w
 | Available (0) | Registered, or expired but within v1's 90-day grace | **Reserve** with expiry `v1Expiry + bonusPeriodDays` |
 | Reserved (1) | Registered, different expiry | **Renew** (sync expiry) |
 | Reserved (1) | Registered, same expiry | **Skip** (up to date) |
-| Registered (2) | Any | **Fail** (already fully owned on v2) |
+| Registered (2) | Any | **Already on v2** (fully owned; counted separately, not a failure) |
 | Any | Never registered, or past v1's 90-day grace | **Skip** (v1 owner lost the claim) |
+
+Names already fully owned on v2 (`Registered (2)`) are tallied in their own `alreadyRegisteredCount`, kept distinct from `failureCount` so the latter reflects only genuine errors (reverts, RPC failures). Skips are likewise split into `skippedNeverRegisteredCount` (never registered on v1) and `skippedPastGraceCount` (registration lapsed past v1's grace), which together make up `skippedCount`.
 
 Reserved names are written with owner/registry `address(0)`, resolver = `ENSV1Resolver`, roleBitmap `0`, and the computed expiry.
 
@@ -91,7 +93,7 @@ Reserved names are written with owner/registry `address(0)`, resolver = `ENSV1Re
 
 ## Checkpoint & resume
 
-A checkpoint (`preMigration-checkpoint.json`) is written after each batch, tracking the last processed line and accumulated counters (reserved, renewed, skipped, invalid, failed). `--continue` loads it, sets `--start-index` to the last processed line, and resumes; counters accumulate across runs.
+A checkpoint (`preMigration-checkpoint.json`) is written after each batch, tracking the last processed line and accumulated counters (reserved, renewed, skipped — split into never-registered and past-grace — already-on-v2, invalid, failed). `--continue` loads it, sets `--start-index` to the last processed line, and resumes; counters accumulate across runs. A run started **without** `--continue` first clears any stale checkpoint so its counts reflect only the current run.
 
 ```bash
 bun run script/preMigration.ts --continue [same options as before]
@@ -103,7 +105,9 @@ bun run script/preMigration.ts --continue [same options as before]
 
 ## Output
 
-Informational output goes to `preMigration.log` and errors to `preMigration-errors.log`; the console mirrors progress with a final summary table (processed / reserved / renewed / skipped / invalid / failed / success rate). Non-CSV failures (individual name reverts, RPC timeouts at a 30s per-call limit, checkpoint write errors) are counted and logged without aborting the run.
+Informational output goes to `preMigration.log` and errors to `preMigration-errors.log`; the console mirrors progress with a final summary table (processed / reserved / renewed / skipped — with never-registered and past-grace sub-totals / already-on-v2 / invalid / failed / success rate). Non-CSV failures (individual name reverts, RPC timeouts at a 30s per-call limit, checkpoint write errors) are counted and logged without aborting the run.
+
+When pre-migration is driven through the migration CLI (see [migration.md](./migration.md)) against a persisted deployment namespace, these counts are also written to a durable `.premigration.json` sidecar in the namespace — counts only, never label strings. See [deployments/README.md](../deployments/README.md) for its shape.
 
 ## Examples
 

--- a/contracts/script/migration.ts
+++ b/contracts/script/migration.ts
@@ -52,6 +52,8 @@ import {
 } from "./deploy-constants.js";
 import { main as exportRegistrationsMain } from "./exportTheGraphRegistrations.js";
 import {
+  CHECKPOINT_FILE,
+  type Checkpoint,
   createFreshCheckpoint,
   isValidLabel,
   loadCheckpoint,
@@ -396,9 +398,7 @@ function csvLabelColumnIndex(header: string[]): number {
 // Quote a CSV field when it contains a delimiter, quote, or newline so labels
 // with such characters survive a round-trip through the premigration reader.
 function escapeCsvField(value: string): string {
-  return /[",\n\r]/.test(value)
-    ? `"${value.replace(/"/g, '""')}"`
-    : value;
+  return /[",\n\r]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
 }
 
 function readLabelsFromCsv(csvFile: string, limit?: number): string[] {
@@ -407,9 +407,7 @@ function readLabelsFromCsv(csvFile: string, limit?: number): string[] {
   const header = parseCSVLine(lines[0]);
   const labelIndex = csvLabelColumnIndex(header);
   if (labelIndex < 0) {
-    throw new Error(
-      `CSV must contain a labelName or label column: ${csvFile}`,
-    );
+    throw new Error(`CSV must contain a labelName or label column: ${csvFile}`);
   }
   const labels: string[] = [];
   for (const line of lines.slice(1)) {
@@ -1111,6 +1109,8 @@ export async function runPreMigrationCommand(
     v1BaseRegistrar?: Address;
     workDir?: string;
     dryRun?: boolean;
+    metadataLabel?: string;
+    persistMetadata?: boolean;
   },
   resume: boolean,
 ) {
@@ -1190,6 +1190,24 @@ export async function runPreMigrationCommand(
       args.push("--bonus-period-days", opts.bonusPeriodDays);
     if (resume) args.push("--continue");
     await preMigrationMain(args);
+
+    // Persist a durable counts sidecar into the deployment namespace. Skipped on
+    // dry runs and when the caller opts out (e.g. a fork rehearsal that does not
+    // save deployments), so a committed namespace is never touched by a throwaway
+    // run. The checkpoint lands in the workDir (or cwd when none was set).
+    if (!opts.dryRun && (opts.persistMetadata ?? true)) {
+      const cpDir = opts.workDir ? resolve(opts.workDir) : previousCwd;
+      const checkpoint = loadCheckpoint(join(cpDir, CHECKPOINT_FILE));
+      if (checkpoint) {
+        recordPreMigrationMetadata({
+          deploymentsDir,
+          deploymentNetwork,
+          network,
+          label: opts.metadataLabel ?? "run",
+          checkpoint,
+        });
+      }
+    }
   } finally {
     process.chdir(previousCwd);
   }
@@ -1398,9 +1416,7 @@ async function verifyPreMigration(opts: {
   console.log(`eligible v1 names: ${eligible}`);
   console.log(`skipped ineligible names: ${skipped}`);
   console.log(`verified active names: ${verifiedActive}`);
-  console.log(
-    `verified expired-bonus names: ${verifiedExpiredBonus}`,
-  );
+  console.log(`verified expired-bonus names: ${verifiedExpiredBonus}`);
   console.log(`verified names: ${verifiedActive + verifiedExpiredBonus}`);
   if (errors.length > 0) {
     console.error(errors.slice(0, 20).join("\n"));
@@ -1527,7 +1543,8 @@ async function sendAdminWrite(opts: {
     );
     return;
   }
-  if (opts.impersonateAccount) await impersonate(opts.client, opts.impersonateAccount);
+  if (opts.impersonateAccount)
+    await impersonate(opts.client, opts.impersonateAccount);
   const wallet = walletClient({
     rpcUrl: opts.rpcUrl,
     chain: opts.chain,
@@ -2154,7 +2171,11 @@ function resolveRegistry(opts: {
 }): ContractRef {
   const registry = opts.registry
     ? null
-    : loadV2Deployment(opts.deploymentsDir, opts.deploymentNetwork, "ETHRegistry");
+    : loadV2Deployment(
+        opts.deploymentsDir,
+        opts.deploymentNetwork,
+        "ETHRegistry",
+      );
   return {
     address: opts.registry ?? registry!.address,
     abi: registry?.abi ?? Artifact_PermissionedRegistry.abi,
@@ -2201,7 +2222,11 @@ async function enableV2Registrar(opts: {
     deploymentNetwork,
     "ETHRegistrar",
   );
-  const beforeEnabled = await readHasRegistrarRoles(client, registry, ethRegistrar);
+  const beforeEnabled = await readHasRegistrarRoles(
+    client,
+    registry,
+    ethRegistrar,
+  );
   console.log(`v2 registrar already enabled: ${beforeEnabled}`);
   if (beforeEnabled) return;
 
@@ -2216,7 +2241,11 @@ async function enableV2Registrar(opts: {
     privateKey: opts.privateKey,
     impersonateAccount: opts.impersonateAccount,
   });
-  const afterEnabled = await readHasRegistrarRoles(client, registry, ethRegistrar);
+  const afterEnabled = await readHasRegistrarRoles(
+    client,
+    registry,
+    ethRegistrar,
+  );
   console.log(`v2 registrar enabled after phase: ${afterEnabled}`);
 }
 
@@ -2789,7 +2818,8 @@ function signerKeyForAccount(
   const keys = candidates.filter((key): key is `0x${string}` => Boolean(key));
   if (!target) return keys[0];
   return keys.find(
-    (key) => getAddress(privateKeyToAccount(key).address) === getAddress(target),
+    (key) =>
+      getAddress(privateKeyToAccount(key).address) === getAddress(target),
   );
 }
 
@@ -3134,7 +3164,9 @@ async function deployV1(opts: DeployV1Options) {
 export async function deployV2(opts: DeployV2Options) {
   const network = NETWORKS[opts.network];
   const deploymentNetwork = opts.deploymentNetwork ?? network.environment;
-  const deploymentsDir = resolve(opts.deploymentsDir ?? DEFAULT_DEPLOYMENTS_DIR);
+  const deploymentsDir = resolve(
+    opts.deploymentsDir ?? DEFAULT_DEPLOYMENTS_DIR,
+  );
   // A fresh deployment archives any existing namespace and therefore must
   // persist the new one, so it implies saving regardless of the flag.
   const persist = Boolean(opts.saveDeployments) || Boolean(opts.fresh);
@@ -3742,7 +3774,11 @@ function loadV2MigrationDeployments(
       deploymentNetwork,
       "ETHRenewerV1",
     ),
-    mockUsdc: maybeLoadV2Deployment(deploymentsDir, deploymentNetwork, "MockUSDC"),
+    mockUsdc: maybeLoadV2Deployment(
+      deploymentsDir,
+      deploymentNetwork,
+      "MockUSDC",
+    ),
     unlockedMigrationController: loadV2Deployment(
       deploymentsDir,
       deploymentNetwork,
@@ -4097,10 +4133,11 @@ export async function runForkFull(opts: RunForkFullOptions) {
     // Signer for the v1-owner-gated controller changes (disable registrars,
     // authorize the renewer, hand off ownership). On a fork we impersonate the
     // owner; for a live run we require the key that controls it.
-    const v1OwnerSigner: { impersonateOwner: true } | { privateKey: `0x${string}` } =
-      useRpcStateControls
-        ? { impersonateOwner: true }
-        : { privateKey: requirePrivateKeyForAddress(v1Owner, keys, "v1 owner") };
+    const v1OwnerSigner:
+      | { impersonateOwner: true }
+      | { privateKey: `0x${string}` } = useRpcStateControls
+      ? { impersonateOwner: true }
+      : { privateKey: requirePrivateKeyForAddress(v1Owner, keys, "v1 owner") };
 
     // The migration wraps whatever the canonical top proxy currently serves.
     // When reusing a long-lived intermediate URP, the top proxy already fronts
@@ -4224,6 +4261,8 @@ export async function runForkFull(opts: RunForkFullOptions) {
         batchSize: opts.batchSize,
         limit: opts.initialLimit,
         workDir,
+        metadataLabel: "initial",
+        persistMetadata: Boolean(opts.saveDeployments),
       },
       resumeFromPhase === 2,
     );
@@ -4303,9 +4342,7 @@ export async function runForkFull(opts: RunForkFullOptions) {
           "ETHRenewerV1 was not authorized as a v1 BaseRegistrar controller in phase 4",
         );
       }
-      console.log(
-        "smoke ETHRenewerV1 authorized as a v1 renewal controller",
-      );
+      console.log("smoke ETHRenewerV1 authorized as a v1 renewal controller");
     }
 
     console.log("phase 5: sync remaining names and finish pre-migration");
@@ -4326,8 +4363,10 @@ export async function runForkFull(opts: RunForkFullOptions) {
         batchSize: opts.batchSize,
         limit: opts.finishLimit,
         workDir: finalSyncWorkDir,
+        metadataLabel: "final-sync",
+        persistMetadata: Boolean(opts.saveDeployments),
       },
-      existsSync(join(finalSyncWorkDir, "preMigration-checkpoint.json")),
+      existsSync(join(finalSyncWorkDir, CHECKPOINT_FILE)),
     );
     if (!postMigration) {
       await assertV2State({
@@ -4366,7 +4405,9 @@ export async function runForkFull(opts: RunForkFullOptions) {
         status: STATUS.REGISTERED,
         owner: smokeMigrationOwner,
       });
-      console.log(`smoke migration registered ${smokeLabels.migrate}.eth on v2`);
+      console.log(
+        `smoke migration registered ${smokeLabels.migrate}.eth on v2`,
+      );
     }
 
     console.log(
@@ -4781,11 +4822,7 @@ function addV1OwnerWriteOptions(command: Command): Command {
   return command
     .option("--private-key <key>", "V1 owner private key")
     .option("--impersonate-owner", "Impersonate owner on a fork", false)
-    .option(
-      "--calldata-only",
-      "Print transaction target and calldata",
-      false,
-    );
+    .option("--calldata-only", "Print transaction target and calldata", false);
 }
 
 function assertCleanDeploymentNamespace(
@@ -4837,6 +4874,125 @@ function recordDeploymentMetadata(
   );
 }
 
+const PREMIGRATION_METADATA_FILE = ".premigration.json";
+
+// One summary entry per logical pre-migration run (initial, final-sync, or a
+// standalone run). Counts only — never label strings.
+interface PreMigrationRunSummary {
+  label: string;
+  finishedAt: string;
+  totalExpected: number;
+  totalProcessed: number;
+  reserved: number;
+  renewed: number;
+  skippedNeverRegistered: number;
+  skippedExpiredPastGrace: number;
+  invalidLabels: number;
+  alreadyOnV2: number;
+  failed: number;
+}
+
+interface PreMigrationMetadata {
+  network: string;
+  deploymentNetwork: string;
+  chainId?: number;
+  updatedAt: string;
+  resolved: {
+    finishedAt: string;
+    totalNames: number;
+    namesPreMigrated: number;
+    newReservations: number;
+    expiryResyncs: number;
+    skippedNeverRegistered: number;
+    skippedExpiredPastGrace: number;
+    invalidLabels: number;
+    alreadyOnV2: number;
+    failed: number;
+  };
+  runs: PreMigrationRunSummary[];
+}
+
+function checkpointToRunSummary(
+  label: string,
+  checkpoint: Checkpoint,
+): PreMigrationRunSummary {
+  return {
+    label,
+    finishedAt: checkpoint.timestamp,
+    totalExpected: checkpoint.totalExpected,
+    totalProcessed: checkpoint.totalProcessed,
+    reserved: checkpoint.successCount,
+    renewed: checkpoint.renewedCount,
+    skippedNeverRegistered: checkpoint.skippedNeverRegisteredCount,
+    skippedExpiredPastGrace: checkpoint.skippedPastGraceCount,
+    invalidLabels: checkpoint.invalidLabelCount,
+    alreadyOnV2: checkpoint.alreadyRegisteredCount,
+    failed: checkpoint.failureCount,
+  };
+}
+
+// The resolved roll-up reflects the run that finished most recently, which in
+// the phased flow is the final-sync pass that re-scans the whole corpus and so
+// represents the end state. `namesPreMigrated` = names currently reserved on v2
+// (newly reserved this run + already-reserved names whose expiry was re-synced).
+function resolveFromRuns(
+  runs: PreMigrationRunSummary[],
+): PreMigrationMetadata["resolved"] {
+  const latest = runs.reduce((a, b) => (b.finishedAt >= a.finishedAt ? b : a));
+  return {
+    finishedAt: latest.finishedAt,
+    totalNames: latest.totalExpected,
+    namesPreMigrated: latest.reserved + latest.renewed,
+    newReservations: latest.reserved,
+    expiryResyncs: latest.renewed,
+    skippedNeverRegistered: latest.skippedNeverRegistered,
+    skippedExpiredPastGrace: latest.skippedExpiredPastGrace,
+    invalidLabels: latest.invalidLabels,
+    alreadyOnV2: latest.alreadyOnV2,
+    failed: latest.failed,
+  };
+}
+
+// Persists a compact pre-migration counts sidecar into the deployment
+// namespace, alongside `.deployment.json`. A dotfile so rocketh's loader ignores
+// it (it only reads `.migrations.json` + non-dot `*.json` artifacts). Each run
+// is upserted by `label` so a resume that re-writes its accumulated checkpoint
+// updates its own entry in place instead of appending a duplicate.
+function recordPreMigrationMetadata(opts: {
+  deploymentsDir: string;
+  deploymentNetwork: string;
+  network: MigrationNetwork;
+  label: string;
+  checkpoint: Checkpoint;
+}) {
+  const dir = join(opts.deploymentsDir, opts.deploymentNetwork);
+  if (!existsSync(dir)) return;
+  const metadataPath = join(dir, PREMIGRATION_METADATA_FILE);
+
+  let existing: PreMigrationMetadata | undefined;
+  if (existsSync(metadataPath)) {
+    try {
+      existing = JSON.parse(readFileSync(metadataPath, "utf-8"));
+    } catch {
+      existing = undefined;
+    }
+  }
+
+  const runs = (existing?.runs ?? []).filter((run) => run.label !== opts.label);
+  runs.push(checkpointToRunSummary(opts.label, opts.checkpoint));
+
+  const metadata: PreMigrationMetadata = {
+    network: opts.network,
+    deploymentNetwork: opts.deploymentNetwork,
+    chainId: NETWORKS[opts.network].chain.id,
+    updatedAt: new Date().toISOString(),
+    resolved: resolveFromRuns(runs),
+    runs,
+  };
+
+  writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+}
+
 // Resolves a namespace's deploy time, preferring the recorded metadata and
 // falling back to the latest `.migrations.json` entry (unix-epoch seconds).
 function readDeploymentDeployedAt(path: string): string | undefined {
@@ -4850,8 +5006,9 @@ function readDeploymentDeployedAt(path: string): string | undefined {
   const migrationsPath = join(path, ".migrations.json");
   if (existsSync(migrationsPath)) {
     try {
-      const migrations = JSON.parse(readFileSync(migrationsPath, "utf-8")) as
-        Record<string, number>;
+      const migrations = JSON.parse(
+        readFileSync(migrationsPath, "utf-8"),
+      ) as Record<string, number>;
       const timestamps = Object.values(migrations).filter(
         (value) => typeof value === "number" && Number.isFinite(value),
       );
@@ -4873,8 +5030,7 @@ function archiveExistingDeploymentNamespace(root: string, environment: string) {
     (file) => file.endsWith(".json") || file === ".chain",
   );
   if (!hasArtifacts) return;
-  const deployedAt =
-    readDeploymentDeployedAt(path) ?? new Date().toISOString();
+  const deployedAt = readDeploymentDeployedAt(path) ?? new Date().toISOString();
   const stamp = deployedAt.slice(0, 10).replace(/-/g, "");
   let revision = 1;
   let archive = `${environment}-${stamp}-r${revision}`;
@@ -5080,6 +5236,7 @@ export async function main(argv = process.argv): Promise<void> {
       await runPreMigrationCommand(
         {
           ...networkOpts,
+          metadataLabel: "run",
         },
         false,
       );
@@ -5093,6 +5250,7 @@ export async function main(argv = process.argv): Promise<void> {
       await runPreMigrationCommand(
         {
           ...networkOpts,
+          metadataLabel: "run",
         },
         true,
       );
@@ -5284,8 +5442,7 @@ export async function main(argv = process.argv): Promise<void> {
         const networkOpts = withNetworkRpc(opts);
         await setV1ReverseDefaultResolver({
           ...networkOpts,
-          privateKey:
-            v1OwnerKeyFromEnv(opts),
+          privateKey: v1OwnerKeyFromEnv(opts),
         });
       },
     ),
@@ -5398,8 +5555,7 @@ export async function main(argv = process.argv): Promise<void> {
         const networkOpts = withNetworkRpc(opts);
         await authorizeTestnetV1PremigrationRegistrar({
           ...networkOpts,
-          privateKey:
-            v1OwnerKeyFromEnv(opts),
+          privateKey: v1OwnerKeyFromEnv(opts),
         });
       },
     ),
@@ -5427,8 +5583,7 @@ export async function main(argv = process.argv): Promise<void> {
         const networkOpts = withNetworkRpc(opts);
         await activateV1Graveyard({
           ...networkOpts,
-          privateKey:
-            v1OwnerKeyFromEnv(opts),
+          privateKey: v1OwnerKeyFromEnv(opts),
         });
       },
     ),
@@ -5463,8 +5618,7 @@ export async function main(argv = process.argv): Promise<void> {
         const networkOpts = withNetworkRpc(opts);
         await activateV1HandoffControllers({
           ...networkOpts,
-          privateKey:
-            v1OwnerKeyFromEnv(opts),
+          privateKey: v1OwnerKeyFromEnv(opts),
         });
       },
     ),
@@ -5492,8 +5646,7 @@ export async function main(argv = process.argv): Promise<void> {
         const networkOpts = withNetworkRpc(opts);
         await authorizeV1Renewer({
           ...networkOpts,
-          privateKey:
-            v1OwnerKeyFromEnv(opts),
+          privateKey: v1OwnerKeyFromEnv(opts),
         });
       },
     ),
@@ -5521,8 +5674,7 @@ export async function main(argv = process.argv): Promise<void> {
         const networkOpts = withNetworkRpc(opts);
         await activateV1RenewerAndTransferOwnership({
           ...networkOpts,
-          privateKey:
-            v1OwnerKeyFromEnv(opts),
+          privateKey: v1OwnerKeyFromEnv(opts),
         });
       },
     ),
@@ -5557,8 +5709,7 @@ export async function main(argv = process.argv): Promise<void> {
         const networkOpts = withNetworkRpc(opts);
         await reclaimV1RegistrarOwnership({
           ...networkOpts,
-          v1Owner:
-            opts.v1Owner ?? NETWORKS[networkOpts.network].defaultV1Owner,
+          v1Owner: opts.v1Owner ?? NETWORKS[networkOpts.network].defaultV1Owner,
           privateKey:
             opts.privateKey ?? envPrivateKey("OWNER_KEY", "DEPLOYER_KEY"),
         });

--- a/contracts/script/preMigration.ts
+++ b/contracts/script/preMigration.ts
@@ -5,6 +5,7 @@ import {
   createReadStream,
   existsSync,
   readFileSync,
+  rmSync,
   writeFileSync,
 } from "node:fs";
 import {
@@ -339,6 +340,18 @@ export function saveCheckpoint(checkpoint: Checkpoint): void {
     writeFileSync(CHECKPOINT_FILE, JSON.stringify(checkpoint, null, 2));
   } catch (error) {
     logger.error(`Failed to save checkpoint: ${error}`);
+  }
+}
+
+// Removes any checkpoint left in the work directory so a fresh run cannot
+// inherit stale counts from a previous one. A run that processes zero batches
+// writes no new checkpoint, so without this a lingering file would otherwise be
+// mistaken for this run's result by anything that reads the checkpoint after.
+export function clearCheckpoint(path: string = CHECKPOINT_FILE): void {
+  try {
+    rmSync(path, { force: true });
+  } catch (error) {
+    logger.error(`Failed to clear checkpoint: ${error}`);
   }
 }
 
@@ -1294,6 +1307,8 @@ export async function main(argv = process.argv): Promise<void> {
         );
         logger.info(`Resuming from CSV line ${config.startIndex}`);
       }
+    } else if (!config.disableCheckpoint) {
+      clearCheckpoint();
     }
     logger.info("");
 

--- a/contracts/script/preMigration.ts
+++ b/contracts/script/preMigration.ts
@@ -118,13 +118,21 @@ export interface Checkpoint {
   successCount: number;
   renewedCount: number;
   failureCount: number;
+  /// Aggregate of the two skip sub-counters below (names not claimable on v1).
   skippedCount: number;
+  /// Names skipped because they were never registered on v1.
+  skippedNeverRegisteredCount: number;
+  /// Names skipped because their v1 registration lapsed past the grace period.
+  skippedPastGraceCount: number;
+  /// Names skipped because they are already registered (owned) on v2. Tracked
+  /// separately from genuine failures.
+  alreadyRegisteredCount: number;
   invalidLabelCount: number;
   timestamp: string;
 }
 
 // Constants
-const CHECKPOINT_FILE = "preMigration-checkpoint.json";
+export const CHECKPOINT_FILE = "preMigration-checkpoint.json";
 const ERROR_LOG_FILE = "preMigration-errors.log";
 const INFO_LOG_FILE = "preMigration.log";
 
@@ -151,6 +159,9 @@ export function createFreshCheckpoint(): Checkpoint {
     renewedCount: 0,
     failureCount: 0,
     skippedCount: 0,
+    skippedNeverRegisteredCount: 0,
+    skippedPastGraceCount: 0,
+    alreadyRegisteredCount: 0,
     invalidLabelCount: 0,
     timestamp: new Date().toISOString(),
   };
@@ -300,20 +311,23 @@ class PreMigrationLogger extends Logger {
       `  → ⊘ Skipping: ${domainName} (invalid label name)`,
     );
   }
-
 }
 
 const logger = new PreMigrationLogger();
 
 // Checkpoint management
-export function loadCheckpoint(): Checkpoint | null {
-  if (!existsSync(CHECKPOINT_FILE)) {
+export function loadCheckpoint(
+  path: string = CHECKPOINT_FILE,
+): Checkpoint | null {
+  if (!existsSync(path)) {
     return null;
   }
 
   try {
-    const data = readFileSync(CHECKPOINT_FILE, "utf-8");
-    return JSON.parse(data);
+    const data = readFileSync(path, "utf-8");
+    // Spread over a fresh checkpoint so counters added after an older run was
+    // written default to 0 rather than undefined (which would break `count++`).
+    return { ...createFreshCheckpoint(), ...JSON.parse(data) };
   } catch (error) {
     logger.error(`Failed to load checkpoint: ${error}`);
     return null;
@@ -979,7 +993,7 @@ async function processBatch(
       logger.error(
         `Name ${registration.labelName}.eth is already registered with owner: ${result.v2LatestOwner}`,
       );
-      checkpoint.failureCount++;
+      checkpoint.alreadyRegisteredCount++;
       checkpoint.totalProcessed++;
       logger.finishedName(registration.labelName, "failed");
       continue;
@@ -989,12 +1003,17 @@ async function processBatch(
     }
 
     if (!result.v1IsClaimable) {
-      const reason =
-        result.v1Expiry === 0n
-          ? "never registered on v1"
-          : `past v1 ${V1_GRACE_PERIOD_DAYS}-day grace period`;
+      const neverRegistered = result.v1Expiry === 0n;
+      const reason = neverRegistered
+        ? "never registered on v1"
+        : `past v1 ${V1_GRACE_PERIOD_DAYS}-day grace period`;
       logger.v1NotRegistered(registration.labelName, reason);
       checkpoint.skippedCount++;
+      if (neverRegistered) {
+        checkpoint.skippedNeverRegisteredCount++;
+      } else {
+        checkpoint.skippedPastGraceCount++;
+      }
       checkpoint.totalProcessed++;
       logger.finishedName(registration.labelName, "skipped");
       continue;
@@ -1096,8 +1115,20 @@ function printFinalSummary(checkpoint: Checkpoint): void {
     cyan(checkpoint.renewedCount.toString()),
   );
   logger.config(
-    "Skipped (already up-to-date/expired)",
+    "Skipped (not claimable on v1)",
     yellow(checkpoint.skippedCount.toString()),
+  );
+  logger.config(
+    "  → never registered on v1",
+    yellow(checkpoint.skippedNeverRegisteredCount.toString()),
+  );
+  logger.config(
+    "  → expired past v1 grace period",
+    yellow(checkpoint.skippedPastGraceCount.toString()),
+  );
+  logger.config(
+    "Already registered on v2",
+    yellow(checkpoint.alreadyRegisteredCount.toString()),
   );
   logger.config(
     "Invalid labels",

--- a/contracts/test/e2e/preMigration.test.ts
+++ b/contracts/test/e2e/preMigration.test.ts
@@ -735,6 +735,25 @@ describe("PreMigration", () => {
     expect(checkpointAfter!.successCount).toBe(0);
   });
 
+  it("fresh run clears a stale checkpoint left by a previous run", async () => {
+    writeTestCheckpoint(
+      createTestCheckpoint({
+        totalProcessed: 5,
+        successCount: 5,
+        totalExpected: 5,
+      }),
+    );
+
+    // Header-only CSV: a fresh run processes zero batches and writes no new
+    // checkpoint, so the stale one must be cleared rather than left to be
+    // mistaken for this run's result.
+    createCSVFile(csvFilePath, []);
+    const args = buildMainArgs(env, csvFilePath);
+    await main(args);
+
+    expect(readTestCheckpoint()).toBeNull();
+  });
+
   // ─── Invalid label handling ────────────────────────────────────────
 
   it("fails fast on empty labelName cell", async () => {
@@ -1213,7 +1232,7 @@ describe("PreMigration", () => {
     expect(checkpoint!.failureCount).toBe(0);
   });
 
-  it("multiple registered names in batch are all counted as failures", async () => {
+  it("multiple already-registered names in batch are all counted separately from failures", async () => {
     const registeredLabels = ["mreg1", "mreg2"];
     const validLabel = "mregvalid";
     const { user, deployer } = env.namedAccounts;
@@ -1239,7 +1258,8 @@ describe("PreMigration", () => {
 
     const checkpoint = readTestCheckpoint();
     expect(checkpoint!.successCount).toBe(1);
-    expect(checkpoint!.failureCount).toBe(2);
+    expect(checkpoint!.alreadyRegisteredCount).toBe(2);
+    expect(checkpoint!.failureCount).toBe(0);
   });
 
   it("re-running same batch after successful reservation uses renewal path", async () => {

--- a/contracts/test/e2e/preMigration.test.ts
+++ b/contracts/test/e2e/preMigration.test.ts
@@ -263,12 +263,7 @@ describe("PreMigration", () => {
     const { user } = env.namedAccounts;
 
     const fiveDays = 5 * 24 * 60 * 60;
-    const v1Expiry = await registerV1Name(
-      env,
-      label,
-      user.address,
-      fiveDays,
-    );
+    const v1Expiry = await registerV1Name(env, label, user.address, fiveDays);
 
     createCSVFile(csvFilePath, [label]);
     const bonusPeriodDays = 90;
@@ -368,7 +363,9 @@ describe("PreMigration", () => {
     await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
 
     createCSVFile(csvFilePath, [label]);
-    const args = buildMainArgs(env, csvFilePath, { useEnvVarForPrivateKey: true });
+    const args = buildMainArgs(env, csvFilePath, {
+      useEnvVarForPrivateKey: true,
+    });
     await main(args);
 
     const state = await verifyV2State(env, label);
@@ -381,7 +378,8 @@ describe("PreMigration", () => {
 
     await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
 
-    process.env.PREMIGRATION_PRIVATE_KEY = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    process.env.PREMIGRATION_PRIVATE_KEY =
+      "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 
     createCSVFile(csvFilePath, [label]);
     const args = buildMainArgs(env, csvFilePath);
@@ -426,7 +424,12 @@ describe("PreMigration", () => {
 
     const expiries: bigint[] = [];
     for (const label of labels) {
-      const expiry = await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
+      const expiry = await registerV1Name(
+        env,
+        label,
+        user.address,
+        ONE_YEAR_SECONDS,
+      );
       expiries.push(expiry);
     }
 
@@ -452,7 +455,11 @@ describe("PreMigration", () => {
     await registerV1Name(env, expiredLabel, user.address, 1);
     await setTimeout(2000);
 
-    createCSVFile(csvFilePath, [validLabel, expiredLabel, neverRegisteredLabel]);
+    createCSVFile(csvFilePath, [
+      validLabel,
+      expiredLabel,
+      neverRegisteredLabel,
+    ]);
     const args = buildMainArgs(env, csvFilePath);
     await main(args);
 
@@ -473,7 +480,12 @@ describe("PreMigration", () => {
     const neverLabel = "bvnever";
     const { user, deployer } = env.namedAccounts;
 
-    const validExpiry = await registerV1Name(env, validLabel, user.address, ONE_YEAR_SECONDS);
+    const validExpiry = await registerV1Name(
+      env,
+      validLabel,
+      user.address,
+      ONE_YEAR_SECONDS,
+    );
     await registerV1Name(env, expiredLabel, user.address, 1);
     await registerV1Name(env, registeredLabel, user.address, ONE_YEAR_SECONDS);
     await setTimeout(2000);
@@ -489,7 +501,9 @@ describe("PreMigration", () => {
 
     const rpcUrl = `http://${env.hostPort}`;
     const client = createWalletClient({
-      account: privateKeyToAccount("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"),
+      account: privateKeyToAccount(
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+      ),
       chain: mainnet,
       transport: http(rpcUrl, { retryCount: 0, timeout: 30000 }),
     }).extend(publicActions);
@@ -560,7 +574,12 @@ describe("PreMigration", () => {
 
     const expiries: bigint[] = [];
     for (const label of labels) {
-      const expiry = await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
+      const expiry = await registerV1Name(
+        env,
+        label,
+        user.address,
+        ONE_YEAR_SECONDS,
+      );
       expiries.push(expiry);
     }
 
@@ -588,7 +607,12 @@ describe("PreMigration", () => {
 
     const expiries: bigint[] = [];
     for (const label of labels) {
-      const expiry = await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
+      const expiry = await registerV1Name(
+        env,
+        label,
+        user.address,
+        ONE_YEAR_SECONDS,
+      );
       expiries.push(expiry);
     }
 
@@ -608,16 +632,17 @@ describe("PreMigration", () => {
   });
 
   it("handles batch of names with long labels (higher calldata cost)", async () => {
-    const labels = [
-      "a".repeat(63),
-      "b".repeat(63),
-      "c".repeat(63),
-    ];
+    const labels = ["a".repeat(63), "b".repeat(63), "c".repeat(63)];
     const { user } = env.namedAccounts;
 
     const expiries: bigint[] = [];
     for (const label of labels) {
-      const expiry = await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
+      const expiry = await registerV1Name(
+        env,
+        label,
+        user.address,
+        ONE_YEAR_SECONDS,
+      );
       expiries.push(expiry);
     }
 
@@ -652,11 +677,13 @@ describe("PreMigration", () => {
     expect(checkpoint).not.toBeNull();
     expect(checkpoint!.successCount).toBe(2);
     expect(checkpoint!.skippedCount).toBe(1);
+    expect(checkpoint!.skippedNeverRegisteredCount).toBe(1);
+    expect(checkpoint!.skippedPastGraceCount).toBe(0);
     expect(checkpoint!.failureCount).toBe(0);
     expect(checkpoint!.totalProcessed).toBe(3);
   });
 
-  it("checkpoint tracks failures for already-registered names", async () => {
+  it("checkpoint tracks already-registered names separately from failures", async () => {
     const registeredLabel = "cptregfail";
     const validLabel = "cptregvalid";
     const { user, deployer } = env.namedAccounts;
@@ -680,7 +707,8 @@ describe("PreMigration", () => {
     const checkpoint = readTestCheckpoint();
     expect(checkpoint).not.toBeNull();
     expect(checkpoint!.successCount).toBe(1);
-    expect(checkpoint!.failureCount).toBe(1);
+    expect(checkpoint!.alreadyRegisteredCount).toBe(1);
+    expect(checkpoint!.failureCount).toBe(0);
   });
 
   it("checkpoint tracks renewed count separately", async () => {
@@ -744,10 +772,7 @@ describe("PreMigration", () => {
   });
 
   it("fails fast when header has no labelName or label column", async () => {
-    const csvContent = [
-      "node,name,owner",
-      "n,foo,0x00",
-    ].join("\n");
+    const csvContent = ["node,name,owner", "n,foo,0x00"].join("\n");
     writeFileSync(csvFilePath, csvContent);
 
     const args = buildMainArgs(env, csvFilePath);
@@ -793,13 +818,12 @@ describe("PreMigration", () => {
 
     await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
 
-    const csvContent =
-      [
-        "node,name,labelHash,owner,parentName,parentLabelHash,labelName,registrationDate,expiryDate",
-        `,,,,,,${label},,`,
-        "",
-        "",
-      ].join("\n");
+    const csvContent = [
+      "node,name,labelHash,owner,parentName,parentLabelHash,labelName,registrationDate,expiryDate",
+      `,,,,,,${label},,`,
+      "",
+      "",
+    ].join("\n");
     writeFileSync(csvFilePath, csvContent);
 
     const args = buildMainArgs(env, csvFilePath);
@@ -837,10 +861,9 @@ describe("PreMigration", () => {
 
     await registerV1Name(env, winning, user.address, ONE_YEAR_SECONDS);
 
-    const csvContent = [
-      "label,labelName,extra",
-      `${losing},${winning},x`,
-    ].join("\n");
+    const csvContent = ["label,labelName,extra", `${losing},${winning},x`].join(
+      "\n",
+    );
     writeFileSync(csvFilePath, csvContent);
 
     const args = buildMainArgs(env, csvFilePath);
@@ -863,10 +886,7 @@ describe("PreMigration", () => {
     writeFileSync(csvFilePath, csvContent);
 
     const args = buildMainArgs(env, csvFilePath);
-    await expectMainToExitWithCsvError(args, [
-      `${csvFilePath}:3`,
-      "is blank",
-    ]);
+    await expectMainToExitWithCsvError(args, [`${csvFilePath}:3`, "is blank"]);
   });
 
   it("skips labels exceeding 255 bytes and encoded labelhashes in CSV", async () => {
@@ -900,7 +920,10 @@ describe("PreMigration", () => {
   // ─── Edge cases ────────────────────────────────────────────────────
 
   it("handles empty CSV file gracefully", async () => {
-    writeFileSync(csvFilePath, "node,name,labelHash,owner,parentName,parentLabelHash,labelName,registrationDate,expiryDate\n");
+    writeFileSync(
+      csvFilePath,
+      "node,name,labelHash,owner,parentName,parentLabelHash,labelName,registrationDate,expiryDate\n",
+    );
 
     const args = buildMainArgs(env, csvFilePath);
     await main(args);
@@ -913,7 +936,12 @@ describe("PreMigration", () => {
     const label = "singlename";
     const { user } = env.namedAccounts;
 
-    const expiry = await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
+    const expiry = await registerV1Name(
+      env,
+      label,
+      user.address,
+      ONE_YEAR_SECONDS,
+    );
 
     createCSVFile(csvFilePath, [label]);
     const args = buildMainArgs(env, csvFilePath);
@@ -1139,7 +1167,10 @@ describe("PreMigration", () => {
     }
 
     createCSVFile(csvFilePath, labels);
-    const args = buildMainArgs(env, csvFilePath, { dryRun: true, batchSize: 1 });
+    const args = buildMainArgs(env, csvFilePath, {
+      dryRun: true,
+      batchSize: 1,
+    });
     await main(args);
 
     for (const label of labels) {

--- a/contracts/test/e2e/runPreMigrationCommandSigner.test.ts
+++ b/contracts/test/e2e/runPreMigrationCommandSigner.test.ts
@@ -1,5 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { privateKeyToAccount } from "viem/accounts";
+import type { Checkpoint } from "../../script/preMigration.js";
 
 // The BatchRegistrar owner that fork/clean-testnet runs impersonate. The env
 // deployer key below does NOT control it.
@@ -12,6 +23,9 @@ const DEPLOYER_KEY =
 const deployerAccount = privateKeyToAccount(DEPLOYER_KEY);
 
 let capturedArgs: string[] | null = null;
+// When set, the mocked pre-migration run writes this checkpoint to its workDir,
+// standing in for the real run so the metadata-persistence path can be exercised.
+let checkpointToWrite: Checkpoint | null = null;
 
 const realPreMigration = await import("../../script/preMigration.js");
 
@@ -19,10 +33,20 @@ mock.module("../../script/preMigration.js", () => ({
   ...realPreMigration,
   main: async (args: string[]) => {
     capturedArgs = args;
+    if (checkpointToWrite) {
+      writeFileSync(
+        realPreMigration.CHECKPOINT_FILE,
+        JSON.stringify(checkpointToWrite),
+      );
+    }
   },
 }));
 
 const { runPreMigrationCommand } = await import("../../script/migration.js");
+
+function makeCheckpoint(overrides: Partial<Checkpoint>): Checkpoint {
+  return { ...realPreMigration.createFreshCheckpoint(), ...overrides };
+}
 
 function flagValue(args: string[], flag: string): string | undefined {
   const i = args.indexOf(flag);
@@ -92,5 +116,189 @@ describe("runPreMigrationCommand signer resolution", () => {
     );
     expect(flagValue(capturedArgs!, "--private-key")).toBe(OWNER_KEY);
     expect(flagValue(capturedArgs!, "--account")).toBe(ownerAccount.address);
+  });
+});
+
+describe("runPreMigrationCommand metadata persistence", () => {
+  let deploymentsDir: string;
+  let workDir: string;
+  const deploymentNetwork = "mainnet";
+
+  beforeEach(() => {
+    process.env.DEPLOYER_KEY = DEPLOYER_KEY;
+    deploymentsDir = mkdtempSync(join(tmpdir(), "premigration-meta-deploy-"));
+    workDir = mkdtempSync(join(tmpdir(), "premigration-meta-work-"));
+    // The namespace dir must exist for the sidecar to be written.
+    mkdirSync(join(deploymentsDir, deploymentNetwork), { recursive: true });
+  });
+
+  afterEach(() => {
+    checkpointToWrite = null;
+    delete process.env.DEPLOYER_KEY;
+    rmSync(deploymentsDir, { recursive: true, force: true });
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  const metadataPath = () =>
+    join(deploymentsDir, deploymentNetwork, ".premigration.json");
+
+  const readMetadata = () => JSON.parse(readFileSync(metadataPath(), "utf-8"));
+
+  it("writes a run summary and resolved roll-up, upserting by label", async () => {
+    checkpointToWrite = makeCheckpoint({
+      totalExpected: 9,
+      totalProcessed: 9,
+      successCount: 5,
+      renewedCount: 0,
+      skippedCount: 3,
+      skippedNeverRegisteredCount: 2,
+      skippedPastGraceCount: 1,
+      alreadyRegisteredCount: 0,
+      invalidLabelCount: 1,
+      failureCount: 0,
+      timestamp: "2026-01-01T00:00:00.000Z",
+    });
+    await runPreMigrationCommand(
+      {
+        ...baseOpts,
+        deploymentsDir,
+        deploymentNetwork,
+        workDir,
+        metadataLabel: "initial",
+      },
+      false,
+    );
+
+    let metadata = readMetadata();
+    expect(metadata.chainId).toBe(1);
+    expect(metadata.runs).toHaveLength(1);
+    expect(metadata.runs[0]).toMatchObject({
+      label: "initial",
+      reserved: 5,
+      renewed: 0,
+      skippedNeverRegistered: 2,
+      skippedExpiredPastGrace: 1,
+      invalidLabels: 1,
+      alreadyOnV2: 0,
+      failed: 0,
+    });
+
+    // Resume re-writes the same label's accumulated checkpoint: upsert, not append.
+    checkpointToWrite = makeCheckpoint({
+      totalExpected: 9,
+      totalProcessed: 9,
+      successCount: 6,
+      skippedCount: 3,
+      skippedNeverRegisteredCount: 2,
+      skippedPastGraceCount: 1,
+      invalidLabelCount: 0,
+      timestamp: "2026-01-01T01:00:00.000Z",
+    });
+    await runPreMigrationCommand(
+      {
+        ...baseOpts,
+        deploymentsDir,
+        deploymentNetwork,
+        workDir,
+        metadataLabel: "initial",
+      },
+      true,
+    );
+    metadata = readMetadata();
+    expect(metadata.runs).toHaveLength(1);
+    expect(metadata.runs[0].reserved).toBe(6);
+
+    // A second logical run (final-sync) appends and drives the resolved section,
+    // being the most recently finished run.
+    checkpointToWrite = makeCheckpoint({
+      totalExpected: 10,
+      totalProcessed: 10,
+      successCount: 1,
+      renewedCount: 5,
+      skippedCount: 3,
+      skippedNeverRegisteredCount: 2,
+      skippedPastGraceCount: 1,
+      alreadyRegisteredCount: 1,
+      invalidLabelCount: 1,
+      failureCount: 0,
+      timestamp: "2026-01-02T00:00:00.000Z",
+    });
+    await runPreMigrationCommand(
+      {
+        ...baseOpts,
+        deploymentsDir,
+        deploymentNetwork,
+        workDir,
+        metadataLabel: "final-sync",
+      },
+      false,
+    );
+    metadata = readMetadata();
+    expect(metadata.runs).toHaveLength(2);
+    expect(metadata.resolved).toMatchObject({
+      finishedAt: "2026-01-02T00:00:00.000Z",
+      totalNames: 10,
+      namesPreMigrated: 6,
+      newReservations: 1,
+      expiryResyncs: 5,
+      skippedNeverRegistered: 2,
+      skippedExpiredPastGrace: 1,
+      invalidLabels: 1,
+      alreadyOnV2: 1,
+      failed: 0,
+    });
+  });
+
+  it("skips the write on dry run and when persistMetadata is false", async () => {
+    checkpointToWrite = makeCheckpoint({
+      successCount: 1,
+      timestamp: "2026-01-01T00:00:00.000Z",
+    });
+
+    await runPreMigrationCommand(
+      {
+        ...baseOpts,
+        deploymentsDir,
+        deploymentNetwork,
+        workDir,
+        metadataLabel: "run",
+        dryRun: true,
+      },
+      false,
+    );
+    expect(existsSync(metadataPath())).toBe(false);
+
+    await runPreMigrationCommand(
+      {
+        ...baseOpts,
+        deploymentsDir,
+        deploymentNetwork,
+        workDir,
+        metadataLabel: "run",
+        persistMetadata: false,
+      },
+      false,
+    );
+    expect(existsSync(metadataPath())).toBe(false);
+  });
+
+  it("does not write when the namespace directory is absent", async () => {
+    checkpointToWrite = makeCheckpoint({
+      successCount: 1,
+      timestamp: "2026-01-01T00:00:00.000Z",
+    });
+    await runPreMigrationCommand(
+      {
+        ...baseOpts,
+        deploymentsDir,
+        deploymentNetwork: "does-not-exist",
+        workDir,
+        metadataLabel: "run",
+      },
+      false,
+    );
+    expect(
+      existsSync(join(deploymentsDir, "does-not-exist", ".premigration.json")),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Write a durable, committed counts sidecar (.premigration.json) into deployments/<namespace>/ so a migration leaves a permanent record of how many names were pre-migrated, re-synced for expiry, skipped, etc. Counts only, never the label strings.

- preMigration.ts: split skippedCount into never-registered vs expired-past-grace sub-counters; break already-on-v2 names out of failureCount into alreadyRegisteredCount so failed reflects genuine errors only; backfill new counters on resume; export CHECKPOINT_FILE.
- migration.ts: recordPreMigrationMetadata writes a dotfile (ignored by rocketh) holding a per-run array upserted by label plus a resolved roll-up of final numbers; wired into phase 2 (initial), phase 5 (final-sync, gated on saveDeployments) and standalone run/resume.
- Document .premigration.json in deployments/README.md; add metadata-persistence tests and update checkpoint assertions.