### PR TITLE
Feat/hca final maybe with gas estimate

### DIFF
--- a/contracts/script/testNames.ts
+++ b/contracts/script/testNames.ts
@@ -23,6 +23,7 @@ import {
   reregisterName,
   renewName,
 } from "./testNames/registrar.js";
+import { deployHCA } from "./testNames/hca.js";
 import { showName, showAlias, formatStatus } from "./testNames/display.js";
 
 // Re-export all utilities for external consumers
@@ -38,6 +39,7 @@ export {
   reregisterName,
   reserveName,
   unregisterName,
+  deployHCA,
 };
 
 const ONE_DAY_SECONDS = 86400;
@@ -335,6 +337,9 @@ export async function testNames(env: DevnetEnvironment) {
 
   // Verify all names are properly registered
   await verifyNames(env, allNames);
+
+  // Deploy a standalone HCA per user to track creation gas cost
+  await deployHCA(env);
 
   // Display gas report at the end
   displayGasReport();

--- a/contracts/script/testNames/hca.ts
+++ b/contracts/script/testNames/hca.ts
@@ -1,0 +1,86 @@
+import {
+  encodeAbiParameters,
+  encodeFunctionData,
+  keccak256,
+  parseAbiParameters,
+  stringToHex,
+  zeroAddress,
+  zeroHash,
+} from "viem";
+import type { DevnetAccount, DevnetEnvironment } from "../setup.js";
+import { trackGas } from "./gas.js";
+
+// Matches the registration duration used by the HCA e2e pipeline.
+const REGISTRATION_DURATION = 28n * 86400n;
+
+/**
+ * Deterministic salt for a user's standalone HCA proxy.
+ * Mirrors `computeStandaloneHcaSalt` in test/e2e/hca.test.ts.
+ */
+function computeStandaloneHcaSalt(label: string): bigint {
+  return BigInt(keccak256(stringToHex(`StandaloneHCA:${label}`)));
+}
+
+/**
+ * Deploy a standalone HCA for each account via the RegistrationBootstrapper —
+ * the same deploy-and-commit pipeline that ships to real networks — and record
+ * the gas cost of each creation under `deployHCA(<account>)` in the gas report.
+ *
+ * @param accounts Accounts to create HCAs for (defaults to owner, user, user2).
+ */
+export async function deployHCA(
+  env: DevnetEnvironment,
+  accounts: DevnetAccount[] = [
+    env.namedAccounts.owner,
+    env.namedAccounts.user,
+    env.namedAccounts.user2,
+  ],
+) {
+  const bootstrapper = env.hca.RegistrationBootstrapper;
+  const hcaImplementation = env.hca.StandaloneHCAImplementation;
+
+  console.log("\n========== Deploying HCA per user ==========");
+
+  for (const account of accounts) {
+    const label = `hca-${account.name}`;
+    const salt = computeStandaloneHcaSalt(label);
+    const hca = env.computeVerifiableProxyAddress(bootstrapper.address, salt);
+
+    // initializeAccount(bytes) — abi-encoded owner address as the init payload.
+    const initData = encodeFunctionData({
+      abi: hcaImplementation.abi,
+      functionName: "initializeAccount",
+      args: [
+        encodeAbiParameters(parseAbiParameters("address"), [account.address]),
+      ],
+    });
+
+    // Commitment the bootstrapper writes alongside the proxy deployment.
+    const commitment = await env.v2.ETHRegistrar.read.makeCommitment([
+      label,
+      account.address,
+      zeroHash,
+      zeroAddress,
+      account.resolver.address,
+      REGISTRATION_DURATION,
+      zeroHash,
+    ]);
+
+    const receipt = await env.waitFor(
+      bootstrapper.write.deployAndCommit(
+        [
+          env.v2.VerifiableFactory.address,
+          hcaImplementation.address,
+          salt,
+          initData,
+          env.v2.ETHRegistrar.address,
+          commitment,
+        ],
+        { account },
+      ),
+    );
+    trackGas(`deployHCA(${account.name})`, receipt);
+
+    console.log(`  - Deployed HCA for ${account.name} at ${hca}`);
+  }
+}

--- a/contracts/script/testNames/registrar.ts
+++ b/contracts/script/testNames/registrar.ts
@@ -139,8 +139,18 @@ export async function reregisterName(
     `Initial expiry: ${new Date(Number(initialExpiry) * 1000).toISOString()}`,
   );
 
-  // Time warp past expiry (must exceed the registration duration, default 28 days)
-  const warpSeconds = 28 * ONE_DAY_SECONDS + 1;
+  // Time warp past expiry, the grace period, AND the expiry premium window.
+  // A name becomes available once block.timestamp >= expiry + GRACE_PERIOD,
+  // but for the first PREMIUM_PERIOD seconds after that it carries a decaying
+  // Dutch-auction premium (starting at ~$100M) that would blow past the test
+  // account's token allowance. Warp just past expiry + grace + premium so the
+  // name re-registers at base price.
+  const gracePeriod = await env.v2.ETHRegistrar.read.GRACE_PERIOD();
+  const premiumPeriod = await env.v2.StandardRentPriceOracle.read.PREMIUM_PERIOD();
+  const { timestamp: nowSec } = await env.client.getBlock();
+  const availableAt = initialExpiry + gracePeriod + premiumPeriod;
+  const warpSeconds =
+    Number(availableAt > nowSec ? availableAt - nowSec : 0n) + 1;
   console.log(`\nTime warping ${warpSeconds} seconds...`);
   await env.sync({ warpSec: warpSeconds });
 


### PR DESCRIPTION
This PR adds `deployHCA` function into `testNames` script that tracks the gas usage of HCA `deploymentAndCommit`.
At the time of the writing HCA deployment and commit function costs about 161k of gas (130k if it excludes commit).


```
========== Deploying HCA per user ==========
  - Deployed HCA for owner at 0xb1dE96c4675FA4f34B0b3e716C66024766402960
  - Deployed HCA for user at 0x13b905d6e0A1786EA39339d29272cd2C44137A78
  - Deployed HCA for user2 at 0xAeDAdCcb123Ac89583776925fda047f6702A7906

========== Gas Usage Report ==========
┌────┬────────────────────────────┬───────┬─────────┬─────────┬─────────┬───────────┐
│    │ Function                   │ Calls │ Avg Gas │ Min Gas │ Max Gas │ Total Gas │
├────┼────────────────────────────┼───────┼─────────┼─────────┼─────────┼───────────┤
│  0 │ deployPermissionedResolver │ 2     │ 176703  │ 176703  │ 176703  │ 353406    │
│  1 │ commit                     │ 10    │ 45431   │ 45421   │ 45433   │ 454318    │
│  2 │ register                   │ 10    │ 210826  │ 206746  │ 213216  │ 2108263   │
│  3 │ setAddr                    │ 10    │ 64542   │ 64542   │ 64542   │ 645420    │
│  4 │ setText                    │ 10    │ 64770   │ 64715   │ 64907   │ 647702    │
│  5 │ transfer                   │ 1     │ 77854   │ 77854   │ 77854   │ 77854     │
│  6 │ renew                      │ 1     │ 83314   │ 83314   │ 83314   │ 83314     │
│  7 │ setAlias                   │ 1     │ 63250   │ 63250   │ 63250   │ 63250     │
│  8 │ changeRole                 │ 2     │ 77025   │ 37333   │ 116717  │ 154050    │
│  9 │ reserve                    │ 1     │ 86211   │ 86211   │ 86211   │ 86211     │
│ 10 │ unregister                 │ 1     │ 53154   │ 53154   │ 53154   │ 53154     │
│ 11 │ deployHCA                  │ 3     │ 161894  │ 161886  │ 161898  │ 485682    │
└────┴────────────────────────────┴───────┴─────────┴─────────┴─────────┴───────────┘
```