### PR TITLE
Fix `clean-testnet` crash: restore rocketh env `config` for ens-contracts v1 deploy scripts

### DIFF
--- a/patches/rocketh@0.19.3.patch
+++ b/patches/rocketh@0.19.3.patch
@@ -61,3 +61,20 @@ index 018a31ca31616c50679b1b566c1092b67857c47d..b21ab3736f81172de7ab5402e97f1390
 +    }
 +}
  //# sourceMappingURL=index.js.map
+diff --git a/dist/environment/index.js b/dist/environment/index.js
+index 8322d74aea4cf8dc59b29690836fd7fa97163255..1ba6ef786a445f3034ca0722372a01380394e737 100644
+--- a/dist/environment/index.js
++++ b/dist/environment/index.js
+@@ -334,6 +334,12 @@ export async function createEnvironment(userConfig, resolvedExecutionParams, dep
+             // for backward compatibility
+             tags: context.tags,
+         },
++        // for backward compatibility with rocketh <0.15 deploy scripts (e.g. the
++        // ens-contracts DNS registrar scripts) that read `config.saveDeployments`;
++        // rocketh 0.19 moved this value onto `context`.
++        config: {
++            saveDeployments: context.saveDeployments,
++        },
+         extra: resolvedExecutionParams.extra || {},
+     };
+     // const signer = {


### PR DESCRIPTION
## Problem

Running `clean-testnet` against a plain Sepolia RPC crashes in phase 0 (fresh v1 deploy) while deploying the public suffix list:

```
clean phase 0: deploy fresh v1 contracts
...
  - DNSSEC Oracle deployment completed successfully
45 |     const fetchedSuffixes = await fetchPublicSuffixes()
46 |     const allowUnsafe =
47 |       network.tags?.allow_unsafe ||
48 |       (network.tags?.test && !config.saveDeployments)
                                   ^
TypeError: undefined is not an object (evaluating 'config.saveDeployments')
      at .../lib/ens-contracts/deploy/dnsregistrar/05_deploy_public_suffix_list.ts:48:31
```

## Root cause

Phase 0 deploys the fresh v1 stack from `lib/ens-contracts/deploy`. Two of those scripts — `dnsregistrar/05_deploy_public_suffix_list` and `dnsregistrar/20_set_tlds` — read `config.saveDeployments` from the deploy environment:

```ts
const allowUnsafe =
  network.tags?.allow_unsafe ||
  (network.tags?.test && !config.saveDeployments)
```

Those scripts were authored against **rocketh 0.14**, whose deploy environment exposed a `config` object. This repo runs them under **rocketh 0.19**, which dropped the environment `config` object (moving `saveDeployments` onto `env.context`) while keeping only the `network.tags` backward-compat shim. So `config` is `undefined` and the dereference throws.

The crash only surfaces when `allow_unsafe` is **absent** from the network tags — i.e. a normal `clean-testnet --network sepolia` run. Passing `--tenderly` adds the `allow_unsafe` tag, which short-circuits the `||` before `config` is ever read, which is why the bug hid until now.

Confirmed the resolution path: for files under `lib/ens-contracts/`, bun uses the submodule's nested `tsconfig.json`, so `@rocketh` resolves to the submodule's own `rocketh.ts` (`setup(functions)`), whose extension set contains no `config` — the environment must therefore supply it.

## Fix

Extend the existing rocketh compatibility patch — the same patch that already re-adds the `setup` export ens-contracts imports — to restore the backward-compat `config` object on the environment produced by `createEnvironment`, sourcing `saveDeployments` from `context`:

```js
// for backward compatibility with rocketh <0.15 deploy scripts (e.g. the
// ens-contracts DNS registrar scripts) that read `config.saveDeployments`;
// rocketh 0.19 moved this value onto `context`.
config: {
    saveDeployments: context.saveDeployments,
},
```

This makes the v1 deploy scripts evaluate the expression exactly as they did under rocketh 0.14 (`allowUnsafe` = `false` for a persisted testnet deploy) instead of throwing. The addition is purely additive — nothing in rocketh 0.19 or this repo's own v2 deploy scripts reads `env.config`.

## Verification

Reproduced the exact failing path in isolation (a probe deploy script placed under `lib/ens-contracts/`, so it resolves `@rocketh` to the submodule's `rocketh.ts`, driven through the same executor `deployV1` uses with a mock provider):

- **Without the patch:** `typeof config === "undefined"` → same crash as reported.
- **With the patch:** `config.saveDeployments === true`, the `allowUnsafe` expression evaluates to `false`, no crash.

Also confirmed the committed patch applies cleanly (`git apply --check`) and that `bun install` applies it to the installed package.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bz1rrfYLoedmLdZDHJzJYp)_