### PR TITLE
feat(devnet): pre-migrate curated names on mainnet-fork devnet

### DIFF
--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -30,6 +30,7 @@ deployments/*-fork/
 deployments/*-clean-*/
 deployments/v1/*
 !deployments/v1/sepolia/
+deployments/devnet*/
 
 # pre-migration
 preMigration.log

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -419,6 +419,46 @@ This runs `testNames()` which creates 17 names in various states. For details on
 - [Indexing Test Names](../docs/indexing-test-names.md) — what each test name does and which events it emits
 - [Indexing ENSv2 Events](../docs/indexing-ensv2-events.md) — full reference of all ENSv2 contract events
 
+### Mainnet Fork Mode
+
+Instead of a synthetic chain, the devnet can fork mainnet so that real ENS v1 names are present. Enable it by pointing at a mainnet RPC (these are also what [morticia](https://github.com/ensdomains/morticia)'s e2e runner uses):
+
+```sh
+FORK_URL=<mainnet-rpc> bun run devnet         # or --forkUrl <mainnet-rpc>
+FORK_URL=<mainnet-rpc> FORK_BLOCK=<block> bun run devnet   # pin the fork block (or --forkBlock)
+```
+
+On a fork you can also **pre-migrate** a curated set of real names — reserving them on the v2 registry (RESERVED state, `ENSV1Resolver` fallback) once the devnet is up, mirroring the DAO's pre-migration so the frontend can drive the v1 → v2 migrate flow:
+
+```sh
+FORK_URL=<mainnet-rpc> bun run devnet --preMigrate
+```
+
+Optionally reassign v1 ownership of the pre-migrated names to a devnet account (`deployer`/`owner`/`user`/`user2`, or a raw address) so a fixed test wallet owns them and can migrate in-app without impersonation:
+
+```sh
+FORK_URL=<mainnet-rpc> bun run devnet --preMigrate --preMigrateOwner user
+```
+
+Both flags have env-var equivalents (`DEVNET_PREMIGRATE=1`, `DEVNET_PREMIGRATE_OWNER=<account|address>`). `--preMigrate` requires a fork.
+
+The ten names cover every migration state (unwrapped, wrapped-locked, wrapped-unlocked):
+
+| Name                 | State                            | Notes                                                            |
+| -------------------- | -------------------------------- | ---------------------------------------------------------------- |
+| `swissborg.eth`      | unwrapped                        | normal happy-path name                                           |
+| `00relayer.eth`      | unwrapped                        | leading-zero label, small subtree                                |
+| `2718.eth`           | unwrapped                        | all-numeric label, multiple subnames                             |
+| `$beep.eth`          | wrapped-locked                   | special `$` char, minimal subtree                                |
+| `agi.eth`            | wrapped-locked                   | carries a locked child + a third-party child                     |
+| `ethscriptions.eth`  | wrapped-locked                   | burn-address owner, emancipated child                            |
+| `holer.eth`          | wrapped-**unlocked**/emancipated | no `CANNOT_UNWRAP`                                               |
+| `analyzes.eth`       | wrapped-locked                   | shared batch owner                                               |
+| `daomarketplace.eth` | wrapped-locked                   | shared batch owner                                               |
+| `alertbot.eth`       | wrapped-locked                   | `CANNOT_TRANSFER` — stays reserve-only under `--preMigrateOwner` |
+
+> The list is curated from [morticia](https://github.com/ensdomains/morticia)'s mainnet-fork e2e scenarios, whose states hold near mainnet block `25120743` (~2026-05). Every name's live state is read from the fork at runtime, so reservation stays correct at any block; a name no longer claimable on v1 is skipped with a log. For the documented locked/unlocked mix, fork near that block.
+
 ### Using Docker Compose
 
 1. Make sure you have Docker and Docker Compose installed

--- a/contracts/script/preMigrateDevnetNames.ts
+++ b/contracts/script/preMigrateDevnetNames.ts
@@ -11,7 +11,12 @@ import {
   type Address,
 } from "viem";
 
-import { FUSES, STATUS } from "./deploy-constants.js";
+import {
+  FUSES,
+  PREMIGRATION_BONUS_PERIOD,
+  SEC_PER_DAY,
+  STATUS,
+} from "./deploy-constants.js";
 import { main as preMigrationMain } from "./preMigration.js";
 import { buildMainArgs, createCSVFile, verifyV2State } from "./preMigrationUtils.js";
 import type { DevnetEnvironment } from "./setup.js";
@@ -148,7 +153,15 @@ export async function preMigrateDevnetNames(
 
   const csvPath = join(tmpdir(), `devnet-premigrate-${env.client.chain.id}.csv`);
   createCSVFile(csvPath, labels);
-  await preMigrationMain(buildMainArgs(env, csvPath, { limit: labels.length }));
+  // Mirror the DAO pre-migration by extending each v2 expiry with the
+  // production bonus period, so names within the v1 grace period (or expiring
+  // during testing) stay RESERVED on v2 rather than reading back as AVAILABLE.
+  await preMigrationMain(
+    buildMainArgs(env, csvPath, {
+      limit: labels.length,
+      bonusPeriodDays: Number(PREMIGRATION_BONUS_PERIOD / SEC_PER_DAY),
+    }),
+  );
 
   if (target) {
     console.log(`\nReassigning v1 ownership to ${target}...`);

--- a/contracts/script/preMigrateDevnetNames.ts
+++ b/contracts/script/preMigrateDevnetNames.ts
@@ -1,0 +1,197 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  getAddress,
+  isAddress,
+  keccak256,
+  namehash,
+  parseEther,
+  stringToBytes,
+  zeroAddress,
+  type Address,
+} from "viem";
+
+import { FUSES, STATUS } from "./deploy-constants.js";
+import { main as preMigrationMain } from "./preMigration.js";
+import { buildMainArgs, createCSVFile, verifyV2State } from "./preMigrationUtils.js";
+import type { DevnetEnvironment } from "./setup.js";
+
+// Curated real-mainnet .eth 2LDs sourced from morticia's e2e scenario config
+// (test/e2e/test-e2e-mainnet-fork-config.json). Chosen to span every migration
+// criterion in ten names: unwrapped, wrapped-locked, and wrapped-but-unlocked,
+// so the frontend has both migration paths and the notable fuse edge cases.
+// Only labels are pinned; every live property (wrap state, owner, fuses,
+// expiry) is read from the fork at runtime, so the set survives any fork block.
+const CURATED_NAMES: { label: string; note: string }[] = [
+  { label: "swissborg", note: "normal unwrapped happy-path (alphabetic, resolver set)" },
+  { label: "00relayer", note: "unwrapped, leading-zero label, small subtree" },
+  { label: "2718", note: "unwrapped, all-numeric label, multi-subname" },
+  { label: "$beep", note: "wrapped-locked, special '$' char, minimal subtree" },
+  { label: "agi", note: "wrapped-locked, carries a locked child + third-party child" },
+  { label: "ethscriptions", note: "wrapped-locked, burn-address owner, emancipated child" },
+  { label: "holer", note: "wrapped-but-UNLOCKED/emancipated (no CANNOT_UNWRAP)" },
+  { label: "analyzes", note: "wrapped-locked, shared batch owner" },
+  { label: "daomarketplace", note: "wrapped-locked, shared batch owner" },
+  { label: "alertbot", note: "wrapped-locked + CANNOT_TRANSFER (reassignment skipped)" },
+];
+
+export interface PreMigrateDevnetOptions {
+  // A devnet named account key (deployer/owner/user/user2) or a raw address to
+  // receive v1 ownership of the reserved names. When unset, names are left
+  // reserved-only (still owned by their real forked mainnet owners).
+  reassignOwnerTo?: string;
+  // Override the curated label set (for tests and smoke runs).
+  labels?: string[];
+}
+
+// The BaseRegistrar ERC-721 id is the labelhash; the NameWrapper ERC-1155 id
+// is the namehash of the full 2LD.
+function baseRegistrarId(label: string): bigint {
+  return BigInt(keccak256(stringToBytes(label)));
+}
+function nameWrapperId(label: string): bigint {
+  return BigInt(namehash(`${label}.eth`));
+}
+
+function resolveTarget(env: DevnetEnvironment, keyOrAddress: string): Address {
+  if (keyOrAddress in env.namedAccounts) {
+    return env.namedAccounts[
+      keyOrAddress as keyof DevnetEnvironment["namedAccounts"]
+    ].address;
+  }
+  if (isAddress(keyOrAddress)) {
+    return getAddress(keyOrAddress);
+  }
+  throw new Error(
+    `--preMigrateOwner must be a named account (${Object.keys(
+      env.namedAccounts,
+    ).join(", ")}) or an address, got: ${keyOrAddress}`,
+  );
+}
+
+async function fund(env: DevnetEnvironment, address: Address): Promise<void> {
+  await env.client.setBalance({ address, value: parseEther("100") });
+}
+
+// Move v1 ownership of a reserved name to `target` so a fixed devnet wallet
+// owns it and can drive the migration in-app. Anvil autoImpersonate lets us
+// send from the real owner directly. Returns how the name was handled.
+async function reassignOwner(
+  env: DevnetEnvironment,
+  label: string,
+  target: Address,
+): Promise<"wrapped" | "unwrapped" | "skipped"> {
+  const [wrapperOwner, fuses] = await env.v1.NameWrapper.read.getData([
+    nameWrapperId(label),
+  ]);
+
+  if (wrapperOwner !== zeroAddress) {
+    if ((Number(fuses) & FUSES.CANNOT_TRANSFER) !== 0) {
+      console.log(`  ⊘ ${label}.eth: CANNOT_TRANSFER burned — left reserve-only`);
+      return "skipped";
+    }
+    await fund(env, wrapperOwner);
+    await env.waitFor(
+      env.v1.NameWrapper.write.safeTransferFrom(
+        [wrapperOwner, target, nameWrapperId(label), 1n, "0x"],
+        { account: wrapperOwner },
+      ),
+    );
+    return "wrapped";
+  }
+
+  const labelId = baseRegistrarId(label);
+  const registrant = await env.v1.BaseRegistrar.read.ownerOf([labelId]);
+  if (registrant === zeroAddress) {
+    console.log(`  ⊘ ${label}.eth: no v1 owner — left reserve-only`);
+    return "skipped";
+  }
+  await fund(env, registrant);
+  await env.waitFor(
+    env.v1.BaseRegistrar.write.transferFrom([registrant, target, labelId], {
+      account: registrant,
+    }),
+  );
+  // Align the ENS registry record with the new token owner. Non-fatal.
+  try {
+    await fund(env, target);
+    await env.waitFor(
+      env.v1.BaseRegistrar.write.reclaim([labelId, target], { account: target }),
+    );
+  } catch (err) {
+    console.log(`  ! ${label}.eth: reclaim skipped (${err})`);
+  }
+  return "unwrapped";
+}
+
+// Pre-migrate the curated names on a running fork devnet: reserve them on v2
+// (RESERVED state, ENSV1Resolver fallback) and optionally reassign v1 ownership
+// to a devnet account. Intended to be called after env.activateV2() in fork mode.
+export async function preMigrateDevnetNames(
+  env: DevnetEnvironment,
+  opts: PreMigrateDevnetOptions = {},
+): Promise<void> {
+  // Resolve the reassignment target up front so a bad value fails before the
+  // reservation work.
+  const target = opts.reassignOwnerTo
+    ? resolveTarget(env, opts.reassignOwnerTo)
+    : undefined;
+
+  const names = opts.labels
+    ? opts.labels.map((label) => ({ label, note: "override" }))
+    : CURATED_NAMES;
+  const labels = names.map((n) => n.label);
+  console.log(`\n========== Pre-migrating ${labels.length} names ==========`);
+  for (const { label, note } of names) {
+    console.log(`  • ${label}.eth — ${note}`);
+  }
+
+  const csvPath = join(tmpdir(), `devnet-premigrate-${env.client.chain.id}.csv`);
+  createCSVFile(csvPath, labels);
+  await preMigrationMain(buildMainArgs(env, csvPath, { limit: labels.length }));
+
+  if (target) {
+    console.log(`\nReassigning v1 ownership to ${target}...`);
+    // Default anvil accounts carry an EIP-7702 delegation on mainnet; the
+    // ERC-1155 acceptance check reverts against delegated code, so clear it and
+    // let the target receive wrapped names as a plain EOA.
+    await env.client.setCode({ address: target, bytecode: "0x" });
+  }
+
+  const summary: {
+    Name: string;
+    Status: string;
+    Reassigned: string;
+  }[] = [];
+  for (const { label } of names) {
+    const { status } = await verifyV2State(env, label);
+    const statusLabel =
+      status === STATUS.RESERVED
+        ? "reserved"
+        : status === STATUS.REGISTERED
+          ? "registered"
+          : "available";
+
+    let reassigned = "—";
+    if (target) {
+      if (status === STATUS.RESERVED) {
+        try {
+          reassigned = await reassignOwner(env, label, target);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.log(`  ✗ ${label}.eth: reassignment failed — ${msg}`);
+          reassigned = "failed";
+        }
+      } else {
+        reassigned = "skipped (not reserved)";
+      }
+    }
+    summary.push({
+      Name: `${label}.eth`,
+      Status: statusLabel,
+      Reassigned: reassigned,
+    });
+  }
+
+  console.table(summary);
+}

--- a/contracts/script/preMigrationUtils.ts
+++ b/contracts/script/preMigrationUtils.ts
@@ -1,0 +1,92 @@
+import { writeFileSync } from "node:fs";
+import { keccak256, stringToBytes, type Address } from "viem";
+import type { DevnetEnvironment } from "./setup.js";
+
+// Default anvil/test-mnemonic account 0, which is the devnet deployer and the
+// BatchRegistrar owner. Used to sign pre-migration reservations on the devnet.
+export const DEPLOYER_PRIVATE_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as const;
+
+// LibLabel.id() — the .eth token id derived from a label.
+function idFromLabel(label: string): bigint {
+  return BigInt(keccak256(stringToBytes(label)));
+}
+
+const CSV_HEADER =
+  "node,name,labelHash,owner,parentName,parentLabelHash,labelName,registrationDate,expiryDate";
+
+export function createCSVFile(filePath: string, labels: string[]) {
+  const rows = labels.map((label) => `,,,,,,${label},,`);
+  const content = [CSV_HEADER, ...rows].join("\n");
+  writeFileSync(filePath, content);
+}
+
+export function buildMainArgs(
+  env: DevnetEnvironment,
+  csvFilePath: string,
+  overrides: {
+    dryRun?: boolean;
+    limit?: number;
+    continue?: boolean;
+    bonusPeriodDays?: number;
+    batchSize?: number;
+    useEnvVarForPrivateKey?: boolean;
+    omitPrivateKey?: boolean;
+  } = {},
+): string[] {
+  const rpcUrl = `http://${env.hostPort}`;
+  const registryAddress = env.v2.ETHRegistry.address;
+
+  const args = [
+    "node",
+    "script",
+    "--rpc-url",
+    rpcUrl,
+    "--registry",
+    registryAddress,
+    "--batch-registrar",
+    env.rocketh.get("BatchRegistrar").address,
+    "--csv-file",
+    csvFilePath,
+    "--v1-resolver",
+    env.v2.ENSV1Resolver.address,
+    "--mainnet-rpc-url",
+    rpcUrl,
+    "--bonus-period-days",
+    String(overrides.bonusPeriodDays ?? 0),
+    "--v1-base-registrar",
+    env.v1.BaseRegistrar.address,
+  ];
+
+  if (overrides.useEnvVarForPrivateKey) {
+    process.env.PREMIGRATION_PRIVATE_KEY = DEPLOYER_PRIVATE_KEY;
+  } else if (!overrides.omitPrivateKey) {
+    args.push("--private-key", DEPLOYER_PRIVATE_KEY);
+  }
+
+  if (overrides.dryRun) {
+    args.push("--dry-run");
+  }
+  if (overrides.limit !== undefined) {
+    args.push("--limit", String(overrides.limit));
+  }
+  if (overrides.continue) {
+    args.push("--continue");
+  }
+  if (overrides.batchSize !== undefined) {
+    args.push("--batch-size", String(overrides.batchSize));
+  }
+
+  return args;
+}
+
+export async function verifyV2State(
+  env: DevnetEnvironment,
+  label: string,
+): Promise<{
+  status: number;
+  expiry: bigint;
+  latestOwner: Address;
+}> {
+  return env.v2.ETHRegistry.read.getState([idFromLabel(label)]);
+}

--- a/contracts/script/runDevnet.ts
+++ b/contracts/script/runDevnet.ts
@@ -1,6 +1,7 @@
 import { createServer } from "node:http";
 import { parseArgs } from "node:util";
 import { getAddress } from "viem";
+import { preMigrateDevnetNames } from "./preMigrateDevnetNames.js";
 import { setupDevnet } from "./setup.js";
 import { testNames } from "./testNames.js";
 import { COIN_TYPE_ETH } from "../test/utils/utils.js";
@@ -15,6 +16,12 @@ const args = parseArgs({
     },
     testNames: {
       type: "boolean",
+    },
+    preMigrate: {
+      type: "boolean",
+    },
+    preMigrateOwner: {
+      type: "string",
     },
     chainId: {
       type: "string",
@@ -38,9 +45,19 @@ const args = parseArgs({
 const forkUrl = args.values.forkUrl ?? process.env.FORK_URL;
 const forkBlock = args.values.forkBlock ?? process.env.FORK_BLOCK;
 const quiet = args.values.quiet ?? process.env.DEVNET_QUIET === "1";
+const preMigrate =
+  args.values.preMigrate ?? process.env.DEVNET_PREMIGRATE === "1";
+const preMigrateOwner =
+  args.values.preMigrateOwner ?? process.env.DEVNET_PREMIGRATE_OWNER;
 
 if (forkUrl && args.values.testNames) {
   console.error("--testNames is incompatible with --forkUrl");
+  process.exit(2);
+}
+
+// Pre-migration reserves real v1 names, which only exist on a mainnet fork.
+if (preMigrate && !forkUrl) {
+  console.error("--preMigrate requires --forkUrl");
   process.exit(2);
 }
 
@@ -87,10 +104,17 @@ if (!quiet) {
     await Promise.all(
       Object.entries(env.rocketh.deployments).map(
         async ([name, { address }]) => {
-          const [primary] = await env.v2.UniversalResolver.read.reverse([
-            address,
-            COIN_TYPE_ETH,
-          ]);
+          // On a mainnet fork, reverse resolution for freshly-deployed
+          // contracts can revert; fall back to no primary name rather than
+          // crashing the whole table.
+          let primary = "";
+          try {
+            const result = await env.v2.UniversalResolver.read.reverse([
+              address,
+              COIN_TYPE_ETH,
+            ]);
+            primary = result[0];
+          } catch {}
           return {
             "Contract Name": name,
             "Contract Address": getAddress(address),
@@ -125,6 +149,9 @@ await env.sync({ warpSec: "local" });
 // expected to grant controller roles themselves via test-side setup.
 if (forkUrl) {
   await env.activateV2();
+  if (preMigrate) {
+    await preMigrateDevnetNames(env, { reassignOwnerTo: preMigrateOwner });
+  }
 }
 
 console.log(new Date(), `Ready! <${Date.now() - t0}ms>`);

--- a/contracts/test/e2e/preMigrateDevnetNames.test.ts
+++ b/contracts/test/e2e/preMigrateDevnetNames.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, setDefaultTimeout } from "bun:test";
+setDefaultTimeout(60_000);
+
+import { existsSync, unlinkSync } from "node:fs";
+import { STATUS } from "../../script/deploy-constants.js";
+import { preMigrateDevnetNames } from "../../script/preMigrateDevnetNames.js";
+import {
+  registerV1Name,
+  setupBaseRegistrarController,
+  verifyV2State,
+} from "../utils/mockPreMigration.js";
+import { idFromLabel } from "../utils/utils.js";
+
+const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60;
+
+describe("preMigrateDevnetNames", () => {
+  const { env, setupEnv } = process.env.TEST_GLOBALS!;
+
+  const cleanupFiles = [
+    "preMigration-checkpoint.json",
+    "preMigration-errors.log",
+    "preMigration.log",
+  ];
+
+  setupEnv({
+    resetOnEach: true,
+    async initialize() {
+      await setupBaseRegistrarController(env);
+    },
+  });
+
+  afterEach(() => {
+    for (const file of cleanupFiles) {
+      if (existsSync(file)) {
+        try {
+          unlinkSync(file);
+        } catch {}
+      }
+    }
+  });
+
+  it("reserves the given names on v2", async () => {
+    const labels = ["premigone", "premigtwo"];
+    const { user } = env.namedAccounts;
+    for (const label of labels) {
+      await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
+    }
+
+    await preMigrateDevnetNames(env, { labels });
+
+    for (const label of labels) {
+      const state = await verifyV2State(env, label);
+      expect(state.status).toBe(STATUS.RESERVED);
+    }
+  });
+
+  it("reassigns v1 ownership of an unwrapped name to a devnet account", async () => {
+    const label = "reassignme";
+    const { user, user2 } = env.namedAccounts;
+    await registerV1Name(env, label, user2.address, ONE_YEAR_SECONDS);
+
+    await preMigrateDevnetNames(env, {
+      labels: [label],
+      reassignOwnerTo: "user",
+    });
+
+    const state = await verifyV2State(env, label);
+    expect(state.status).toBe(STATUS.RESERVED);
+
+    const owner = await env.v1.BaseRegistrar.read.ownerOf([idFromLabel(label)]);
+    expect(owner.toLowerCase()).toBe(user.address.toLowerCase());
+  });
+});

--- a/contracts/test/e2e/runPreMigrationCommandSigner.test.ts
+++ b/contracts/test/e2e/runPreMigrationCommandSigner.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
 import { privateKeyToAccount } from "viem/accounts";
 
 // The BatchRegistrar owner that fork/clean-testnet runs impersonate. The env
@@ -14,6 +22,9 @@ const deployerAccount = privateKeyToAccount(DEPLOYER_KEY);
 let capturedArgs: string[] | null = null;
 
 const realPreMigration = await import("../../script/preMigration.js");
+// Capture the real export before mocking: mock.module rebinds the live
+// namespace, so realPreMigration.main would otherwise resolve to the stub.
+const realMain = realPreMigration.main;
 
 mock.module("../../script/preMigration.js", () => ({
   ...realPreMigration,
@@ -21,6 +32,16 @@ mock.module("../../script/preMigration.js", () => ({
     capturedArgs = args;
   },
 }));
+
+// bun's mock.module is global and persists past this file, so a later suite
+// that imports preMigration.main would run the stub. Restore the real module
+// once these tests finish.
+afterAll(() => {
+  mock.module("../../script/preMigration.js", () => ({
+    ...realPreMigration,
+    main: realMain,
+  }));
+});
 
 const { runPreMigrationCommand } = await import("../../script/migration.js");
 

--- a/contracts/test/utils/mockPreMigration.ts
+++ b/contracts/test/utils/mockPreMigration.ts
@@ -1,10 +1,15 @@
-import { writeFileSync } from "node:fs";
 import type { Address } from "viem";
 import type { DevnetEnvironment } from "../../script/setup.js";
 import { idFromLabel } from "./utils.js";
 
-const DEPLOYER_PRIVATE_KEY =
-  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as const;
+// Pre-migration helpers shared with the devnet runner live in script/ so
+// production code doesn't import from test/. Re-exported here for tests.
+export {
+  DEPLOYER_PRIVATE_KEY,
+  createCSVFile,
+  buildMainArgs,
+  verifyV2State,
+} from "../../script/preMigrationUtils.js";
 
 export async function setupBaseRegistrarController(env: DevnetEnvironment) {
   const { deployer, owner } = env.namedAccounts;
@@ -40,84 +45,4 @@ export async function renewV1Name(
   await env.v1.BaseRegistrar.write.renew([tokenId, BigInt(additionalDuration)]);
   const expiry = await env.v1.BaseRegistrar.read.nameExpires([tokenId]);
   return expiry;
-}
-
-const CSV_HEADER =
-  "node,name,labelHash,owner,parentName,parentLabelHash,labelName,registrationDate,expiryDate";
-
-export function createCSVFile(filePath: string, labels: string[]) {
-  const rows = labels.map((label) => `,,,,,,${label},,`);
-  const content = [CSV_HEADER, ...rows].join("\n");
-  writeFileSync(filePath, content);
-}
-
-export function buildMainArgs(
-  env: DevnetEnvironment,
-  csvFilePath: string,
-  overrides: {
-    dryRun?: boolean;
-    limit?: number;
-    continue?: boolean;
-    bonusPeriodDays?: number;
-    batchSize?: number;
-    useEnvVarForPrivateKey?: boolean;
-    omitPrivateKey?: boolean;
-  } = {},
-): string[] {
-  const rpcUrl = `http://${env.hostPort}`;
-  const registryAddress = env.v2.ETHRegistry.address;
-
-  const args = [
-    "node",
-    "script",
-    "--rpc-url",
-    rpcUrl,
-    "--registry",
-    registryAddress,
-    "--batch-registrar",
-    env.rocketh.get("BatchRegistrar").address,
-    "--csv-file",
-    csvFilePath,
-    "--v1-resolver",
-    env.v2.ENSV1Resolver.address,
-    "--mainnet-rpc-url",
-    rpcUrl,
-    "--bonus-period-days",
-    String(overrides.bonusPeriodDays ?? 0),
-    "--v1-base-registrar",
-    env.v1.BaseRegistrar.address,
-  ];
-
-  if (overrides.useEnvVarForPrivateKey) {
-    process.env.PREMIGRATION_PRIVATE_KEY = DEPLOYER_PRIVATE_KEY;
-  } else if (!overrides.omitPrivateKey) {
-    args.push("--private-key", DEPLOYER_PRIVATE_KEY);
-  }
-
-  if (overrides.dryRun) {
-    args.push("--dry-run");
-  }
-  if (overrides.limit !== undefined) {
-    args.push("--limit", String(overrides.limit));
-  }
-  if (overrides.continue) {
-    args.push("--continue");
-  }
-  if (overrides.batchSize !== undefined) {
-    args.push("--batch-size", String(overrides.batchSize));
-  }
-
-  return args;
-}
-
-
-export async function verifyV2State(
-  env: DevnetEnvironment,
-  label: string,
-): Promise<{
-  status: number;
-  expiry: bigint;
-  latestOwner: Address;
-}> {
-  return env.v2.ETHRegistry.read.getState([idFromLabel(label)]);
 }


### PR DESCRIPTION
Add a --preMigrate option (env DEVNET_PREMIGRATE) that, once the mainnet-fork devnet is up, reserves 10 curated real mainnet .eth 2LDs on the v2 registry (RESERVED state, ENSV1Resolver fallback) via the existing pre-migration pipeline. The set spans every migration criterion — unwrapped, wrapped-locked and wrapped-unlocked/emancipated — so the frontend has both migration paths and the notable fuse edge cases.

Add optional --preMigrateOwner <account|address> (env DEVNET_PREMIGRATE_OWNER) to reassign v1 ownership of the reserved names to a devnet account so a fixed test wallet owns them. Reads live v1 state to route ERC-721 (labelhash) vs NameWrapper ERC-1155 (namehash) transfers, clears the target's EIP-7702 delegation so wrapped names can be received, and skips CANNOT_TRANSFER names. Reassignment is resilient: a single failing name is logged and skipped.

Move createCSVFile/buildMainArgs/verifyV2State into script/preMigrationUtils.ts (re-exported from test/utils/mockPreMigration.ts) so devnet code no longer imports from test/.

Harden the non-quiet deployments table against reverse-resolution reverts on a fork so the documented command runs to completion.

Document fork mode and the exact 10 pre-migrated names in the README; add e2e coverage in test/e2e/preMigrateDevnetNames.test.ts.