### PR TITLE
Expand migration documentation with detailed runbooks and rehearsal guides

### DIFF
--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -1,98 +1,474 @@
 # Phased v1 → v2 Migration
 
-## Overview
+The v1 → v2 migration runs as seven explicit phases, driven by the `bun run migration` operator CLI
+from `contracts/`. Phases run **strictly in order**. To rehearse the whole thing in one command see
+[Quick start](#quick-start); to run it for real, work through [Phases](#phases) and the
+[Live deployment (Sepolia)](#live-deployment-sepolia) runbook.
 
-The v1 → v2 migration runs as seven explicit phases, orchestrated by three pieces:
+## Quick start
 
-- **Operator CLI** — [`script/migration.ts`](../script/migration.ts), run as `bun run migration -- <command>` from `contracts/`. Each phase is an individual subcommand; `fork full` and `clean-testnet` run all phases end-to-end as rehearsals.
-- **Hardhat plugin** — [`plugins/migration/index.ts`](../plugins/migration/index.ts), registering `migration <task>` tasks. These wrap the same phase functions but derive signers from the configured Hardhat network/keystore: `bunx hardhat --network <net> migration <task>`.
-- **Phased deploy scripts** — the scripts under [`deploy/`](../deploy/) carry migration tags (`migration:phase1:deploy-v2`, `migration:phase5:switch-urp-to-managed`, `migration:phase6:upgrade-managed-urp`, `migration:post-cutover:direct-urp-to-v2`) so each on-chain change is bound to a deploy step. Phase 1 (`phase deploy-v2`) runs only the `migration:phase1:deploy-v2` tag by default; the `…switch-urp-to-managed` / `…upgrade-managed-urp` tags drive the resolution cutover in phase 7 (their tag strings predate this numbering and are kept as stable identifiers).
+Rehearse all seven phases end-to-end against a throwaway local Anvil fork of the network — nothing
+touches a real chain:
 
-Phase numbering below matches the console output of the `runForkFull` orchestrator in [`script/migration.ts`](../script/migration.ts).
+```bash
+cd contracts
+bun run compile
+bun run migration -- fork full --network sepolia --csv-file ./csv-data/ens-registrations-sepolia.csv
+```
 
-> **Ordering note.** Renewal compatibility is enabled early (phase 4) so unmigrated v1 names stay renewable throughout the migration window, and the final pre-migration sync (phase 5) then picks up any renewed expiries. The Universal Resolver is cut over to v2 last (phase 7) so public resolution flips only once everything else is live.
+That impersonates every signer and runs phases 1–7 with smoke checks interleaved. To rehearse against
+a **live fork** (real v1 state) use a Tenderly virtual testnet — see
+[Tenderly virtual testnets](#tenderly-virtual-testnets). To stand up a fresh, fully-owned testnet
+stack instead, see [`clean-testnet`](#clean-testnet).
+
+## Deployment contexts
+
+Pick your path before running anything — it determines which phases apply:
+
+- **Live public network (sepolia/mainnet)** — v1 already exists on-chain; run phases **1–7** with real
+  signer keys. On mainnet the owner, URP admin, and v1 owner are the DAO/multisig, so owner-gated
+  phases run with `--calldata-only` (or deferred) and execute through a Safe. → [Live deployment
+  (Sepolia)](#live-deployment-sepolia).
+- **Clean testnet (fresh v1)** — no usable v1; deploy a fresh v1 stack first (**phase 0**), then
+  phases 1–7, always including `TestnetV1PremigrationRegistrar`. Sepolia only, via `clean-testnet`.
+  → [`clean-testnet`](#clean-testnet).
+- **Fork / Tenderly rehearsal** — dry-run phases 1–7 against a fork of the target network,
+  impersonating every signer. Local Anvil via [`fork full`](#fork-full); a live fork via a
+  [Tenderly virtual testnet](#tenderly-virtual-testnets).
+
+The Universal Resolver cutover (phase 7) has a further split: **sepolia is a reuse network** (the top
+proxy already fronts the intermediate one, so `switch-urp-to-managed` is skipped) while **mainnet and
+fresh chains are bootstrap** (run `switch-urp-to-managed` first). Details in
+[Phase 7](#phase-7-switch-the-universal-resolver-to-v2).
 
 ## Phases
 
-| Phase | Action | CLI command(s) | Signer |
-| --- | --- | --- | --- |
-| 0 † | Deploy fresh v1 contracts (clean-testnet only) | part of `clean-testnet` | `deployer` |
-| 1 | Deploy all v2 contracts (incl. reverse-registrar adapters), registrar deferred | `phase deploy-v2` | `deployer` / `owner` / `urManager` (+ one `v1Owner` tx, deferrable) |
-| 2 | Initial pre-migration: seed v1 names as reserved on v2 | `premigration run` / `resume`, then `premigration verify` | BatchRegistrar owner |
-| 3 | Disable v1 registrar controllers (v1 registration freeze) | `phase disable-v1-registrars`, then `phase verify-v1-registrars-disabled` | v1 owner |
-| 4 | Authorize `ETHRenewerV1` as a v1 controller so unmigrated names stay renewable | `phase authorize-v1-renewer` | v1 owner |
-| 5 | Final pre-migration sync from a fresh post-freeze export (picks up renewed expiries) | `premigration run`, then `premigration verify` | BatchRegistrar owner |
-| 6 | Enable the v2 controller: revoke `REGISTRAR \| RENEW` from `BatchRegistrar` → authorize v1 handoff controllers (`Graveyard`, testnet helper) → transfer v1 `BaseRegistrar` ownership to `ETHRenewerV1` → grant `REGISTRAR \| RENEW` to `ETHRegistrar` | `phase disable-batch-registrar`, `phase activate-v1-handoff-controllers`, `phase activate-v1-renewer`, `phase enable-v2-registrar` (+ the matching `verify-*`) | registry root-role admin + v1 owner |
-| 7 | Switch Universal Resolver to v2 (resolution cutover): intermediate URP → `UniversalResolverV2` (sepolia reuses the existing top URP → intermediate URP wiring; bootstrap networks first switch top URP → intermediate URP) | `phase upgrade-managed-urp`, then `phase verify-urp` (bootstrap also runs `phase switch-urp-to-managed` first) | `urManager` (intermediate URP admin); bootstrap also needs the top URP admin (DAO on mainnet) for the switch |
+Phase numbering matches the console output of the `fork full` orchestrator in
+[`script/migration.ts`](../script/migration.ts). Every command below also takes the shared
+[common options](#common-options) (`--network`, `--rpc-url`, deployment dirs); run any command with
+`--help` for its authoritative option list.
 
-† Phase 0 only exists in `clean-testnet`, which deploys a fresh v1 stack (from `lib/ens-contracts/deploy`) into a `deployments/v1/<namespace>` directory before running phases 1–7.
+| Phase | Action | Command(s) | Applies to | Signer |
+| --- | --- | --- | --- | --- |
+| 0 | Deploy fresh v1 contracts | part of `clean-testnet` | clean-testnet only | `deployer` |
+| 1 | Deploy all v2 contracts (registrar deferred) | `phase deploy-v2` | live + clean-testnet | `deployer` / `owner` / `urManager` (+ v1 owner) |
+| 2 | Seed v1 names as reserved on v2 | `premigration run` → `verify` | live + clean-testnet | BatchRegistrar owner |
+| 3 | Freeze v1 registrations | `phase disable-v1-registrars` (+ `verify-*`) | live + clean-testnet | v1 owner |
+| 4 | Keep unmigrated names renewable | `phase authorize-v1-renewer` | live + clean-testnet | v1 owner |
+| 5 | Final pre-migration sync | `premigration run` → `verify` | live + clean-testnet | BatchRegistrar owner |
+| 6 | Enable the v2 controller | `disable-batch-registrar` → `activate-v1-handoff-controllers` → `activate-v1-renewer` → `enable-v2-registrar` (+ `verify-*`) | live + clean-testnet | registry root-role admin + v1 owner |
+| 7 | Switch Universal Resolver to v2 (cutover) | `phase upgrade-managed-urp` (+ `switch-urp-to-managed` on bootstrap) (+ `verify-urp`) | live + clean-testnet (bootstrap step mainnet/fresh only) | `urManager` (+ top URP owner on bootstrap) |
 
-Every phase command takes `--network sepolia|mainnet` plus `--rpc-url` (or the `SEPOLIA_RPC_URL` / `MAINNET_RPC_URL` env var). Contract addresses default to the deployment JSON under `--deployments-dir` / `--deployment-network` (v2) and `--v1-deployments-dir` / `--v1-deployment-network` (v1); explicit address flags override. The v1-owner-signed and URP-admin phase commands (`disable-v1-registrars`, `set-v1-reverse-default-resolver`, `authorize-v1-renewer`, `activate-v1-graveyard`, `activate-v1-handoff-controllers`, `activate-v1-renewer`, `authorize-testnet-v1-premigration-registrar`, `switch-urp-to-managed`, `upgrade-managed-urp`) accept `--calldata-only` to print the transaction target and calldata for multisig execution instead of broadcasting. The registry root-role admin commands (`disable-batch-registrar`, `enable-v2-registrar`) broadcast or impersonate only.
+### Phase 0: deploy fresh v1 (clean-testnet only)
+
+- **Applies to:** clean-testnet only. Skipped for live deployments — sepolia/mainnet already have v1.
+- **Command:** no standalone phase command; it is the first step of [`clean-testnet`](#clean-testnet).
+- **Prerequisites:** none — it is the entry step of `clean-testnet`. Sepolia only.
+- **Env / args:** `--network sepolia`, `--rpc-url`, `--deployer <address>`. A funded deployer key is
+  required unless the RPC provides state controls (local node or Tenderly virtual testnet, which
+  impersonate instead).
+- **Expected outcome:** a fresh v1 ENS stack (from `lib/ens-contracts/deploy`) deployed into
+  `deployments/v1/<namespace>`, giving a v1 set to migrate from.
 
 ### Phase 1: deploy v2 contracts
 
-Runs all deploy scripts tagged `migration:phase1:deploy-v2` with the `deferV2Registrar` tag set, so [`deploy/03_ETHRegistrar.ts`](../deploy/03_ETHRegistrar.ts) deploys `ETHRegistrar` **without** granting it `REGISTRAR | RENEW` at the registry root — that grant is deferred to [phase 6](#phase-6-enable-the-v2-controller). `BatchRegistrar` holds the roles in the meantime for pre-migration seeding. The deploy also sets up the URP proxy chain pointing at the v1 `UniversalResolver` (see [universalResolver.md](./universalResolver.md)) and deploys the v2 reverse-registrar adapters ([`deploy/02_ReverseRegistrarAdapter.ts`](../deploy/02_ReverseRegistrarAdapter.ts) and [`deploy/02_DefaultReverseRegistrarAdapter.ts`](../deploy/02_DefaultReverseRegistrarAdapter.ts)), each authorized as a controller on the corresponding v1 reverse registrar via a v1-owner transaction.
+- **Applies to:** live + clean-testnet.
+- **Command:**
+  ```bash
+  bun run migration -- phase deploy-v2 --network sepolia
 
-Several steps require a v1-owner signature: pointing the v1 `.eth` resolver at `ENSV2Resolver` ([`deploy/00_ENSV2Resolver.ts`](../deploy/00_ENSV2Resolver.ts)) and the reverse-adapter controller grants above. With `--defer-v1-owner-transactions` (and `--deferred-v1-owner-transactions-file <path>`) such transactions are recorded to a JSONL file instead of broadcast; the owner executes them later with `phase execute-owner-txs --file <path> --role v1Owner`.
+  # On live networks, record the v1-owner txs instead of broadcasting, then replay them:
+  bun run migration -- phase deploy-v2 --network sepolia \
+    --defer-v1-owner-transactions \
+    --deferred-v1-owner-transactions-file .dev/phase1-v1owner.jsonl
+  bun run migration -- phase execute-owner-txs --network sepolia \
+    --role v1Owner --file .dev/phase1-v1owner.jsonl
+  ```
+  Add `--include-testnet-premigration-registrar` on testnet/clean runs to also deploy
+  `TestnetV1PremigrationRegistrar`. Re-run with `--resume` to continue an interrupted deploy.
+- **Prerequisites:** `bun run compile`; a freshly funded deployer (phase 1 sends many transactions).
+  Re-deploying onto an **already-migrated** chain first requires `phase
+  reclaim-v1-registrar-ownership` (the v1 `BaseRegistrar` is still owned by the prior `ETHRenewerV1`,
+  and one deferred tx is an owner-gated `setResolver`).
+- **Env / args:** `DEPLOYER_KEY` (also the `owner`/`urManager` fallback and the BatchRegistrar owner);
+  `SEPOLIA_V1_OWNER_KEY` / `V1_OWNER_KEY` for the deferred v1-owner replay. `phase deploy-v2` cannot
+  sign v1-owner transactions itself, hence the defer-then-replay flow above.
+- **Expected outcome:** all v2 contracts deployed with the `ETHRegistrar` grant **deferred** to
+  [phase 6](#phase-6-enable-the-v2-controller) (`BatchRegistrar` holds `REGISTRAR | RENEW` for
+  seeding); the URP proxy chain points at the v1 `UniversalResolver`
+  (see [universalResolver.md](./universalResolver.md)); the v2 reverse-registrar adapters are deployed
+  and authorized as controllers on the v1 reverse registrars; artifacts written to
+  `deployments/<network>/` (deploys fresh by default — see [Deployment artifacts](#deployment-artifacts)).
 
-`--include-testnet-premigration-registrar` additionally deploys `TestnetV1PremigrationRegistrar` (see [premigration.md](./premigration.md)).
-
-> The migration timeline also lists external deployments (e.g. an HCA component) that live outside this repository; they are out of scope for these contracts and are not driven by `phase deploy-v2`.
+> External deployments on the migration timeline (e.g. an HCA component) live outside this repo and
+> are not driven by `phase deploy-v2`.
 
 ### Phase 2: initial pre-migration
 
-Seeds every active or in-grace v1 `.eth` 2LD into the v2 registry as a **reserved** entry via `BatchRegistrar`, driven by a registration CSV — see [premigration.md](./premigration.md) for the CSV format, the bonus-period expiry rule, checkpointing, and verification. Each reservation's v2 expiry is the name's v1 expiry plus the configurable `--bonus-period-days` (default 62).
+- **Applies to:** live + clean-testnet.
+- **Command:**
+  ```bash
+  bun run migration -- premigration run --network sepolia \
+    --csv-file <registrations.csv> --work-dir .dev/premig-1
+  bun run migration -- premigration verify --network sepolia --csv-file <registrations.csv>
+  ```
+- **Prerequisites:** phase 1 complete. A current v1 registration CSV (Dune export for sepolia,
+  BigQuery for mainnet). See [premigration.md](./premigration.md) for the CSV format, expiry rule,
+  checkpointing, and verification.
+- **Env / args:** BatchRegistrar owner key (`PREMIGRATION_PRIVATE_KEY`, `BATCH_REGISTRAR_OWNER_KEY`,
+  or `DEPLOYER_KEY`); `--csv-file`, `--work-dir`, `--bonus-period-days` (default 62).
+- **Expected outcome:** every active or in-grace v1 `.eth` 2LD seeded as a **reserved** entry on v2,
+  with v2 expiry = v1 expiry + bonus period. `premigration verify` confirms the reservations.
 
 ### Phase 3: disable v1 registrars
 
-Removes `LegacyETHRegistrarController`, `ETHRegistrarController`, `WrappedETHRegistrarController`, and `NameWrapper` as v1 `BaseRegistrar` controllers (via `RegistrarSecurityController` when deployed, otherwise directly on `BaseRegistrar`). New v1 registrations are frozen from this point.
+- **Applies to:** live + clean-testnet.
+- **Command:**
+  ```bash
+  bun run migration -- phase disable-v1-registrars --network sepolia \
+    --private-key $SEPOLIA_V1_OWNER_KEY
+  bun run migration -- phase verify-v1-registrars-disabled --network sepolia
+  ```
+- **Prerequisites:** phase 2 complete (so no active name is stranded by the freeze). Signed by the v1
+  owner. This command takes the key via `--private-key` explicitly — the env fallback applies only
+  when it is run through `phase execute-owner-txs --role v1Owner`.
+- **Env / args:** v1 owner key via `--private-key` (or `SEPOLIA_V1_OWNER_KEY` / `V1_OWNER_KEY` through
+  execute-owner-txs). `--calldata-only` emits calldata for a multisig instead of broadcasting.
+- **Expected outcome:** `LegacyETHRegistrarController`, `ETHRegistrarController`,
+  `WrappedETHRegistrarController`, and `NameWrapper` removed as v1 `BaseRegistrar` controllers (via
+  `RegistrarSecurityController` when deployed); new v1 registrations frozen.
+  `verify-v1-registrars-disabled` confirms.
 
 ### Phase 4: authorize ETHRenewerV1
 
-`phase authorize-v1-renewer` authorizes `ETHRenewerV1` as a v1 `BaseRegistrar` controller (via `RegistrarSecurityController` when deployed). `ETHRenewerV1` *only renews* names already reserved on v2, so this does **not** reopen the registration freeze from phase 3 — it keeps unmigrated names renewable throughout the migration window, with each renewal extending both the v1 registration and the v2 reservation in a single transaction. The final lock-down step that transfers v1 `BaseRegistrar` ownership to `ETHRenewerV1` is deferred to phase 6, after the handoff controllers are authorized.
+- **Applies to:** live + clean-testnet.
+- **Command:**
+  ```bash
+  bun run migration -- phase authorize-v1-renewer --network sepolia
+  ```
+- **Prerequisites:** phase 2 complete — `ETHRenewerV1` can only renew names already `RESERVED` on v2,
+  so this phase is effective only after the initial pre-migration. Runs right after the phase 3 freeze.
+- **Env / args:** v1 owner key (`SEPOLIA_V1_OWNER_KEY` / `V1_OWNER_KEY`, read from env).
+  `--calldata-only` for a multisig.
+- **Expected outcome:** `ETHRenewerV1` authorized as a v1 `BaseRegistrar` controller; unmigrated names
+  stay renewable, each renewal extending both the v1 registration and the v2 reservation in one
+  transaction. This does **not** reopen the phase 3 registration freeze. The final lock-down that
+  transfers v1 `BaseRegistrar` ownership to `ETHRenewerV1` is deferred to
+  [phase 6](#phase-6-enable-the-v2-controller).
 
-Because `ETHRenewerV1` can only renew names that are already `RESERVED` on v2, this phase is effective only once the initial pre-migration (phase 2) has completed.
-
-> **Mainnet renewal continuity.** Renewals are paused between phase 3 (freeze) and phase 4 (authorize), and the phase 5 sync can run for days. When the v1 owner is a DAO/multisig, execute phases 3 and 4 **atomically in one v1-owner batch** — both support `--calldata-only`, so their calldata combines into a single Safe/multisend transaction.
+> **Mainnet renewal continuity.** Renewals are paused between phase 3 (freeze) and phase 4
+> (authorize), and the phase 5 sync can run for days. When the v1 owner is a DAO/multisig, execute
+> phases 3 and 4 **atomically in one v1-owner batch** — both support `--calldata-only`, so their
+> calldata combines into a single Safe/multisend transaction.
 
 ### Phase 5: final pre-migration sync
 
-After the freeze, export a fresh registration CSV (Dune for Sepolia, BigQuery for mainnet — see [premigration.md](./premigration.md#cli-reference)) and re-run pre-migration so names registered or renewed since phase 2 are caught up. Names already reserved on v2 are re-reserved with their bonus-adjusted expiry — picking up any expiry extensions from renewals performed via `ETHRenewerV1` since phase 4 — and newly eligible names are reserved for the first time.
+- **Applies to:** live + clean-testnet.
+- **Command:**
+  ```bash
+  bun run migration -- premigration run --network sepolia \
+    --csv-file <fresh-post-freeze.csv> --work-dir .dev/premig-2
+  bun run migration -- premigration verify --network sepolia --csv-file <fresh-post-freeze.csv>
+  ```
+- **Prerequisites:** phase 3 freeze done. Export a **fresh** post-freeze registration CSV so names
+  registered or renewed since phase 2 are caught up.
+- **Env / args:** same BatchRegistrar owner key as [phase 2](#phase-2-initial-pre-migration).
+- **Expected outcome:** names already reserved on v2 are re-reserved with their bonus-adjusted expiry
+  — picking up any expiry extensions from `ETHRenewerV1` renewals since phase 4 — and newly eligible
+  names are reserved for the first time.
 
 ### Phase 6: enable the v2 controller
 
-The "enable the v2 controller" cutover bundles four owner-gated steps, in order:
-
-1. **Disable the BatchRegistrar** (`phase disable-batch-registrar`) — revokes `REGISTRAR | RENEW` from `BatchRegistrar` on the v2 `ETHRegistry`, ending pre-migration seeding. On testnets, `TestnetV1PremigrationRegistrar` keeps its roles so test names can still be created. `phase batch-registrar-owner` prints (and optionally verifies) the BatchRegistrar owner beforehand.
-2. **Authorize v1 handoff controllers** (`phase activate-v1-handoff-controllers`) — authorizes `Graveyard` as a v1 `BaseRegistrar` controller, and (re-)authorizes `TestnetV1PremigrationRegistrar` when that deployment exists. The individual steps are also available as `phase activate-v1-graveyard` and `phase authorize-testnet-v1-premigration-registrar`.
-3. **Transfer v1 `BaseRegistrar` ownership to `ETHRenewerV1`** (`phase activate-v1-renewer`) — the final v1 lock-down (via `RegistrarSecurityController.transferRegistrarOwnership` when deployed). It re-authorizes `ETHRenewerV1` as a controller if needed, but the authorization usually already happened in phase 4. This must run **after** the handoff-controller grants above, because the v1 owner can no longer manage controllers once ownership has moved.
-4. **Enable the v2 `ETHRegistrar`** (`phase enable-v2-registrar`) — grants `REGISTRAR | RENEW` on the v2 `ETHRegistry` to `ETHRegistrar`, the grant deferred since phase 1, opening live v2 registrations. `phase verify-v2-registrar` confirms the grant.
+- **Applies to:** live + clean-testnet.
+- **Command:** four owner-gated steps, **in order**, then verify:
+  ```bash
+  bun run migration -- phase disable-batch-registrar          --network sepolia
+  bun run migration -- phase activate-v1-handoff-controllers  --network sepolia
+  bun run migration -- phase activate-v1-renewer              --network sepolia
+  bun run migration -- phase enable-v2-registrar              --network sepolia
+  bun run migration -- phase verify-v2-registrar              --network sepolia
+  ```
+- **Prerequisites:** phase 5 complete. Order matters — the handoff controllers must be authorized
+  **before** `activate-v1-renewer` transfers v1 `BaseRegistrar` ownership away from the v1 owner
+  (after which the v1 owner can no longer manage controllers).
+- **Env / args:** registry root-role admin key (`OWNER_KEY`, falls back to `DEPLOYER_KEY`) for
+  `disable-batch-registrar` and `enable-v2-registrar`; v1 owner key for the `activate-v1-*` steps. The
+  owner-gated and v1-owner steps accept `--calldata-only` for a multisig. On testnets
+  `TestnetV1PremigrationRegistrar` keeps its roles, re-authorized by `activate-v1-handoff-controllers`
+  (the individual steps are also available as `activate-v1-graveyard` and
+  `authorize-testnet-v1-premigration-registrar`).
+- **Expected outcome:** `BatchRegistrar` roles revoked (pre-migration seeding ends); `Graveyard` (+
+  testnet helper) authorized as v1 controllers; v1 `BaseRegistrar` ownership transferred to
+  `ETHRenewerV1` (final lock-down); `ETHRegistrar` granted `REGISTRAR | RENEW` on the v2 `ETHRegistry`
+  — live v2 registrations open. `verify-v2-registrar` confirms the grant. This bundle replaces the
+  all-at-once role swap done by [prepareMigration.md](./prepareMigration.md).
 
 ### Phase 7: switch the Universal Resolver to v2
 
-The resolution cutover, run last so public resolution flips to v2 only once everything else is live. On **reuse** networks (sepolia) the top `UpgradableUniversalResolverProxy` already fronts the long-lived intermediate `ManagedUniversalResolverProxy`, so the cutover is a single transaction — the intermediate URP admin (`urManager`) upgrades it to `UniversalResolverV2` (`phase upgrade-managed-urp`); the externally-administered top URP is never touched. On **bootstrap** networks (mainnet, fresh chains) the top URP admin first points the top URP at the intermediate URP (`phase switch-urp-to-managed`) before the upgrade. `phase verify-urp` confirms both implementations. See [universalResolver.md](./universalResolver.md) for the proxy chain, deploy scripts, and the optional post-cutover step.
+- **Applies to:** live + clean-testnet. The **`switch-urp-to-managed`** step is **bootstrap-only**
+  (mainnet and fresh chains); the sepolia reuse path skips it.
+- **Command:**
+  ```bash
+  # Reuse networks (sepolia): the top URP already fronts the intermediate URP, so only the upgrade runs
+  bun run migration -- phase upgrade-managed-urp --network sepolia
+  bun run migration -- phase verify-urp          --network sepolia
 
-> **Relation to `prepareMigration.ts`:** phase 6 replaces the all-at-once role swap performed by [prepareMigration.md](./prepareMigration.md); that script remains the path for non-phased deployments.
+  # Bootstrap networks (mainnet, fresh chains): point the top URP at the intermediate URP first
+  bun run migration -- phase switch-urp-to-managed --network mainnet
+  bun run migration -- phase upgrade-managed-urp   --network mainnet
+  bun run migration -- phase verify-urp            --network mainnet
+  ```
+- **Prerequisites:** phase 6 complete. Run **last**, so public resolution flips to v2 only once
+  everything else is live.
+- **Env / args:** intermediate URP admin key (`UR_MANAGER_KEY`, falls back to `DEPLOYER_KEY`) for
+  `upgrade-managed-urp`; top URP owner key (`SEPOLIA_TOP_URP_OWNER_KEY` / `TOP_URP_OWNER_KEY`) for the
+  bootstrap `switch-urp-to-managed`. `--calldata-only` for a multisig/DAO.
+- **Expected outcome:** the resolution cutover — the intermediate URP is upgraded to
+  `UniversalResolverV2` and public resolution serves v2. `verify-urp` confirms both proxy
+  implementations. See [universalResolver.md](./universalResolver.md) for the proxy chain and the
+  optional post-cutover step.
+
+## Live deployment (Sepolia)
+
+End-to-end runbook for a fresh Sepolia deployment against the canonical (live) v1. **Rehearse first**
+— [`fork full`](#fork-full), ideally against a [Tenderly live fork](#tenderly-virtual-testnets),
+exercises this exact sequence.
+
+### Signer keys
+
+Three keys cover every signature on the sepolia reuse path. The top URP owner key is **not** needed —
+the top URP already fronts the intermediate URP, so the cutover never touches it.
+
+| Key | Role |
+| --- | --- |
+| `DEPLOYER_KEY` | Deployer EOA; on sepolia also resolves as `owner` (registry root-role admin) and is the `BatchRegistrar` owner. Must be freshly funded — phase 1 sends many transactions. |
+| `SEPOLIA_V1_OWNER_KEY` | v1 owner (`0x0f32b753afc8abad9ca6fe589f707755f4df2353`); signs the deferred phase-1 v1-owner txs, phase 3, phase 4, and the phase-6 `activate-v1-*` steps. |
+| `UR_MANAGER_KEY` | Intermediate `ManagedUniversalResolverProxy` admin (`0x6d80F2172CFdEc5730fE683860C33d26fC42e6F1`, admin `0xffFffFFfFF52D316B7Bd028358089bc8066b8f80`); signs the phase-7 cutover. |
+
+### Setup
+
+```bash
+cd contracts
+bun run compile                                      # forge + hardhat → generated/artifacts
+
+export SEPOLIA_RPC_URL=<reliable paid sepolia RPC>   # phase 1 sends many txs
+export DEPLOYER_KEY=0x<fresh funded EOA>             # also owner / urManager / BatchRegistrar owner
+export SEPOLIA_V1_OWNER_KEY=0x<key for 0x0f32…2353>
+
+mkdir -p .dev/sepolia-live
+```
+
+Also export a **current** Sepolia registration CSV for the pre-migration phases (Dune export — see
+[premigration.md](./premigration.md)); the repo's `csv-data/ens-registrations-sepolia.csv` is a small
+sample, not a real export.
+
+> **Deployer and `.env` hygiene.** `DEPLOYER_KEY` should be a freshly funded EOA. If it happens to be
+> the same address as the v1 owner, `phase deploy-v2` wires that address with the v1-owner key so it
+> keeps a local signer. Keep `.env` values free of inline `#` comments — quote a value if it must
+> contain a literal `#`.
+
+### Run the phases
+
+Run the phases in order; each links to its entry in [Phases](#phases) for the exact command,
+prerequisites, and expected outcome:
+
+1. [Phase 1 — deploy fresh v2](#phase-1-deploy-v2-contracts), recording v1-owner txs with
+   `--defer-v1-owner-transactions --deferred-v1-owner-transactions-file .dev/sepolia-live/phase1-v1owner.jsonl`
+   and replaying them via `phase execute-owner-txs --role v1Owner`.
+2. [Phase 2 — initial pre-migration](#phase-2-initial-pre-migration) (`--work-dir .dev/sepolia-live/premig-1`).
+3. [Phase 3 — freeze v1 registrations](#phase-3-disable-v1-registrars) (`--private-key $SEPOLIA_V1_OWNER_KEY`).
+4. [Phase 4 — keep names renewable](#phase-4-authorize-ethrenewerv1). With an EOA v1 owner on Sepolia
+   you can run phases 3 and 4 back-to-back, so the renewal gap is small.
+5. [Phase 5 — final sync](#phase-5-final-pre-migration-sync) from a fresh post-freeze CSV
+   (`--work-dir .dev/sepolia-live/premig-2`).
+6. [Phase 6 — enable the v2 controller](#phase-6-enable-the-v2-controller).
+7. [Phase 7 — resolution cutover](#phase-7-switch-the-universal-resolver-to-v2): sepolia is a reuse
+   network, so only `upgrade-managed-urp` + `verify-urp` run.
+
+### After
+
+The new `deployments/sepolia/` namespace (and any dated archive) is committed automatically —
+`.gitignore` tracks real namespaces and ignores only the `-fork` / `-clean-` runtime sets (see
+[deployments/README.md](../deployments/README.md)). Pre-migration (phases 2 and 5) is the heavy,
+stateful part: it is checkpointed (`premigration resume`) and has its own flags — read
+[premigration.md](./premigration.md) and confirm the CSV export before the live run.
+
+> **Mainnet differs.** The owner, top URP admin, and v1 owner are all the DAO/multisig, so the
+> owner-signed and URP-admin phases run with `--calldata-only` (or deferred) and execute through the
+> Safe. Mainnet is also a **bootstrap** URP network, so phase 7 additionally runs
+> `switch-urp-to-managed` first.
+
+### Verify source code
+
+Once live, submit the deployed contracts for source verification on Etherscan and Sourcify. This reads
+the artifacts under `deployments/<network>/` — no recompile or redeploy is required:
+
+```bash
+cd contracts
+export ETHERSCAN_API_KEY=<etherscan v2 api key>   # one key covers all chains; not needed for Sourcify
+bun run verify:sepolia                            # → verify:mainnet for the mainnet set
+```
+
+`verify:<network>` runs [`script/verify.ts`](../script/verify.ts), which submits every contract to
+both Etherscan and Sourcify via [`@rocketh/verifier`](https://www.npmjs.com/package/@rocketh/verifier).
+It is idempotent and re-runnable: contracts already verified on a backend are detected and skipped. The
+verifier rebuilds the solc standard-JSON input from each artifact's metadata, backfilling source
+content from disk for forge-compiled artifacts, so a contract verifies regardless of which compiler
+produced it. Flags after `--` pass through (e.g. `bun run verify -- --network sepolia --etherscan-only`).
+
+## Rehearsals
+
+### `fork full`
+
+```bash
+bun run migration -- fork full --network sepolia --csv-file ./csv-data/ens-registrations-sepolia.csv \
+  [--work-dir <dir>] [--save-deployments] [--snapshot-file <path>]
+```
+
+Spawns a local Anvil fork of the network RPC (default port 8547 sepolia / 8548 mainnet), impersonates
+the deployer, owner, v1 owner, URP admins, and BatchRegistrar owner, and runs phases 1–7 in order with
+smoke checks interleaved:
+
+- v1 registration succeeds before phase 3 and is rejected after;
+- `ETHRenewerV1` is confirmed as an authorized v1 renewal controller after phase 4;
+- a pre-migrated name is migrated to v2 via `UnlockedMigrationController` after phase 5;
+- the v2 registrar rejects registrations before phase 6's grant, rejects pre-migrated reserved names
+  after it, and accepts a fresh name after enablement.
+
+When the target chain has already completed the v1 hand-off (re-running against an already-migrated
+Sepolia, or a repeat mainnet run), `fork full` detects this from the v1 registrar-controller state and
+skips the smoke checks that require live v1 registration, while still running the deploy,
+pre-migration, renewer authorization, the pre-enablement rejection, the fresh-name registration, and
+the URP cutover. A pristine chain runs all of them; there is no flag — it is detected automatically.
+
+`--direct` skips Anvil and targets `--rpc-url` directly (see
+[Tenderly virtual testnets](#tenderly-virtual-testnets)) — it requires explicit `--deployer` and
+`--ur-manager` addresses, plus `--owner` on sepolia (the Hardhat `migration fork-full` task derives
+them from the keystore). `--resume-from-phase 2` (requires `--work-dir`) skips phase 1 and reloads
+saved deployments. `--snapshot-file` records a pre-rehearsal `evm_snapshot` id, which the Hardhat
+`migration revert` task can restore.
+
+### `clean-testnet`
+
+`clean-testnet` stands up a **complete, throwaway v1 → v2 migration on public Sepolia using a fresh v1
+stack you fully own** — for integration testing or demos where you want a real, on-chain v1 + v2
+migrated set without depending on, or risking, the canonical ENS deployment.
+
+```bash
+bun run migration -- clean-testnet --network sepolia --rpc-url <url> --deployer <address>
+```
+
+Sepolia only. It runs **phase 0** — a fresh v1 stack deployed into `deployments/v1/<namespace>` — then
+phases 1–7 directly against the RPC, always including `TestnetV1PremigrationRegistrar`. The v2
+namespace defaults to `sepolia-clean-<timestamp>`; the command refuses to reuse the canonical
+`sepolia` namespace or any namespace that already contains deployment files. Without `--csv-file`,
+only the generated smoke labels are seeded. Against an RPC without state controls (anything other than
+a local node or a Tenderly virtual testnet) a configured deployer key is required — prefer the Hardhat
+`migration clean-testnet` task, which signs with the configured Hardhat account.
+
+### Tenderly virtual testnets
+
+Every command that impersonates signers also works against a **Tenderly Virtual TestNet** — an RPC
+whose host is `virtual.<...>.rpc.tenderly.co`. The CLI **auto-detects** these (there is no `--tenderly`
+flag) and uses Tenderly's state-control methods (`tenderly_setBalance`, `tenderly_impersonateAccount`,
+time-travel) to fund and impersonate every account, so **no signer keys are needed**.
+
+The main use is a **full dress rehearsal of a live network against a Tenderly live fork**: create a
+Virtual TestNet that forks live Sepolia or mainnet (so the real v1 ENS state is present) and run the
+whole migration against it in one command:
+
+```bash
+bun run migration -- fork full --direct --network sepolia \
+  --rpc-url https://virtual.<...>.rpc.tenderly.co/<id> \
+  --csv-file <fresh-sepolia.csv> \
+  --deployer <address> --ur-manager <address> --owner <address>   # --owner required on sepolia
+```
+
+`--direct` targets the Tenderly RPC directly instead of spawning Anvil; because it can't derive
+accounts from a Hardhat keystore, pass the signer **addresses** explicitly (`--deployer`,
+`--ur-manager`, and `--owner` on sepolia). Mainnet works the same way (`--network mainnet`; it is a
+bootstrap URP network). Individual [`phase`](#cli-commands) commands can likewise target a Tenderly RPC
+using their `--impersonate-account` / `--impersonate-owner` / `--impersonate-v1-owner` flags instead of
+keys.
+
+> `clean-testnet` also runs against a Tenderly virtual testnet, but it deploys a **fresh** v1 stack
+> (phase 0) rather than migrating the forked live v1 — use `fork full --direct` to rehearse the real
+> v1 → v2 migration of live Sepolia or mainnet.
+
+## Orchestration
+
+The migration is driven by three pieces:
+
+- **Operator CLI** — [`script/migration.ts`](../script/migration.ts), run as
+  `bun run migration -- <command>` from `contracts/`. Each phase is an individual subcommand;
+  `fork full` and `clean-testnet` run all phases end-to-end as rehearsals.
+- **Hardhat plugin** — [`plugins/migration/index.ts`](../plugins/migration/index.ts), registering
+  `migration <task>` tasks that wrap the same phase functions but derive signers from the configured
+  Hardhat network/keystore: `bunx hardhat --network <net> migration <task>`.
+- **Phased deploy scripts** — the scripts under [`deploy/`](../deploy/) carry migration tags
+  (`migration:phase1:deploy-v2`, `migration:phase5:switch-urp-to-managed`,
+  `migration:phase6:upgrade-managed-urp`, `migration:post-cutover:direct-urp-to-v2`) so each on-chain
+  change is bound to a deploy step. (The tag strings predate the current numbering and are kept as
+  stable identifiers.)
+
+> **Ordering.** Renewal compatibility is enabled early (phase 4) so unmigrated v1 names stay renewable
+> throughout the migration window, and the final pre-migration sync (phase 5) then picks up any
+> renewed expiries. The Universal Resolver is cut over to v2 last (phase 7) so public resolution flips
+> only once everything else is live.
 
 ## Deployment artifacts
 
-Phase 1 reads and writes rocketh deployment artifacts under [`deployments/`](../deployments/README.md), grouped into per-deployment **namespace** directories selected with `--deployments-dir` / `--deployment-network` (v1 references via `--v1-deployments-dir` / `--v1-deployment-network`).
+Phase 1 reads and writes rocketh deployment artifacts under
+[`deployments/`](../deployments/README.md), grouped into per-deployment **namespace** directories
+selected with `--deployments-dir` / `--deployment-network` (v1 references via `--v1-deployments-dir` /
+`--v1-deployment-network`).
 
-`phase deploy-v2` **deploys fresh by default** — it archives the current namespace to `deployments/<env>-<YYYYMMDD>-r<N>` and deploys into a clean one. Since phase 1 sends many transactions and can be interrupted, re-run with `--resume` to continue into the existing namespace instead (rocketh is idempotent, sending only the not-yet-deployed contracts). See [`deployments/README.md`](../deployments/README.md) for the namespace layout, archiving, git-tracking, and idempotency rules.
+`phase deploy-v2` **deploys fresh by default** — it archives the current namespace to
+`deployments/<env>-<YYYYMMDD>-r<N>` and deploys into a clean one. Since phase 1 sends many
+transactions and can be interrupted, re-run with `--resume` to continue into the existing namespace
+instead (rocketh is idempotent, sending only the not-yet-deployed contracts). See
+[`deployments/README.md`](../deployments/README.md) for the namespace layout, archiving, git-tracking,
+and idempotency rules.
 
-## CLI reference
+## Reference
 
-`bun run migration -- <command>` from `contracts/` (entrypoint [`script/migration.ts`](../script/migration.ts), wired through `package.json`). The CLI auto-loads `contracts/.env` (already-set environment variables win). Run `bun run migration -- <command> --help` for full options.
+### Common options
+
+Most commands share these option groups. Run `bun run migration -- <command> --help` for the
+authoritative per-command list — it is the source of truth for what each command accepts.
+
+- **Network** (every on-chain command): `--network sepolia|mainnet` (required),
+  `--rpc-url <url>` (falls back to `SEPOLIA_RPC_URL` / `MAINNET_RPC_URL`), `--chain-id <id>`.
+- **Deployments**: `--deployments-dir <path>`, `--deployment-network <name>` (v2 addresses);
+  `--v1-deployments-dir <path>`, `--v1-deployment-network <name>` (v1 addresses). Contract addresses
+  default to the deployment JSON under these dirs; explicit address flags (e.g. `--registry`,
+  `--batch-registrar`) override.
+- **Owner-gated writes** (v1-owner and URP-admin phases): `--private-key <key>`, `--impersonate-owner`
+  or `--impersonate-account <address>` (fork/Tenderly), `--calldata-only` (print the transaction
+  target and calldata for multisig execution instead of broadcasting).
+
+Two commands are **not** on-chain and intentionally omit the network options:
+
+- **`premigration status`** reads the local checkpoint file only — its sole option is `--work-dir`. It
+  does **not** accept `--network` / `--rpc-url`; passing them errors with `unknown option`.
+- **`fetch-data`** queries TheGraph, not a chain — it has its own `--network` (default `mainnet`) and
+  no `--rpc-url`.
+
+### CLI commands
+
+`bun run migration -- <command>` from `contracts/` (entrypoint
+[`script/migration.ts`](../script/migration.ts), wired through `package.json`). The CLI auto-loads
+`contracts/.env` (already-set environment variables win).
 
 | Command | Purpose |
 | --- | --- |
 | `fetch-data` | Export ENS registrations from the TheGraph subgraph (mainnet or sepolia) into a pre-migration CSV |
-| `premigration run` | Start pre-migration reservations from a fresh checkpoint (phases 2/4) |
+| `premigration run` | Start pre-migration reservations from a fresh checkpoint (phases 2/5) |
 | `premigration resume` | Resume pre-migration from the checkpoint |
-| `premigration status` | Print the current pre-migration checkpoint JSON |
+| `premigration status` | Print the current pre-migration checkpoint JSON (local; `--work-dir` only) |
 | `premigration verify` | Verify eligible CSV names were reserved or registered on v2 |
-| `phase deploy-v2` | Phase 1: deploy the v2 migration contracts (incl. reverse-registrar adapters) with the registrar deferred; archives any existing namespace and deploys fresh by default (`--resume` continues an interrupted deploy instead) |
-| `phase reclaim-v1-registrar-ownership` | Re-migration only: reclaim v1 `BaseRegistrar` ownership from a prior deployment's `ETHRenewerV1` back to the v1 owner (run before the Phase 1 deferred-tx replay on an already-migrated chain); signed by the prior renewer's owner / urManager |
+| `phase deploy-v2` | Phase 1: deploy the v2 migration contracts with the registrar deferred; archives any existing namespace and deploys fresh by default (`--resume` continues an interrupted deploy) |
+| `phase reclaim-v1-registrar-ownership` | Re-migration only: reclaim v1 `BaseRegistrar` ownership from a prior deployment's `ETHRenewerV1` back to the v1 owner (run before the Phase 1 deferred-tx replay on an already-migrated chain) |
 | `phase disable-v1-registrars` | Phase 3: disable v1 registrar controllers |
 | `phase set-v1-reverse-default-resolver` | Point the v1 `ReverseRegistrar` default resolver at the v1 `PublicResolver` (v1-owner write) |
 | `phase verify-v1-registrars-disabled` | Verify v1 registrar controllers are disabled |
@@ -107,13 +483,13 @@ Phase 1 reads and writes rocketh deployment artifacts under [`deployments/`](../
 | `phase activate-v1-renewer` | Phase 6: transfer v1 `BaseRegistrar` ownership to `ETHRenewerV1` (final lock-down) |
 | `phase enable-v2-registrar` | Phase 6: grant registrar/renew roles to `ETHRegistrar` |
 | `phase verify-v2-registrar` | Verify `ETHRegistrar` has registrar/renew roles |
-| `phase switch-urp-to-managed` | Phase 7: point the top URP at the managed URP |
+| `phase switch-urp-to-managed` | Phase 7 (bootstrap only): point the top URP at the managed URP |
 | `phase upgrade-managed-urp` | Phase 7: upgrade the managed URP to `UniversalResolverV2` (resolution cutover) |
 | `phase verify-urp` | Verify top and managed URP implementations |
-| `fork full` | Run the full phased migration rehearsal against an Anvil fork |
+| `fork full` | Run the full phased migration rehearsal against an Anvil fork (or a Tenderly fork with `--direct`) |
 | `clean-testnet` | Deploy fresh testnet v1 contracts and run the full phased migration (sepolia only) |
 
-## Hardhat plugin tasks
+### Hardhat plugin tasks
 
 Registered by [`plugins/migration/index.ts`](../plugins/migration/index.ts); invoke as:
 
@@ -121,7 +497,9 @@ Registered by [`plugins/migration/index.ts`](../plugins/migration/index.ts); inv
 bunx hardhat --network <net> migration <task> [--options]
 ```
 
-The tasks select the migration network with `--migration-network sepolia|mainnet` and use the Hardhat network's RPC and configured signer (so private keys can come from the Hardhat keystore instead of flags/env). See `bunx hardhat migration <task> --help` for options.
+The tasks select the migration network with `--migration-network sepolia|mainnet` and use the Hardhat
+network's RPC and configured signer (so private keys can come from the Hardhat keystore instead of
+flags/env). See `bunx hardhat migration <task> --help` for options.
 
 | Task | Purpose |
 | --- | --- |
@@ -136,7 +514,7 @@ The tasks select the migration network with `--migration-network sepolia|mainnet
 | `deploy-v2` | Deploy the v2 migration contracts (phase 1) |
 | `premigration-run` | Run pre-migration reservations (phases 2/5) with the Hardhat signer as BatchRegistrar owner |
 
-## Environment variables
+### Environment variables
 
 Resolved by [`script/migration.ts`](../script/migration.ts) (the CLI also auto-loads `contracts/.env`):
 
@@ -147,169 +525,26 @@ Resolved by [`script/migration.ts`](../script/migration.ts) (the CLI also auto-l
 | `OWNER_KEY` | Owner / registry root-role admin (`phase deploy-v2`, `disable-batch-registrar`, `enable-v2-registrar`; falls back to `DEPLOYER_KEY`) |
 | `UR_MANAGER_KEY` | Intermediate URP admin (`phase upgrade-managed-urp`; falls back to `DEPLOYER_KEY`) |
 | `SEPOLIA_V1_OWNER_KEY` / `V1_OWNER_KEY` | v1 owner (`disable-v1-registrars` †, `set-v1-reverse-default-resolver`, `authorize-v1-renewer`, `activate-v1-*`, `authorize-testnet-v1-premigration-registrar`) |
-| `SEPOLIA_TOP_URP_OWNER_KEY` / `TOP_URP_OWNER_KEY` | Top URP admin (`phase switch-urp-to-managed`) |
+| `SEPOLIA_TOP_URP_OWNER_KEY` / `TOP_URP_OWNER_KEY` | Top URP admin (`phase switch-urp-to-managed`, bootstrap networks only) |
 | `OWNER_TX_KEY` | Generic signer for `phase execute-owner-txs` when no role-specific key matches |
 | `<PREFIX>_MNEMONIC`, `<PREFIX>_MNEMONIC_PATH`, `<PREFIX>_MNEMONIC_INDEX`, `<PREFIX>_MNEMONIC_PASSPHRASE` | Mnemonic-backed signer alternatives for `phase execute-owner-txs`; prefixes `OWNER_TX`, `SEPOLIA_V1_OWNER` / `V1_OWNER`, `SEPOLIA_TOP_URP_OWNER` / `TOP_URP_OWNER` |
 | `PREMIGRATION_PRIVATE_KEY`, `BATCH_REGISTRAR_OWNER_KEY`, `DEPLOYER_KEY` | BatchRegistrar owner key fallbacks for `premigration run` / `resume` |
 | `THEGRAPH_API_KEY` / `GRAPH_API_KEY` | TheGraph Gateway key for `fetch-data` |
 | `ETHERSCAN_API_KEY` | Etherscan v2 (multichain) API key for source-code verification (`bun run verify:<network>`); not needed for Sourcify |
 
-† `phase disable-v1-registrars` takes the key via `--private-key`; the env fallbacks apply when it is executed through `phase execute-owner-txs` with `--role v1Owner`.
-
-For `phase execute-owner-txs`, the key is selected by the `--role` filter: `v1Owner` → the v1-owner variables, `sepolia-top-urp-owner` → the top-URP-owner variables, `deployer` → `DEPLOYER_KEY`; with no role, `OWNER_TX_KEY` and then the role-specific variables are tried in order.
-
-## Live deployment (Sepolia)
-
-End-to-end runbook for a real, fresh Sepolia deployment that replaces the live v2 set and re-runs every phase. Rehearse first (see [Rehearsals](#rehearsals)) — `fork full` exercises this exact sequence against forked state.
-
-### Signer keys
-
-Three keys cover every signature in the sepolia reuse flow. The deployer fills the `owner`/registry-root-admin role, the v1 owner is a separate account, and the intermediate URP admin is the wallet that controls the long-lived intermediate URP. The top URP owner key is **not** needed here — the top URP already fronts the intermediate URP, so the cutover never touches it:
-
-- **`DEPLOYER_KEY`** — the deployer EOA that signs phase-1 contract deployments. On Sepolia it also resolves as `owner` (registry root-role admin: `disable-batch-registrar`, `enable-v2-registrar`). It is also the `BatchRegistrar` owner that drives pre-migration. Must be a freshly funded account with enough Sepolia ETH for the many transactions in phase 1.
-- **`SEPOLIA_V1_OWNER_KEY`** — the v1 owner (`0x0f32b753afc8abad9ca6fe589f707755f4df2353`), which controls the v1 `BaseRegistrar` / `RegistrarSecurityController`. Signs the deferred phase-1 v1-owner transactions (pointing the v1 `.eth` resolver at the new `ENSV2Resolver` and authorizing the reverse-registrar adapters), plus `disable-v1-registrars` (phase 3), `authorize-v1-renewer` (phase 4), and `activate-v1-handoff-controllers` / `activate-v1-renewer` (phase 6).
-- **`UR_MANAGER_KEY`** — the admin of the long-lived intermediate `ManagedUniversalResolverProxy` (`0x6d80F2172CFdEc5730fE683860C33d26fC42e6F1`, admin `0xffFffFFfFF52D316B7Bd028358089bc8066b8f80`). Signs `upgrade-managed-urp` (phase 7), the v2 resolution cutover. Configured as `securityCouncil`/`urManager` for sepolia in the account config.
-
-> **`SEPOLIA_TOP_URP_OWNER_KEY`** is only needed on bootstrap networks (mainnet, fresh chains) where the top URP does not yet front an intermediate URP and the top URP admin (`0x69420f05A11f617B4B74fFe2E04B2D300dFA556F` on sepolia, the DAO on mainnet) must first run `switch-urp-to-managed`. On sepolia that switch is a no-op.
-
-> **`phase deploy-v2` cannot sign v1-owner transactions itself** — it only wires the deployer/owner keys. So phase 1 must record its v1-owner transactions with `--defer-v1-owner-transactions` and you replay them with `phase execute-owner-txs --role v1Owner`, which reads `SEPOLIA_V1_OWNER_KEY`. Every later v1-owner / top-URP command reads its key from env directly, except `disable-v1-registrars`, which takes `--private-key` explicitly.
-
-### Setup
-
-```bash
-cd contracts
-bun run compile                     # forge + hardhat → generated/artifacts
-
-export SEPOLIA_RPC_URL=<reliable paid sepolia RPC>     # phase 1 sends many txs
-export DEPLOYER_KEY=0x<fresh funded EOA>               # also owner / urManager / securityCouncil / BatchRegistrar owner
-export SEPOLIA_V1_OWNER_KEY=0x<key for 0x0f32…2353>
-export SEPOLIA_TOP_URP_OWNER_KEY=0x<key for 0x6942…556F>
-
-mkdir -p .dev/sepolia-live
-```
-
-Also prepare a **current** Sepolia registration CSV for the pre-migration phases (Dune export — see [premigration.md](./premigration.md)). The repo's `csv-data/ens-registrations-sepolia.csv` is a small sample, not a real export.
-
-### Phase 1 — deploy fresh v2
-
-```bash
-# deployer-signed deploy into deployments/sepolia/; v1-owner txs recorded, not broadcast
-bun run migration -- phase deploy-v2 --network sepolia \
-  --defer-v1-owner-transactions \
-  --deferred-v1-owner-transactions-file .dev/sepolia-live/phase1-v1owner.jsonl
-
-# Re-deploying onto an ALREADY-MIGRATED chain only: the v1 BaseRegistrar is still
-# owned by the prior deployment's ETHRenewerV1, so reclaim it to the v1 owner before
-# replaying the deferred txs — one of them is a v1 BaseRegistrar setResolver, which is
-# owner-gated. Signed by the prior renewer's owner (urManager). No-op on a pristine chain.
-bun run migration -- phase reclaim-v1-registrar-ownership --network sepolia \
-  --private-key $UR_MANAGER_KEY
-
-# v1 owner replays the deferred setResolver + reverse-adapter grants
-bun run migration -- phase execute-owner-txs --network sepolia \
-  --role v1Owner --file .dev/sepolia-live/phase1-v1owner.jsonl
-```
-
-`phase deploy-v2` archives any existing `sepolia` namespace (to `sepolia-<YYYYMMDD>-r<N>`) and deploys fresh into the default `sepolia` namespace; every later phase auto-resolves addresses from `deployments/sepolia/`. If phase 1 is interrupted, re-run the same command with `--resume` to continue.
-
-> **Deployer and `.env` hygiene.** `DEPLOYER_KEY` should be a freshly funded EOA. If it
-> happens to be the same address as the v1 owner, `phase deploy-v2` now wires that address
-> with the v1-owner key (from `SEPOLIA_V1_OWNER_KEY`/`V1_OWNER_KEY`, falling back to
-> `DEPLOYER_KEY`) so it keeps a local signer; previously a keyless same-address v1 owner
-> would shadow the deployer's signer and every deploy tx would fail node-side signing.
-> Keep `.env` values free of inline `#` comments — the loader trims a whitespace-introduced
-> inline comment, but quote the value if it must contain a literal `#`.
-
-### Phases 2–7 — wire up and cut over
-
-```bash
-# Phase 2 — initial pre-migration (BatchRegistrar owner = deployer). See premigration.md.
-bun run migration -- premigration run --network sepolia \
-  --csv-file <fresh-sepolia.csv> --work-dir .dev/sepolia-live/premig-1
-bun run migration -- premigration verify --network sepolia --csv-file <fresh-sepolia.csv>
-
-# Phase 3 — freeze v1 registrations (v1 owner; this command needs --private-key)
-bun run migration -- phase disable-v1-registrars --network sepolia \
-  --private-key $SEPOLIA_V1_OWNER_KEY
-bun run migration -- phase verify-v1-registrars-disabled --network sepolia
-
-# Phase 4 — keep unmigrated names renewable (v1 owner via env)
-bun run migration -- phase authorize-v1-renewer --network sepolia
-
-# Phase 5 — final sync from a fresh post-freeze CSV export
-bun run migration -- premigration run --network sepolia \
-  --csv-file <fresh-sepolia-post-freeze.csv> --work-dir .dev/sepolia-live/premig-2
-bun run migration -- premigration verify --network sepolia --csv-file <fresh-sepolia-post-freeze.csv>
-
-# Phase 6 — enable v2 controller (registry root admin = deployer/owner; + v1 owner)
-bun run migration -- phase disable-batch-registrar --network sepolia
-bun run migration -- phase activate-v1-handoff-controllers --network sepolia
-bun run migration -- phase activate-v1-renewer --network sepolia
-bun run migration -- phase enable-v2-registrar --network sepolia
-bun run migration -- phase verify-v2-registrar --network sepolia
-
-# Phase 7 — resolution cutover (intermediate URP admin = UR_MANAGER_KEY).
-# The top URP already fronts the intermediate URP, so only the upgrade is needed.
-bun run migration -- phase upgrade-managed-urp --network sepolia
-bun run migration -- phase verify-urp --network sepolia
-```
-
-### After
-
-The new `deployments/sepolia/` namespace (and any dated archive) is committed automatically — `.gitignore` tracks real namespaces by default and ignores only the `-fork` / `-clean-` runtime sets (see [deployments/README.md](../deployments/README.md)).
-
-Two things to plan for:
-
-- **Renewal gap (phases 3→5).** Between the freeze and the end of the long final sync renewals are paused until `authorize-v1-renewer` (phase 4) reopens them. With an EOA v1 owner on Sepolia you can run phases 3 and 4 back-to-back, so the window is small. (The atomic-batch guidance under [phase 4](#phase-4-authorize-ethrenewerv1) is a mainnet/multisig concern.)
-- **Pre-migration is the heavy, stateful part.** Phases 2 and 5 are checkpointed (`premigration resume`) and have their own flags (`--registry`, `--batch-registrar`, `--batch-size`, the v1-expiry RPC). Read [premigration.md](./premigration.md) and confirm the CSV export before the live run.
-
-> **Mainnet differs.** There the owner, top URP admin, and v1 owner are all the DAO/multisig, so the owner-signed and URP-admin phases are run with `--calldata-only` (or deferred) and executed through the Safe rather than with local keys.
-
-### Verify source code
-
-Once the deployment is live, submit the deployed contracts for source-code verification on Etherscan and Sourcify. This reads the deployment artifacts under `deployments/<network>/` (each carries the solc metadata and constructor args needed) — no recompilation or redeploy is required.
-
-```bash
-cd contracts
-export ETHERSCAN_API_KEY=<etherscan v2 api key>   # one key covers all chains; not needed for Sourcify
-bun run verify:sepolia                            # → verify:mainnet for the mainnet set
-```
-
-`verify:<network>` runs [`script/verify.ts`](../script/verify.ts), which submits every contract to both Etherscan and Sourcify via [`@rocketh/verifier`](https://www.npmjs.com/package/@rocketh/verifier). It is idempotent and re-runnable: contracts already verified on a backend are detected and skipped, so it is safe to re-run after a partial deploy or to pick up newly added contracts. Proxy entries are verified from their `*_Proxy` / `*_Implementation` artifacts.
-
-The verifier rebuilds the solc standard-JSON input from each artifact's recorded metadata, which needs the literal content of every source file. Hardhat-compiled artifacts embed that content, but forge-compiled ones record only each source's hash and URLs; for those, `verify.ts` backfills the missing content from disk (keyed by the metadata source paths and checked against the recorded hash) before submitting, so a contract verifies regardless of which compiler produced its artifact. Flags after `--` pass through to the underlying CLI (e.g. `bun run verify -- --network sepolia --etherscan-only`).
-
-## Rehearsals
-
-### `fork full`
-
-```bash
-bun run migration -- fork full --network sepolia --csv-file ./csv-data/ens-registrations-sepolia.csv \
-  [--work-dir <dir>] [--save-deployments] [--snapshot-file <path>]
-```
-
-Spawns a local Anvil fork of the network RPC (default port 8547 sepolia / 8548 mainnet), impersonates the deployer, owner, v1 owner, URP admins, and BatchRegistrar owner, and runs phases 1–7 in order with smoke checks interleaved:
-
-- v1 registration succeeds before phase 3 and is rejected after;
-- `ETHRenewerV1` is confirmed as an authorized v1 renewal controller after phase 4;
-- a pre-migrated name is migrated to v2 via `UnlockedMigrationController` after phase 5;
-- the v2 registrar rejects registrations before phase 6's grant, rejects pre-migrated reserved names after it, and accepts a fresh name after enablement.
-
-When the target chain has already completed the v1 hand-off — re-running against an already-migrated Sepolia, or a repeat mainnet run after a redeploy — `fork full` detects this from the v1 registrar-controller state and skips the smoke checks that require live v1 registration (the v1-registration bullet and the pre-migrated-reserved-name rejection in the last bullet), while still running the deploy, pre-migration, renewer authorization, the pre-enablement rejection, the fresh-name registration, and the URP cut-over. A pristine chain runs all of them. There is no flag for this; it is detected automatically.
-
-`--direct` skips Anvil and targets `--rpc-url` directly (e.g. a Tenderly virtual testnet) — it requires explicit `--deployer` and `--ur-manager` addresses, plus `--owner` on sepolia (the Hardhat `migration fork-full` task derives them from the keystore). `--resume-from-phase 2` (requires `--work-dir`) skips phase 1 and reloads saved deployments. `--snapshot-file` records a pre-rehearsal `evm_snapshot` id, which the Hardhat `migration revert` task can restore.
-
-### `clean-testnet`
-
-```bash
-bun run migration -- clean-testnet --network sepolia --rpc-url <url> --deployer <address>
-```
-
-Sepolia only. Runs phase 0 — a fresh v1 stack deployed into `deployments/v1/<namespace>` — then phases 1–7 directly against the RPC, always including `TestnetV1PremigrationRegistrar`. The v2 namespace defaults to `sepolia-clean-<timestamp>`; the command refuses to reuse the canonical `sepolia` namespace or any namespace that already contains deployment files. Without `--csv-file`, only the generated smoke labels are seeded. Against an RPC without state controls (anything other than a local node or a Tenderly virtual testnet), a configured deployer key is required — prefer the Hardhat `migration clean-testnet` task, which signs with the configured Hardhat account.
+† `phase disable-v1-registrars` takes the key via `--private-key`; the env fallbacks apply when it is
+executed through `phase execute-owner-txs` with `--role v1Owner`. For `phase execute-owner-txs`, the
+key is selected by the `--role` filter: `v1Owner` → the v1-owner variables, `sepolia-top-urp-owner` →
+the top-URP-owner variables, `deployer` → `DEPLOYER_KEY`; with no role, `OWNER_TX_KEY` then the
+role-specific variables are tried in order.
 
 ## Related docs
 
-- [deployments/README.md](../deployments/README.md) — deployment artifact layout, namespace naming, and the idempotency rule for fresh re-deploys.
-- [premigration.md](./premigration.md) — the `BatchRegistrar` seeding step in detail (phases 2 and 5): CSV format, continuity expiry, checkpoints, verification.
-- [universalResolver.md](./universalResolver.md) — the URP proxy chain behind phase 7, and the post-cutover step.
-- [prepareMigration.md](./prepareMigration.md) — the non-phased, all-at-once role hand-off script that phase 6 supersedes.
+- [premigration.md](./premigration.md) — the `BatchRegistrar` seeding step in detail (phases 2 and 5):
+  CSV format, continuity expiry, checkpoints, verification.
+- [universalResolver.md](./universalResolver.md) — the URP proxy chain behind phase 7, and the
+  post-cutover step.
+- [prepareMigration.md](./prepareMigration.md) — the non-phased, all-at-once role hand-off script that
+  phase 6 supersedes.
+- [deployments/README.md](../deployments/README.md) — deployment artifact layout, namespace naming,
+  and the idempotency rule for fresh re-deploys.

--- a/contracts/docs/premigration.md
+++ b/contracts/docs/premigration.md
@@ -1,19 +1,49 @@
 # ENS Pre-Migration Script
 
-## Overview
+The pre-migration script (`contracts/script/preMigration.ts`) seeds ENS v1 `.eth` second-level (2LD)
+registrations into the v2 registry. It reads a CSV export of v1 registrations, verifies each name
+on-chain against the v1 `BaseRegistrar`, and reserves or renews it on v2 via the `BatchRegistrar`
+contract. Names are written in a **reserved** state (owner `address(0)`) with the v1 expiry preserved
+(plus a configurable bonus period) and `ENSV1Resolver` set as the fallback resolver; ownership
+transfer happens in a later migration phase.
 
-The pre-migration script (`contracts/script/preMigration.ts`) seeds ENS v1 `.eth` second-level (2LD) registrations into the v2 registry. It reads a CSV export of v1 registrations, verifies each name on-chain against the v1 `BaseRegistrar`, and reserves or renews it on v2 via the `BatchRegistrar` contract.
+## Quick start
 
-Names are written to v2 in a **reserved** state (owner `address(0)`) with the v1 expiry preserved (plus a configurable bonus period) and `ENSV1Resolver` set as the fallback resolver. Ownership transfer happens in a later migration phase.
+Run from `contracts/` after `forge build`. Dry-run first (full pipeline, sends nothing), then execute;
+resume with `--continue` after any interruption:
 
-In the phased migration this script is driven through the operator CLI (`bun run migration -- premigration run` / `resume`, then `verify`); see [migration.md](./migration.md). The reference below documents the underlying script directly.
+```bash
+export PREMIGRATION_PRIVATE_KEY=0x...   # BatchRegistrar owner key
+
+# 1. Dry run — parses, verifies, computes expiries, checkpoints; sends no transactions
+bun run script/preMigration.ts \
+  --rpc-url <url> --registry <addr> --batch-registrar <addr> \
+  --v1-resolver <addr> --csv-file ./data/v1-registrations.csv --dry-run
+
+# 2. Execute (drop --dry-run)
+bun run script/preMigration.ts \
+  --rpc-url <url> --registry <addr> --batch-registrar <addr> \
+  --v1-resolver <addr> --csv-file ./data/v1-registrations.csv
+
+# 3. Resume from the last checkpoint after an interruption (same options as before)
+bun run script/preMigration.ts --continue \
+  --rpc-url <url> --registry <addr> --batch-registrar <addr> \
+  --v1-resolver <addr> --csv-file ./data/v1-registrations.csv
+```
+
+In the phased migration this script is driven through the operator CLI
+(`bun run migration -- premigration run` / `resume`, then `verify`) — see
+[migration.md](./migration.md). The reference below documents the underlying script directly.
 
 ## Prerequisites
 
 - **Bun** runtime, and forge artifacts compiled (`forge build` in `contracts/`).
-- **Deployed contracts:** the v2 `PermissionedRegistry`, `BatchRegistrar` (owned by the signer), and `ENSV1Resolver`.
-- **Signer key** for the `BatchRegistrar` owner — `--private-key` or the `PREMIGRATION_PRIVATE_KEY` env var.
-- **RPC endpoint** where both v1 and v2 contracts live (chain ID auto-detected). Optionally a separate `--mainnet-rpc-url` for v1 reads (e.g. when v2 runs on a devnet with its own v1 set).
+- **Deployed contracts:** the v2 `PermissionedRegistry`, `BatchRegistrar` (owned by the signer), and
+  `ENSV1Resolver`.
+- **Signer key** for the `BatchRegistrar` owner — `--private-key` or the `PREMIGRATION_PRIVATE_KEY`
+  env var.
+- **RPC endpoint** where both v1 and v2 contracts live (chain ID auto-detected). Optionally a separate
+  `--mainnet-rpc-url` for v1 reads (e.g. when v2 runs on a devnet with its own v1 set).
 - **CSV file** of v1 registrations (see [CSV input](#csv-input)).
 
 ## CLI Reference
@@ -23,6 +53,12 @@ Run from `contracts/`:
 ```bash
 bun run script/preMigration.ts [options]
 ```
+
+> In the phased flow these options map onto the operator-CLI subcommands `premigration run` /
+> `resume` / `verify`, which additionally accept the shared
+> [common options](./migration.md#common-options) (`--network`, deployment dirs). `premigration
+> status` is a separate, local checkpoint read that takes **only** `--work-dir` — it does not touch an
+> RPC. Run `bun run migration -- premigration <sub> --help` for the authoritative per-subcommand list.
 
 ### Required
 
@@ -49,11 +85,17 @@ bun run script/preMigration.ts [options]
 | `--bonus-period-days <days>` | `62` | Days added to each name's v1 expiry to compute its v2 expiry. `0` preserves v1 expiries exactly. |
 | `--v1-base-registrar <address>` | mainnet `BaseRegistrar` | v1 `BaseRegistrar` for expiry lookups (override for testing). |
 
-> Eligibility is independently gated by v1's hard-coded 90-day grace: a name expired more than 90 days ago is past grace and skipped, regardless of `--bonus-period-days`. Choose a bonus period large enough that the deepest in-grace name you want migrated does not compute a past v2 expiry (which would fail registration).
+> Eligibility is independently gated by v1's hard-coded 90-day grace: a name expired more than 90 days
+> ago is past grace and skipped, regardless of `--bonus-period-days`. Choose a bonus period large
+> enough that the deepest in-grace name you want migrated does not compute a past v2 expiry (which
+> would fail registration).
 
 ## CSV input
 
-Parsing is **header-driven**: the first line is the header, the label column is located by name, everything else is ignored. Two column names are accepted (case-insensitive, trimmed): **`labelName`** (v1 subgraph schema, preferred) or **`label`** (the `exportTheGraphRegistrations.ts` exporter). Both work with no flag:
+Parsing is **header-driven**: the first line is the header, the label column is located by name,
+everything else is ignored. Two column names are accepted (case-insensitive, trimmed): **`labelName`**
+(v1 subgraph schema, preferred) or **`label`** (the `exportTheGraphRegistrations.ts` exporter). Both
+work with no flag:
 
 ```csv
 node,name,labelHash,owner,parentName,parentLabelHash,labelName,registrationDate,expiryDate
@@ -65,17 +107,28 @@ name,label,labelhash,registrant,expiryDate,registrationDate
 vitalik.eth,vitalik,0x...,0x...,...,...
 ```
 
-Quoted fields and `""`-escaped quotes are handled; a UTF-8 BOM, a single trailing blank line, and CRLF endings are tolerated.
+Quoted fields and `""`-escaped quotes are handled; a UTF-8 BOM, a single trailing blank line, and CRLF
+endings are tolerated.
 
-**Strict structural parsing.** Any structural problem aborts the run with the CSV path and 1-based line number (header = line 1); fix the file and re-run. Aborts on: missing both `labelName` and `label` columns; unbalanced quotes (header or row); a data row whose column count differs from the header; an empty/whitespace-only label cell; a blank line anywhere but a single trailing one; an empty file.
+**Strict structural parsing.** Any structural problem aborts the run with the CSV path and 1-based
+line number (header = line 1); fix the file and re-run. Aborts on: missing both `labelName` and
+`label` columns; unbalanced quotes (header or row); a data row whose column count differs from the
+header; an empty/whitespace-only label cell; a blank line anywhere but a single trailing one; an empty
+file.
 
-**Application-level filtering** happens *after* structural parsing and does **not** abort: labels longer than 255 bytes and the bracketed-labelhash form (`[0x…]`) are skipped and counted as `invalidLabelCount`.
+**Application-level filtering** happens *after* structural parsing and does **not** abort: labels
+longer than 255 bytes and the bracketed-labelhash form (`[0x…]`) are skipped and counted as
+`invalidLabelCount`.
 
-> **Limitation:** `readline` splits on `\n`, so a field containing a literal newline inside quotes is misread. No exporter we control produces these; pre-process the file if you have one.
+> **Limitation:** `readline` splits on `\n`, so a field containing a literal newline inside quotes is
+> misread. No exporter we control produces these; pre-process the file if you have one.
 
 ## How it works
 
-Names stream from the CSV in batches of `--batch-size`. Each batch is verified with a single multicall (two RPC calls regardless of size) reading v2 state (`PermissionedRegistry.getState()`) and v1 expiry (`BaseRegistrar.nameExpires()`), then submitted as one `BatchRegistrar.batchRegister()` transaction. Per-name action:
+Names stream from the CSV in batches of `--batch-size`. Each batch is verified with a single multicall
+(two RPC calls regardless of size) reading v2 state (`PermissionedRegistry.getState()`) and v1 expiry
+(`BaseRegistrar.nameExpires()`), then submitted as one `BatchRegistrar.batchRegister()` transaction.
+Per-name action:
 
 | v2 status | v1 status | Action |
 |---|---|---|
@@ -85,47 +138,43 @@ Names stream from the CSV in batches of `--batch-size`. Each batch is verified w
 | Registered (2) | Any | **Fail** (already fully owned on v2) |
 | Any | Never registered, or past v1's 90-day grace | **Skip** (v1 owner lost the claim) |
 
-Reserved names are written with owner/registry `address(0)`, resolver = `ENSV1Resolver`, roleBitmap `0`, and the computed expiry.
+Reserved names are written with owner/registry `address(0)`, resolver = `ENSV1Resolver`, roleBitmap
+`0`, and the computed expiry.
 
-**Gas safety.** Before submitting, the script estimates gas; if it exceeds 80% of the block limit the batch is split in half and re-estimated (recursively). If a batch reverts at execution, it is recursively halved and retried (binary search) until failing names are isolated — preserving partial progress. A checkpoint is saved after each batch.
+**Gas safety.** Before submitting, the script estimates gas; if it exceeds 80% of the block limit the
+batch is split in half and re-estimated (recursively). If a batch reverts at execution, it is
+recursively halved and retried (binary search) until failing names are isolated — preserving partial
+progress. A checkpoint is saved after each batch.
 
 ## Checkpoint & resume
 
-A checkpoint (`preMigration-checkpoint.json`) is written after each batch, tracking the last processed line and accumulated counters (reserved, renewed, skipped, invalid, failed). `--continue` loads it, sets `--start-index` to the last processed line, and resumes; counters accumulate across runs.
-
-```bash
-bun run script/preMigration.ts --continue [same options as before]
-```
+A checkpoint (`preMigration-checkpoint.json`) is written after each batch, tracking the last processed
+line and accumulated counters (reserved, renewed, skipped, invalid, failed). `--continue` loads it,
+sets `--start-index` to the last processed line, and resumes; counters accumulate across runs. See the
+resume command in [Quick start](#quick-start).
 
 ## Dry run
 
-`--dry-run` runs the full pipeline — CSV parse, v1/v2 verification, expiry computation, checkpointing — and logs what would happen, but sends no transactions.
+`--dry-run` runs the full pipeline — CSV parse, v1/v2 verification, expiry computation, checkpointing
+— and logs what would happen, but sends no transactions. It is the default first step in
+[Quick start](#quick-start).
 
 ## Output
 
-Informational output goes to `preMigration.log` and errors to `preMigration-errors.log`; the console mirrors progress with a final summary table (processed / reserved / renewed / skipped / invalid / failed / success rate). Non-CSV failures (individual name reverts, RPC timeouts at a 30s per-call limit, checkpoint write errors) are counted and logged without aborting the run.
-
-## Examples
-
-```bash
-export PREMIGRATION_PRIVATE_KEY=0x...
-
-# Dry run first
-bun run script/preMigration.ts \
-  --rpc-url <url> --registry <addr> --batch-registrar <addr> \
-  --v1-resolver <addr> --csv-file ./data/v1-registrations.csv --dry-run
-
-# Execute (drop --dry-run); resume after an interruption with --continue
-bun run script/preMigration.ts \
-  --rpc-url <url> --registry <addr> --batch-registrar <addr> \
-  --v1-resolver <addr> --csv-file ./data/v1-registrations.csv
-```
+Informational output goes to `preMigration.log` and errors to `preMigration-errors.log`; the console
+mirrors progress with a final summary table (processed / reserved / renewed / skipped / invalid /
+failed / success rate). Non-CSV failures (individual name reverts, RPC timeouts at a 30s per-call
+limit, checkpoint write errors) are counted and logged without aborting the run.
 
 ## Testing on a Sepolia fork
 
-To rehearse pre-migration against real Sepolia v1 state without a full `fork full` run, deploy the v2 stack onto a local Anvil fork (v2 is not on real Sepolia) and run pre-migration against it.
+To rehearse pre-migration against real Sepolia v1 state without a full `fork full` run, deploy the v2
+stack onto a local Anvil fork (v2 is not on real Sepolia) and run pre-migration against it.
 
-> **Account requirement:** the deployer/owner must be an address with **no code** on Sepolia. The standard Anvil test accounts carry an EIP-7702 delegation there, so their `onERC1155Received` does not return the ERC-1155 acceptance value and the `eth` 2LD mint during deploy reverts. Use a fresh throwaway key funded via `anvil_setBalance`.
+> **Account requirement:** the deployer/owner must be an address with **no code** on Sepolia. The
+> standard Anvil test accounts carry an EIP-7702 delegation there, so their `onERC1155Received` does
+> not return the ERC-1155 acceptance value and the `eth` 2LD mint during deploy reverts. Use a fresh
+> throwaway key funded via `anvil_setBalance`.
 
 ```bash
 # 1. Fork Sepolia
@@ -150,4 +199,5 @@ bun run migration -- premigration verify --network sepolia --rpc-url http://127.
   --csv-file ./csv-data/ens-registrations-sepolia.csv
 ```
 
-For the full phased rehearsal instead, see the `fork full` command in [migration.md](./migration.md#rehearsals).
+For the full phased rehearsal instead, see the `fork full` command in
+[migration.md](./migration.md#rehearsals).


### PR DESCRIPTION
## Summary

This PR significantly expands the migration documentation to provide comprehensive, step-by-step guidance for executing the v1 → v2 migration across different deployment contexts. The documentation now includes detailed runbooks for live deployments, rehearsal procedures, and clarified phase-by-phase instructions.

## Key Changes

- **Restructured migration.md** with new sections:
  - Added "Quick start" section for rapid end-to-end rehearsal
  - Introduced "Deployment contexts" to clarify three distinct paths: live public networks, clean testnet, and fork/Tenderly rehearsals
  - Expanded "Phases" table with applicability columns and clearer signer information
  - Added detailed subsections for each phase (0-7) with command syntax, prerequisites, environment variables, and expected outcomes
  - New "Live deployment (Sepolia)" section with complete runbook including signer key requirements, setup instructions, and phase-by-phase execution steps
  - New "Rehearsals" section documenting `fork full`, `clean-testnet`, and Tenderly virtual testnet workflows
  - Reorganized "Orchestration" section explaining the three-piece architecture (CLI, Hardhat plugin, deploy scripts)
  - Added "Deployment artifacts" section explaining namespace management and archiving
  - New "Reference" section with common options and CLI commands reference

- **Enhanced premigration.md** with:
  - Added "Quick start" section with concrete command examples
  - Improved "Prerequisites" section with clearer formatting
  - Added context note linking to operator CLI subcommands in migration.md
  - Better structured "CSV input" section with clearer parsing rules
  - Improved formatting and readability throughout

- **Documentation improvements**:
  - Consistent formatting with code blocks for commands and examples
  - Clear distinction between different deployment paths and their requirements
  - Explicit signer key mappings and environment variable names
  - Detailed prerequisites and expected outcomes for each phase
  - Cross-references between related sections
  - Clarification of bootstrap vs. reuse network differences for URP cutover

## Notable Details

- The documentation now explicitly maps environment variables to their roles (e.g., `DEPLOYER_KEY`, `SEPOLIA_V1_OWNER_KEY`, `UR_MANAGER_KEY`)
- Provides concrete examples of command invocations with realistic file paths and options
- Clarifies the defer-then-replay pattern for v1-owner transactions in phase 1
- Documents the automatic detection of Tenderly virtual testnets and their state-control capabilities
- Explains the idempotent nature of `phase deploy-v2` with `--resume` for interrupted deployments
- Details the smoke checks performed during `fork full` rehearsals

https://claude.ai/code/session_01UobfNAfjVtGPg5wWqd4HSN