### PR TITLE
Support {ether, `WETH`} and add `{register,renew}Batch()`

### DIFF
--- a/contracts/deploy/00_MockTokens.ts
+++ b/contracts/deploy/00_MockTokens.ts
@@ -19,6 +19,21 @@ export default execute(
       artifact: MockERC20,
       args: ["DAI", 18],
     });
+
+    await deploy("MockWETH", {
+      account: deployer,
+      artifact: MockERC20,
+      args: ["WETH", 18],
+    });
+
+    const ethPrice = 2000;
+    const decimals = 8; // arbitrary, matches mainnet
+    await deploy("MockChainlinkETHUSD", {
+      account: deployer,
+      artifact: artifacts.MockChainlinkAggregator,
+      args: [BigInt(ethPrice) * 10n ** BigInt(decimals), decimals],
+    });
+    console.log(`USD/ETH = $${ethPrice}`);
   },
   {
     tags: ["MockTokens", "migration:phase1:deploy-v2", "v2"],

--- a/contracts/deploy/01_StandardRentPriceOracle.ts
+++ b/contracts/deploy/01_StandardRentPriceOracle.ts
@@ -1,3 +1,4 @@
+import { zeroAddress, type Address } from "viem";
 import { artifacts, execute } from "@rocketh";
 import {
   SEC_PER_YEAR,
@@ -12,10 +13,11 @@ import {
   SEPOLIA_USDC,
   MAINNET_USDC,
   MAINNET_DAI,
+  MAINNET_WETH,
+  MAINNET_ETH_ORACLE,
+  SEPOLIA_WETH,
+  SEPOLIA_ETH_ORACLE,
 } from "../script/deploy-constants.js";
-
-type MockERC20 =
-  (typeof artifacts)["test/mocks/MockERC20.sol/MockERC20"]["abi"];
 
 export default execute(
   async ({
@@ -27,22 +29,29 @@ export default execute(
     namedAccounts: { deployer, owner },
     tags,
   }) => {
-    const mockTokenArtifact = artifacts["test/mocks/MockERC20.sol/MockERC20"];
     // Mainnet whitelists the real payment tokens; the free-mint mocks are only
     // deployed (and only accepted) on test/dev networks. The ERC20 metadata
     // reads below (symbol/decimals) work against the real tokens too.
-    const paymentTokens = tags.hasDao
-      ? [
-          { address: MAINNET_USDC, abi: mockTokenArtifact.abi },
-          { address: MAINNET_DAI, abi: mockTokenArtifact.abi },
-        ]
-      : [
-          get<MockERC20>("MockUSDC"),
-          get<MockERC20>("MockDAI"),
-          ...(tags.sepolia || tags["clean-testnet"]
-            ? [{ address: SEPOLIA_USDC, abi: mockTokenArtifact.abi }]
-            : []),
-        ];
+
+    const paymentTokens: Address[] = [];
+    let wethAddress: Address;
+    let ethOracleAddress: Address;
+    if (tags.hasDao) {
+      ethOracleAddress = MAINNET_ETH_ORACLE;
+      wethAddress = MAINNET_WETH;
+      paymentTokens.push(MAINNET_USDC);
+      paymentTokens.push(MAINNET_DAI);
+    } else if (tags.sepolia) {
+      ethOracleAddress = SEPOLIA_ETH_ORACLE;
+      wethAddress = SEPOLIA_WETH;
+      paymentTokens.push(SEPOLIA_USDC);
+    } else {
+      ethOracleAddress = get("MockChainlinkETHUSD").address;
+      wethAddress = get("MockWETH").address;
+      paymentTokens.push(get("MockUSDC").address);
+      paymentTokens.push(get("MockDAI").address);
+    }
+    paymentTokens.push(wethAddress);
 
     const baseRates = BASE_RATE_PER_CP.flatMap((rate, i) => {
       const yearly = Number(rate * SEC_PER_YEAR) / Number(PRICE_SCALE);
@@ -50,15 +59,16 @@ export default execute(
     }).reverse();
 
     const paymentFactors = await Promise.all(
-      paymentTokens.map(async (x) => {
+      paymentTokens.map(async (address) => {
+        const { abi } = artifacts["test/mocks/MockERC20.sol/MockERC20"];
         const [symbol, decimalsResult] = await Promise.all([
-          read(x, { functionName: "symbol" }),
-          read(x, { functionName: "decimals" }),
+          read({ address, abi }, { functionName: "symbol" }),
+          read({ address, abi }, { functionName: "decimals" }),
         ]);
         const decimals = Number(decimalsResult);
         return {
           MockERC20: symbol,
-          paymentToken: x.address,
+          paymentToken: address,
           decimals,
           Δ: decimals - PRICE_DECIMALS,
           numer: 10n ** BigInt(Math.max(decimals - PRICE_DECIMALS, 0)),
@@ -66,6 +76,15 @@ export default execute(
         };
       }),
     );
+
+    const wethIndex = paymentTokens.indexOf(wethAddress);
+    if (wethIndex >= 0) {
+      paymentFactors.push({
+        ...paymentFactors[wethIndex],
+        MockERC20: "[ether]",
+        paymentToken: zeroAddress,
+      });
+    }
 
     console.table(paymentFactors);
 
@@ -89,9 +108,12 @@ export default execute(
           PREMIUM_HALVING_PERIOD,
           PREMIUM_PERIOD,
           paymentFactors,
+          wethAddress,
+          ethOracleAddress,
         ],
       }));
 
+    // sync ratios
     for (const paymentFactor of paymentFactors) {
       const [numer, denom] = (await read(standardRentPriceOracle, {
         functionName: "getPaymentTokenRatio",

--- a/contracts/deploy/01_StandardRentPriceOracle.ts
+++ b/contracts/deploy/01_StandardRentPriceOracle.ts
@@ -1,4 +1,4 @@
-import { zeroAddress, type Address } from "viem";
+import type { Address } from "viem";
 import { artifacts, execute } from "@rocketh";
 import {
   SEC_PER_YEAR,
@@ -17,6 +17,7 @@ import {
   MAINNET_ETH_ORACLE,
   SEPOLIA_WETH,
   SEPOLIA_ETH_ORACLE,
+  NATIVE_ETH,
 } from "../script/deploy-constants.js";
 
 export default execute(
@@ -82,7 +83,7 @@ export default execute(
       paymentFactors.push({
         ...paymentFactors[wethIndex],
         MockERC20: "[ether]",
-        paymentToken: zeroAddress,
+        paymentToken: NATIVE_ETH,
       });
     }
 

--- a/contracts/script/deploy-constants.ts
+++ b/contracts/script/deploy-constants.ts
@@ -1,26 +1,36 @@
+import type { Address } from "viem";
+
 export const MAX_EXPIRY = (1n << 64n) - 1n; // see: DatastoreUtils.sol
 
 export const LOCAL_BATCH_GATEWAY_URL = "x-batch-gateway:true";
-export const DEPLOYED_UNIVERSAL_RESOLVER_PROXY =
-  "0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe" as const;
+export const DEPLOYED_UNIVERSAL_RESOLVER_PROXY: Address =
+  "0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe";
 
 // Networks whose top URP already fronts a long-lived intermediate (managed) URP
 // whose admin we control, keyed by network name. On these networks a fresh v2
 // deployment reuses the existing intermediate URP instead of deploying a new one.
-export const KNOWN_INTERMEDIATE_URP: Record<string, `0x${string}`> = {
+export const KNOWN_INTERMEDIATE_URP: Record<string, Address> = {
   sepolia: "0x6d80F2172CFdEc5730fE683860C33d26fC42e6F1",
 };
 
 export const SEPOLIA_USDC =
-  "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238" as const;
+  "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238" satisfies Address;
+export const SEPOLIA_WETH =
+  "0xC558DBdd856501FCd9aaF1E62eae57A9F0629a3c" satisfies Address;
+export const SEPOLIA_ETH_ORACLE =
+  "0x10E7e7D64d7dA687f7DcF8443Df58A0415329b15" satisfies Address;
 
 // Real mainnet payment tokens used by the rent price oracle in place of the
 // free-mint test mocks (which must never ship to mainnet). Confirm/adjust the
 // accepted set before a mainnet deploy.
 export const MAINNET_USDC =
-  "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" as const;
+  "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" satisfies Address;
 export const MAINNET_DAI =
-  "0x6B175474E89094C44Da98b954EedeAC495271d0F" as const;
+  "0x6B175474E89094C44Da98b954EedeAC495271d0F" satisfies Address;
+export const MAINNET_WETH =
+  "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" satisfies Address;
+export const MAINNET_ETH_ORACLE =
+  "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419" satisfies Address;
 
 export const STANDARD_RENT_PRICE_ORACLE_PRICE_DECIMALS = 12n;
 export const STANDARD_RENT_PRICE_ORACLE_PRICE_SCALE =

--- a/contracts/script/deploy-constants.ts
+++ b/contracts/script/deploy-constants.ts
@@ -21,7 +21,7 @@ export const SEPOLIA_USDC =
 export const SEPOLIA_WETH =
   "0xC558DBdd856501FCd9aaF1E62eae57A9F0629a3c" satisfies Address;
 export const SEPOLIA_ETH_ORACLE =
-  "0x10E7e7D64d7dA687f7DcF8443Df58A0415329b15" satisfies Address;
+  "0x694AA1769357215DE4FAC081bf1f309aDC325306" satisfies Address;
 
 // Real mainnet payment tokens used by the rent price oracle in place of the
 // free-mint test mocks (which must never ship to mainnet). Confirm/adjust the

--- a/contracts/script/deploy-constants.ts
+++ b/contracts/script/deploy-constants.ts
@@ -6,6 +6,9 @@ export const LOCAL_BATCH_GATEWAY_URL = "x-batch-gateway:true";
 export const DEPLOYED_UNIVERSAL_RESOLVER_PROXY: Address =
   "0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe";
 
+export const NATIVE_ETH =
+  "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE" satisfies Address;
+
 // Networks whose top URP already fronts a long-lived intermediate (managed) URP
 // whose admin we control, keyed by network name. On these networks a fresh v2
 // deployment reuses the existing intermediate URP instead of deploying a new one.

--- a/contracts/script/migration.ts
+++ b/contracts/script/migration.ts
@@ -3561,19 +3561,20 @@ async function registerViaV2Registrar({
   const client = publicClient(rpcUrl, chain);
   const wallet = walletClient({ rpcUrl, chain, privateKey });
   const payer = privateKeyToAccount(privateKey).address;
+  const commitData = {
+    label,
+    owner,
+    secret: zeroHash,
+    subregistry: zeroAddress,
+    resolver: zeroAddress,
+    duration: V2_REGISTRATION_DURATION,
+    referrer: zeroHash,
+  };
   const commitment = (await client.readContract({
     address: ethRegistrar.address,
     abi: ethRegistrar.abi,
     functionName: "makeCommitment",
-    args: [
-      label,
-      owner,
-      zeroHash,
-      zeroAddress,
-      zeroAddress,
-      V2_REGISTRATION_DURATION,
-      zeroHash,
-    ],
+    args: [commitData],
   })) as `0x${string}`;
   let hash = await wallet.writeContract({
     address: ethRegistrar.address,
@@ -3624,16 +3625,7 @@ async function registerViaV2Registrar({
     address: ethRegistrar.address,
     abi: ethRegistrar.abi,
     functionName: "register",
-    args: [
-      label,
-      owner,
-      zeroHash,
-      zeroAddress,
-      zeroAddress,
-      V2_REGISTRATION_DURATION,
-      mockUsdc.address,
-      zeroHash,
-    ],
+    args: [commitData, mockUsdc.address, zeroAddress],
   });
   await waitForSuccessfulReceipt(client, hash, `v2 register ${label}.eth`);
 }

--- a/contracts/script/testNames.ts
+++ b/contracts/script/testNames.ts
@@ -92,21 +92,21 @@ export async function testNames(env: DevnetEnvironment) {
   }
 
   // Commit-reveal for alias.eth, using test.eth's resolver
-  const aliasSecret =
-    "0x00000000000000000000000000000000000000000000000000000000000000ff";
-  const aliasDuration = BigInt(28 * ONE_DAY_SECONDS);
-  const aliasPaymentToken = env.erc20.MockUSDC.address;
-  const aliasReferrer =
-    "0x0000000000000000000000000000000000000000000000000000000000000000";
 
+  const aliasPaymentToken = env.erc20.MockUSDC.address;
+  const aliasCommitData = {
+    label: "alias",
+    duration: BigInt(28 * ONE_DAY_SECONDS),
+    owner: env.namedAccounts.owner.address,
+    secret:
+      "0x00000000000000000000000000000000000000000000000000000000000000ff" as const,
+    subregistry: zeroAddress,
+    resolver: testNameData.resolver,
+    referrer:
+      "0x0000000000000000000000000000000000000000000000000000000000000000" as const,
+  };
   const aliasCommitment = await env.v2.ETHRegistrar.read.makeCommitment([
-    "alias",
-    env.namedAccounts.owner.address,
-    aliasSecret,
-    zeroAddress,
-    testNameData.resolver,
-    aliasDuration,
-    aliasReferrer,
+    aliasCommitData,
   ]);
   const aliasCommitReceipt = await env.waitFor(
     env.v2.ETHRegistrar.write.commit([aliasCommitment], {
@@ -122,7 +122,7 @@ export async function testNames(env: DevnetEnvironment) {
     await env.v2.StandardRentPriceOracle.read.getRegisterPrice([
       "alias",
       MAX_EXPIRY,
-      aliasDuration,
+      aliasCommitData.duration,
       aliasPaymentToken,
     ]);
   const aliasPrice = aliasBase + aliasPremium;
@@ -142,16 +142,7 @@ export async function testNames(env: DevnetEnvironment) {
 
   const aliasRegisterReceipt = await env.waitFor(
     env.v2.ETHRegistrar.write.register(
-      [
-        "alias",
-        env.namedAccounts.owner.address,
-        aliasSecret,
-        zeroAddress,
-        testNameData.resolver,
-        aliasDuration,
-        aliasPaymentToken,
-        aliasReferrer,
-      ],
+      [aliasCommitData, aliasPaymentToken, zeroAddress],
       { account: env.namedAccounts.owner },
     ),
   );

--- a/contracts/script/testNames/registrar.ts
+++ b/contracts/script/testNames/registrar.ts
@@ -30,7 +30,7 @@ export async function registerTestNames(
   const duration = BigInt(durationInDays * ONE_DAY_SECONDS);
   const paymentToken = env.erc20.MockUSDC.address;
   const referrer =
-    "0x0000000000000000000000000000000000000000000000000000000000000000";
+    "0x0000000000000000000000000000000000000000000000000000000000000000" as const;
 
   // use account's resolver (already deployed by devnet)
   const { resolver } = account;
@@ -40,13 +40,15 @@ export async function registerTestNames(
   // Step 1: Commit all names
   for (let i = 0; i < labels.length; i++) {
     const commitment = await env.v2.ETHRegistrar.read.makeCommitment([
-      labels[i],
-      account.address,
-      secret(i),
-      zeroAddress,
-      resolver.address,
-      duration,
-      referrer,
+      {
+        label: labels[i],
+        duration: duration,
+        owner: account.address,
+        secret: secret(i),
+        subregistry: zeroAddress,
+        resolver: resolver.address,
+        referrer,
+      },
     ]);
     const receipt = await env.waitFor(
       env.v2.ETHRegistrar.write.commit([commitment], {
@@ -92,14 +94,17 @@ export async function registerTestNames(
     const receipt = await env.waitFor(
       env.v2.ETHRegistrar.write.register(
         [
-          labels[i],
-          account.address,
-          secret(i),
-          zeroAddress,
-          resolver.address,
-          duration,
+          {
+            label: labels[i],
+            duration: duration,
+            owner: account.address,
+            secret: secret(i),
+            subregistry: zeroAddress,
+            resolver: resolver.address,
+            referrer,
+          },
           paymentToken,
-          referrer,
+          zeroAddress,
         ],
         { account },
       ),
@@ -228,9 +233,10 @@ export async function renewName(
   });
 
   const receipt = await env.waitFor(
-    env.v2.ETHRegistrar.write.renew([label, duration, paymentToken, referrer], {
-      account,
-    }),
+    env.v2.ETHRegistrar.write.renew(
+      [{ label, duration, referrer }, paymentToken, zeroAddress],
+      { account },
+    ),
   );
 
   const newExpiry = await env.v2.ETHRegistry.read.getExpiry([

--- a/contracts/src/registrar/AbstractETHRegistrar.sol
+++ b/contracts/src/registrar/AbstractETHRegistrar.sol
@@ -139,8 +139,11 @@ abstract contract AbstractETHRegistrar is Ownable, ERC165, IETHRenewer {
         );
     }
 
-    /// @dev Pay beneficiary and refund any leftovers.
+    /// @dev Pay beneficiary and refund extra ether.
     function _transferPayment(IERC20 paymentToken, uint256 amount, address refundTo) internal {
+        if (amount == 0) {
+            return;
+        }
         if (address(paymentToken) == NATIVE_ETH) {
             if (msg.value < amount) {
                 revert InsufficientETH(msg.value, amount);
@@ -156,6 +159,9 @@ abstract contract AbstractETHRegistrar is Ownable, ERC165, IETHRenewer {
                 }
             }
         } else {
+            if (msg.value > 0) {
+                revert UnexpectedETH(msg.value);
+            }
             SafeERC20.safeTransferFrom(paymentToken, msg.sender, BENEFICIARY, amount); // reverts if payment failed
         }
     }

--- a/contracts/src/registrar/AbstractETHRegistrar.sol
+++ b/contracts/src/registrar/AbstractETHRegistrar.sol
@@ -8,7 +8,7 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
 import {LibLabel} from "../utils/LibLabel.sol";
 
-import {IETHRenewer} from "./interfaces/IETHRenewer.sol";
+import {IETHRenewer, RenewData, NATIVE_ETH} from "./interfaces/IETHRenewer.sol";
 import {IRentPriceOracle} from "./interfaces/IRentPriceOracle.sol";
 
 /// @dev Abstract registrar implementation shared between `ETHRegistrar` and `ETHRenewerV1`.
@@ -81,16 +81,20 @@ abstract contract AbstractETHRegistrar is Ownable, ERC165, IETHRenewer {
     }
 
     /// @inheritdoc IETHRenewer
-    function renew(string calldata label, uint64 duration, IERC20 paymentToken, bytes32 referrer)
+    function renew(RenewData calldata rd, IERC20 paymentToken, address refundTo) external payable {
+        _transferPayment(paymentToken, _renew(rd, paymentToken), refundTo);
+    }
+
+    /// @inheritdoc IETHRenewer
+    function renewBatch(RenewData[] calldata rds, IERC20 paymentToken, address refundTo)
         external
+        payable
     {
-        IPermissionedRegistry.State memory state = _requireRenewable(label, duration); // reverts if not
-        uint64 newExpiry = state.expiry + duration; // reverts if overflow
-        uint256 amount = rentPriceOracle.getRenewPrice(label, state.expiry, duration, paymentToken); // reverts if invalid
-        SafeERC20.safeTransferFrom(paymentToken, msg.sender, BENEFICIARY, amount); // reverts if payment failed
-        ETH_REGISTRY.renew(state.tokenId, newExpiry);
-        _onRenew(label, duration);
-        emit NameRenewed(state.tokenId, label, duration, newExpiry, paymentToken, referrer, amount);
+        uint256 total;
+        for (uint256 i; i < rds.length; ++i) {
+            total += _renew(rds[i], paymentToken);
+        }
+        _transferPayment(paymentToken, total, refundTo);
     }
 
     /// @inheritdoc IETHRenewer
@@ -116,6 +120,45 @@ abstract contract AbstractETHRegistrar is Ownable, ERC165, IETHRenewer {
     ////////////////////////////////////////////////////////////////////////
     // Internal Functions
     ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Renew a name and return the amount of `paymentToken`.
+    function _renew(RenewData calldata rd, IERC20 paymentToken) internal returns (uint256 amount) {
+        IPermissionedRegistry.State memory state = _requireRenewable(rd.label, rd.duration); // reverts if not
+        uint64 newExpiry = state.expiry + rd.duration; // reverts if overflow
+        amount = rentPriceOracle.getRenewPrice(rd.label, state.expiry, rd.duration, paymentToken); // reverts if invalid
+        ETH_REGISTRY.renew(state.tokenId, newExpiry);
+        _onRenew(rd.label, rd.duration);
+        emit NameRenewed(
+            state.tokenId,
+            rd.label,
+            rd.duration,
+            newExpiry,
+            paymentToken,
+            rd.referrer,
+            amount
+        );
+    }
+
+    /// @dev Pay beneficiary and refund any leftovers.
+    function _transferPayment(IERC20 paymentToken, uint256 amount, address refundTo) internal {
+        if (address(paymentToken) == NATIVE_ETH) {
+            if (msg.value < amount) {
+                revert InsufficientETH(msg.value, amount);
+            }
+            (bool ok, ) = payable(BENEFICIARY).call{value: amount}("");
+            if (!ok) {
+                revert ETHTransferFailed(BENEFICIARY);
+            }
+            if (msg.value > amount) {
+                (ok, ) = payable(refundTo).call{value: msg.value - amount}("");
+                if (!ok) {
+                    revert ETHTransferFailed(refundTo);
+                }
+            }
+        } else {
+            SafeERC20.safeTransferFrom(paymentToken, msg.sender, BENEFICIARY, amount); // reverts if payment failed
+        }
+    }
 
     /// @dev Callback for when a name is renewed.
     function _onRenew(string calldata label, uint64 duration) internal virtual {}

--- a/contracts/src/registrar/ETHRegistrar.sol
+++ b/contracts/src/registrar/ETHRegistrar.sol
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import {InvalidOwner} from "../CommonErrors.sol";
 import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
-import {IRegistry} from "../registry/interfaces/IRegistry.sol";
 import {RegistryRolesLib} from "../registry/libraries/RegistryRolesLib.sol";
 import {LibLabel} from "../utils/LibLabel.sol";
 
 import {AbstractETHRegistrar} from "./AbstractETHRegistrar.sol";
-import {IETHRegistrar} from "./interfaces/IETHRegistrar.sol";
+import {IETHRegistrar, CommitData} from "./interfaces/IETHRegistrar.sol";
 import {IETHRenewer} from "./interfaces/IETHRenewer.sol";
 import {IRentPriceOracle} from "./interfaces/IRentPriceOracle.sol";
 
@@ -120,54 +119,30 @@ contract ETHRegistrar is AbstractETHRegistrar, IETHRegistrar {
     }
 
     /// @inheritdoc IETHRegistrar
-    function register(
-        string calldata label,
-        address owner,
-        bytes32 secret,
-        IRegistry subregistry,
-        address resolver,
-        uint64 duration,
-        IERC20 paymentToken,
-        bytes32 referrer
-    )
+    function register(CommitData calldata cd, IERC20 paymentToken, address refundTo)
         external
+        payable
         returns (uint256 tokenId)
     {
-        if (owner == address(0)) {
-            revert InvalidOwner();
+        uint256 amount;
+        (amount, tokenId) = _register(cd, paymentToken);
+        _transferPayment(paymentToken, amount, refundTo);
+    }
+
+    /// @inheritdoc IETHRegistrar
+    function registerBatch(CommitData[] calldata cds, IERC20 paymentToken, address refundTo)
+        external
+        payable
+        returns (uint256[] memory tokenIds)
+    {
+        tokenIds = new uint256[](cds.length);
+        uint256 total;
+        uint256 amount;
+        for (uint256 i; i < cds.length; ++i) {
+            (amount, tokenIds[i]) = _register(cds[i], paymentToken);
+            total += amount;
         }
-        _consumeCommitment(
-            makeCommitment(label, owner, secret, subregistry, resolver, duration, referrer)
-        ); // reverts if no commitment
-        IPermissionedRegistry.State memory state = _requireAvailable(label, duration); // reverts if not
-        (uint256 base, uint256 premium) =
-            rentPriceOracle.getRegisterPrice(
-                label,
-                _availablePeriod(state.expiry),
-                duration,
-                paymentToken
-            ); // reverts if invalid
-        SafeERC20.safeTransferFrom(paymentToken, msg.sender, BENEFICIARY, base + premium); // reverts if payment failed
-        tokenId = ETH_REGISTRY.register(
-            label,
-            owner,
-            subregistry,
-            resolver,
-            REGISTRATION_ROLE_BITMAP,
-            uint64(block.timestamp) + duration // new expiry
-        ); // should not revert
-        emit NameRegistered(
-            tokenId,
-            label,
-            owner,
-            subregistry,
-            resolver,
-            duration,
-            paymentToken,
-            referrer,
-            base,
-            premium
-        );
+        _transferPayment(paymentToken, total, refundTo);
     }
 
     /// @inheritdoc IETHRegistrar
@@ -202,27 +177,64 @@ contract ETHRegistrar is AbstractETHRegistrar, IETHRegistrar {
     }
 
     /// @inheritdoc IETHRegistrar
-    function makeCommitment(
-        string calldata label,
-        address owner,
-        bytes32 secret,
-        IRegistry subregistry,
-        address resolver,
-        uint64 duration,
-        bytes32 referrer
-    )
-        public
-        pure
-        override
-        returns (bytes32)
-    {
+    function makeCommitment(CommitData calldata cd) public pure override returns (bytes32) {
         return
-            keccak256(abi.encode(label, owner, secret, subregistry, resolver, duration, referrer));
+            keccak256(
+                abi.encode(
+                    cd.label,
+                    cd.owner,
+                    cd.secret,
+                    cd.subregistry,
+                    cd.resolver,
+                    cd.duration,
+                    cd.referrer
+                )
+            );
     }
 
     ////////////////////////////////////////////////////////////////////////
     // Internal Functions
     ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Register a name and return the amount of `paymentToken` and token ID.
+    function _register(CommitData calldata cd, IERC20 paymentToken)
+        internal
+        returns (uint256 amount, uint256 tokenId)
+    {
+        if (cd.owner == address(0)) {
+            revert InvalidOwner();
+        }
+        _consumeCommitment(makeCommitment(cd)); // reverts if no commitment
+        IPermissionedRegistry.State memory state = _requireAvailable(cd.label, cd.duration); // reverts if not
+        (uint256 base, uint256 premium) =
+            rentPriceOracle.getRegisterPrice(
+                cd.label,
+                _availablePeriod(state.expiry),
+                cd.duration,
+                paymentToken
+            ); // reverts if invalid
+        amount = base + premium;
+        tokenId = ETH_REGISTRY.register(
+            cd.label,
+            cd.owner,
+            cd.subregistry,
+            cd.resolver,
+            REGISTRATION_ROLE_BITMAP,
+            uint64(block.timestamp) + cd.duration // new expiry
+        ); // should not revert
+        emit NameRegistered(
+            tokenId,
+            cd.label,
+            cd.owner,
+            cd.subregistry,
+            cd.resolver,
+            cd.duration,
+            paymentToken,
+            cd.referrer,
+            base,
+            premium
+        );
+    }
 
     /// @dev Validates that the given `commitment` was recorded within the allowed time window
     ///      (between minimum and maximum commitment age), then deletes it so it cannot be reused.

--- a/contracts/src/registrar/StandardRentPriceOracle.sol
+++ b/contracts/src/registrar/StandardRentPriceOracle.sol
@@ -9,6 +9,8 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {EnhancedAccessControl} from "../access-control/EnhancedAccessControl.sol";
 import {IContractNamer} from "../reverse-registrar/interfaces/IContractNamer.sol";
 
+import {IChainlinkAggregator} from "./interfaces/IChainlinkAggregator.sol";
+import {NATIVE_ETH} from "./interfaces/IETHRenewer.sol";
 import {IRentPriceOracle} from "./interfaces/IRentPriceOracle.sol";
 import {LibHalving} from "./libraries/LibHalving.sol";
 
@@ -73,6 +75,8 @@ struct PaymentRatio {
 ///    Since no external oracle is consulted, only stablecoins.
 ///    Accounts with `ROLE_DISABLE_TOKEN` can only disable payment tokens.
 ///
+/// If `paymentToken = NATIVE_ETH`, uses ether.
+///
 contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, IContractNamer {
     ////////////////////////////////////////////////////////////////////////
     // Types
@@ -102,6 +106,15 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
 
     /// @notice Precomputed premium halving at end of period.
     uint256 public immutable PREMIUM_PRICE_OFFSET;
+
+    /// @notice Chainlink Oracle for ETH/USD.
+    IChainlinkAggregator public immutable ETH_ORACLE;
+
+    /// @dev Denominator for ETH/USD conversions.
+    uint128 internal immutable _ETH_DENOM;
+
+    /// @notice Wrapped Ether token.
+    IERC20 public immutable WETH;
 
     ////////////////////////////////////////////////////////////////////////
     // Storage
@@ -154,6 +167,8 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
     /// @param premiumHalvingPeriod Premium halving period, in seconds.
     /// @param premiumPeriod Premium period, in seconds.
     /// @param paymentRatios List of payment tokens with exchange rates.
+    /// @param weth Wrapped Ether token.
+    /// @param ethOracle Chainlink Oracle for ETH/USD.
     constructor(
         address rootAccount,
         uint256[] memory baseRatePerCp,
@@ -162,7 +177,9 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
         uint256 premiumPriceInitial,
         uint64 premiumHalvingPeriod,
         uint64 premiumPeriod,
-        PaymentRatio[] memory paymentRatios
+        PaymentRatio[] memory paymentRatios,
+        IERC20 weth,
+        IChainlinkAggregator ethOracle
     )
     {
         _grantRoles(ROOT_RESOURCE, DEFAULT_ROLE_BITMAP, rootAccount, false);
@@ -208,6 +225,10 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
             _paymentRatios[pr.paymentToken] = Ratio(pr.numer, pr.denom);
             emit PaymentTokenUpdated(pr.paymentToken, pr.numer, pr.denom);
         }
+
+        WETH = weth;
+        ETH_ORACLE = ethOracle;
+        _ETH_DENOM = uint128(address(ethOracle) == address(0) ? 0 : 10 ** ethOracle.decimals());
     }
 
     /// @inheritdoc ERC165
@@ -285,7 +306,7 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
         view
         returns (uint128 numer, uint128 denom)
     {
-        Ratio storage ratio = _paymentRatios[paymentToken];
+        Ratio memory ratio = _getPaymentRatio(paymentToken);
         return (ratio.numer, ratio.denom);
     }
 
@@ -348,8 +369,9 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
         uint128 numer;
         for (uint256 i; i < n; ++i) {
             DiscountPoint storage p = _discountPoints[i];
-            if (duration < p.duration)
+            if (duration < p.duration) {
                 break;
+            }
             numer = p.numer;
         }
         return
@@ -408,9 +430,21 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
         }
     }
 
+    /// @dev Get payment ratio. If (W)ETH, use oracle.
+    function _getPaymentRatio(IERC20 paymentToken) internal view returns (Ratio memory ratio) {
+        ratio = _paymentRatios[paymentToken];
+        if (address(paymentToken) == NATIVE_ETH || paymentToken == WETH) {
+            int256 answer = ETH_ORACLE.latestAnswer();
+            if (answer < 1) {
+                revert PaymentTokenNotSupported(paymentToken); // none or invalid
+            }
+            ratio = Ratio(uint128(uint256(answer)), _ETH_DENOM * ratio.denom);
+        }
+    }
+
     /// @dev Ensure `paymentToken` is supported.
     function _requirePaymentToken(IERC20 paymentToken) internal view returns (Ratio memory ratio) {
-        ratio = _paymentRatios[paymentToken];
+        ratio = _getPaymentRatio(paymentToken);
         if (ratio.denom == 0) {
             revert PaymentTokenNotSupported(paymentToken);
         }

--- a/contracts/src/registrar/StandardRentPriceOracle.sol
+++ b/contracts/src/registrar/StandardRentPriceOracle.sol
@@ -110,8 +110,8 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
     /// @notice Chainlink Oracle for ETH/USD.
     IChainlinkAggregator public immutable ETH_ORACLE;
 
-    /// @dev Denominator for ETH/USD conversions.
-    uint128 internal immutable _ETH_DENOM;
+    /// @dev Scaling for ETH/USD conversions.
+    uint128 internal immutable _ETH_ORACLE_SCALE;
 
     /// @notice Wrapped Ether token.
     IERC20 public immutable WETH;
@@ -228,7 +228,9 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
 
         WETH = weth;
         ETH_ORACLE = ethOracle;
-        _ETH_DENOM = uint128(address(ethOracle) == address(0) ? 0 : 10 ** ethOracle.decimals());
+        _ETH_ORACLE_SCALE = uint128(
+            address(ethOracle) == address(0) ? 0 : 10 ** ethOracle.decimals()
+        );
     }
 
     /// @inheritdoc ERC165
@@ -438,7 +440,7 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
             if (answer < 1) {
                 revert PaymentTokenNotSupported(paymentToken); // none or invalid
             }
-            ratio = Ratio(uint128(uint256(answer)), _ETH_DENOM * ratio.denom);
+            ratio = Ratio(_ETH_ORACLE_SCALE * ratio.numer, uint128(uint256(answer)) * ratio.denom);
         }
     }
 

--- a/contracts/src/registrar/StandardRentPriceOracle.sol
+++ b/contracts/src/registrar/StandardRentPriceOracle.sol
@@ -107,14 +107,14 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
     /// @notice Precomputed premium halving at end of period.
     uint256 public immutable PREMIUM_PRICE_OFFSET;
 
+    /// @notice Wrapped Ether token.
+    IERC20 public immutable WETH;
+
     /// @notice Chainlink Oracle for ETH/USD.
     IChainlinkAggregator public immutable ETH_ORACLE;
 
     /// @dev Scaling for ETH/USD conversions.
     uint128 internal immutable _ETH_ORACLE_SCALE;
-
-    /// @notice Wrapped Ether token.
-    IERC20 public immutable WETH;
 
     ////////////////////////////////////////////////////////////////////////
     // Storage
@@ -167,8 +167,8 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
     /// @param premiumHalvingPeriod Premium halving period, in seconds.
     /// @param premiumPeriod Premium period, in seconds.
     /// @param paymentRatios List of payment tokens with exchange rates.
-    /// @param weth Wrapped Ether token.
-    /// @param ethOracle Chainlink Oracle for ETH/USD.
+    /// @param weth Wrapped Ether token or null.
+    /// @param ethOracle Chainlink Oracle for ETH/USD or null.
     constructor(
         address rootAccount,
         uint256[] memory baseRatePerCp,
@@ -300,6 +300,7 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
     }
 
     /// @notice Get numerator/denominator for `paymentToken`.
+    ///         If ETH, includes ETH/USD ratio.
     /// @param paymentToken The payment token.
     /// @return numer The numerator of the exchange rate.
     /// @return denom The denominator of the exchange rate.
@@ -308,7 +309,7 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
         view
         returns (uint128 numer, uint128 denom)
     {
-        Ratio memory ratio = _getPaymentRatio(paymentToken);
+        Ratio memory ratio = _computePaymentRatio(paymentToken);
         return (ratio.numer, ratio.denom);
     }
 
@@ -432,21 +433,30 @@ contract StandardRentPriceOracle is EnhancedAccessControl, IRentPriceOracle, ICo
         }
     }
 
-    /// @dev Get payment ratio. If (W)ETH, use oracle.
-    function _getPaymentRatio(IERC20 paymentToken) internal view returns (Ratio memory ratio) {
+    /// @dev Determine ratio for `paymentToken`.
+    ///      If ETH, includes ETH/USD ratio.
+    ///      If invalid, `denom = 0`.
+    function _computePaymentRatio(IERC20 paymentToken) internal view returns (Ratio memory ratio) {
         ratio = _paymentRatios[paymentToken];
-        if (address(paymentToken) == NATIVE_ETH || paymentToken == WETH) {
+        if (
+            address(paymentToken) == NATIVE_ETH ||
+            (paymentToken == WETH && address(WETH) != address(0))
+        ) {
+            if (address(ETH_ORACLE) == address(0)) {
+                return Ratio(0, 0); // no oracle
+            }
             int256 answer = ETH_ORACLE.latestAnswer();
             if (answer < 1) {
-                revert PaymentTokenNotSupported(paymentToken); // none or invalid
+                return Ratio(0, 0); // invalid response
             }
+            // note: the oracle is USD per ETH => use reciprocal
             ratio = Ratio(_ETH_ORACLE_SCALE * ratio.numer, uint128(uint256(answer)) * ratio.denom);
         }
     }
 
     /// @dev Ensure `paymentToken` is supported.
     function _requirePaymentToken(IERC20 paymentToken) internal view returns (Ratio memory ratio) {
-        ratio = _getPaymentRatio(paymentToken);
+        ratio = _computePaymentRatio(paymentToken);
         if (ratio.denom == 0) {
             revert PaymentTokenNotSupported(paymentToken);
         }

--- a/contracts/src/registrar/interfaces/IChainlinkAggregator.sol
+++ b/contracts/src/registrar/interfaces/IChainlinkAggregator.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.13;
 
 // https://docs.chain.link/chainlink-local/api-reference/v0.2.3/aggregator-v2-v3-interface
 // https://github.com/smartcontractkit/chainlink-evm/blob/develop/contracts/src/v0.8/shared/interfaces/AggregatorInterface.sol
+// https://github.com/smartcontractkit/chainlink-evm/blob/develop/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol
 
 /// @dev Interface selector: `0x61eebeaa`
 interface IChainlinkAggregator {
@@ -11,4 +12,21 @@ interface IChainlinkAggregator {
 
     /// @notice Gets the latest answer from the aggregator.
     function latestAnswer() external view returns (int256);
+
+    // /// @notice Gets the latest round data.
+    // /// @return roundId The latest round ID.
+    // /// @return answer The latest answer.
+    // /// @return startedAt The timestamp when the latest round started.
+    // /// @return updatedAt The timestamp when the latest round was updated.
+    // /// @return answeredInRound The round ID in which the latest answer was computed.
+    // function latestRoundData()
+    //     external
+    //     view
+    //     returns (
+    //         uint80 roundId,
+    //         int256 answer,
+    //         uint256 startedAt,
+    //         uint256 updatedAt,
+    //         uint80 answeredInRound
+    //     );
 }

--- a/contracts/src/registrar/interfaces/IChainlinkAggregator.sol
+++ b/contracts/src/registrar/interfaces/IChainlinkAggregator.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+// https://docs.chain.link/chainlink-local/api-reference/v0.2.3/aggregator-v2-v3-interface
+// https://github.com/smartcontractkit/chainlink-evm/blob/develop/contracts/src/v0.8/shared/interfaces/AggregatorInterface.sol
+
+/// @dev Interface selector: `0x61eebeaa`
+interface IChainlinkAggregator {
+    /// @notice Number of decimals used in `latestAnswer()`.
+    function decimals() external view returns (uint8);
+
+    /// @notice Gets the latest answer from the aggregator.
+    function latestAnswer() external view returns (int256);
+}

--- a/contracts/src/registrar/interfaces/IETHRegistrar.sol
+++ b/contracts/src/registrar/interfaces/IETHRegistrar.sol
@@ -7,8 +7,25 @@ import {IRegistry} from "../../registry/interfaces/IRegistry.sol";
 
 import {IETHRenewer} from "./IETHRenewer.sol";
 
+struct CommitData {
+    /// @param label The name to register.
+    string label;
+    /// @param owner The owner address.
+    address owner;
+    /// @param secret The secret for the registration.
+    bytes32 secret;
+    /// @param subregistry The initial registry address.
+    IRegistry subregistry;
+    /// @param resolver The initial resolver address.
+    address resolver;
+    /// @param duration The registration duration, in seconds.
+    uint64 duration;
+    /// @param referrer The referrer hash.
+    bytes32 referrer;
+}
+
 /// @notice Interface for registering ".eth" names.
-/// @dev Interface selector: `0xc1401b80`
+/// @dev Interface selector: `0x432eb5d9`
 interface IETHRegistrar is IETHRenewer {
     ////////////////////////////////////////////////////////////////////////
     // Events
@@ -72,27 +89,24 @@ interface IETHRegistrar is IETHRenewer {
     function commit(bytes32 commitment) external;
 
     /// @notice Register a name.
-    /// @param label The name from commitment.
-    /// @param owner The owner from commitment.
-    /// @param secret The secret from commitment.
-    /// @param subregistry The registry from commitment.
-    /// @param resolver The resolver from commitment.
-    /// @param duration The registration from commitment.
+    /// @param cd The commit data.
     /// @param paymentToken The payment token.
-    /// @param referrer The referrer hash.
+    /// @param refundTo The refund address if ether is used.
     /// @return The registered token ID.
-    function register(
-        string memory label,
-        address owner,
-        bytes32 secret,
-        IRegistry subregistry,
-        address resolver,
-        uint64 duration,
-        IERC20 paymentToken,
-        bytes32 referrer
-    )
+    function register(CommitData calldata cd, IERC20 paymentToken, address refundTo)
         external
+        payable
         returns (uint256);
+
+    /// @notice Register multiple names.
+    /// @param cds The commit data.
+    /// @param paymentToken The payment token.
+    /// @param refundTo The refund address if ether is used.
+    /// @return The registered token IDs.
+    function registerBatch(CommitData[] calldata cds, IERC20 paymentToken, address refundTo)
+        external
+        payable
+        returns (uint256[] memory);
 
     /// @notice Get timestamp of a prior commitment.
     /// @param commitment The commitment hash.
@@ -116,24 +130,7 @@ interface IETHRegistrar is IETHRenewer {
     function isAvailable(string memory label) external view returns (bool);
 
     /// @notice Compute hash of registration parameters.
-    /// @param label The name to register.
-    /// @param owner The owner address.
-    /// @param secret The secret for the registration.
-    /// @param subregistry The initial registry address.
-    /// @param resolver The initial resolver address.
-    /// @param duration The registration duration, in seconds.
-    /// @param referrer The referrer hash.
+    /// @param cd The commit data.
     /// @return The commitment hash.
-    function makeCommitment(
-        string calldata label,
-        address owner,
-        bytes32 secret,
-        IRegistry subregistry,
-        address resolver,
-        uint64 duration,
-        bytes32 referrer
-    )
-        external
-        pure
-        returns (bytes32);
+    function makeCommitment(CommitData calldata cd) external pure returns (bytes32);
 }

--- a/contracts/src/registrar/interfaces/IETHRenewer.sol
+++ b/contracts/src/registrar/interfaces/IETHRenewer.sol
@@ -3,8 +3,19 @@ pragma solidity >=0.8.13;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+address constant NATIVE_ETH = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE; // https://eips.ethereum.org/EIPS/eip-7528
+
+struct RenewData {
+    /// @param label The name to renew.
+    string label;
+    /// @param duration The duration extension, in seconds.
+    uint64 duration;
+    /// @param referrer The referrer hash.
+    bytes32 referrer;
+}
+
 /// @notice Interface for renewing ".eth" names.
-/// @dev Interface selector: `0x06aaeb32`
+/// @dev Interface selector: `0xca53b3c9`
 interface IETHRenewer {
     ////////////////////////////////////////////////////////////////////////
     // Events
@@ -40,17 +51,31 @@ interface IETHRenewer {
     /// @dev Error selector: `0x1caefaa0`
     error NameNotRenewable(string label);
 
+    /// @notice `account` unable to recieve ether.
+    /// @dev Error selector: `0x1c988062`
+    error ETHTransferFailed(address account);
+
+    /// @notice `supplied` ether less than `required` ether.
+    /// @dev Error selector: `0x1fbeaea0`
+    error InsufficientETH(uint256 supplied, uint256 required);
+
     ////////////////////////////////////////////////////////////////////////
     // Functions
     ////////////////////////////////////////////////////////////////////////
 
     /// @notice Renew a name.
-    /// @param label The name to renew.
-    /// @param duration The duration extension, in seconds.
+    /// @param rd The renew data.
     /// @param paymentToken The payment token.
-    /// @param referrer The referrer hash.
-    function renew(string memory label, uint64 duration, IERC20 paymentToken, bytes32 referrer)
-        external;
+    /// @param refundTo The refund address if ether is used.
+    function renew(RenewData calldata rd, IERC20 paymentToken, address refundTo) external payable;
+
+    /// @notice Renew multiple names.
+    /// @param rds The renew data.
+    /// @param paymentToken The payment token.
+    /// @param refundTo The refund address if ether is used.
+    function renewBatch(RenewData[] calldata rds, IERC20 paymentToken, address refundTo)
+        external
+        payable;
 
     /// @notice Determine renew price for a name.
     /// @param label The name to renew.

--- a/contracts/src/registrar/interfaces/IETHRenewer.sol
+++ b/contracts/src/registrar/interfaces/IETHRenewer.sol
@@ -59,6 +59,10 @@ interface IETHRenewer {
     /// @dev Error selector: `0x1fbeaea0`
     error InsufficientETH(uint256 supplied, uint256 required);
 
+    /// @notice `supplied` ether was positive.
+    /// @dev Error selector: `0x31e99b9f`
+    error UnexpectedETH(uint256 supplied);
+
     ////////////////////////////////////////////////////////////////////////
     // Functions
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/test/StandardRegistrar.sol
+++ b/contracts/test/StandardRegistrar.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 import {PaymentRatio, DiscountPoint} from "~src/registrar/StandardRentPriceOracle.sol";
-import {MockERC20} from "~test/mocks/MockERC20.sol";
 
 library StandardRegistrar {
     uint64 internal constant SEC_PER_YEAR = 365 * 1 days; // 31536000
@@ -19,6 +20,8 @@ library StandardRegistrar {
 
     uint8 internal constant PRICE_DECIMALS = 12;
     uint256 internal constant PRICE_SCALE = 10 ** PRICE_DECIMALS;
+
+    uint256 internal constant ETH_PRICE = 2000; // dollars
 
     uint256 internal constant PREMIUM_PRICE_INITIAL = 100_000_000 * PRICE_SCALE;
     uint64 internal constant PREMIUM_HALVING_PERIOD = 1 days;
@@ -81,12 +84,15 @@ library StandardRegistrar {
         return uint128((DISCOUNT_DENOMINATOR * numer + denom - 1) / denom); // round up
     }
 
-    function ratioFromStable(MockERC20 token) internal view returns (PaymentRatio memory) {
-        uint8 d = token.decimals();
-        if (d > PRICE_DECIMALS) {
-            return PaymentRatio(token, uint128(10) ** (d - PRICE_DECIMALS), 1);
+    function ratioFromParts(IERC20 token, uint8 decimals)
+        internal
+        pure
+        returns (PaymentRatio memory)
+    {
+        if (decimals > PRICE_DECIMALS) {
+            return PaymentRatio(token, uint128(10) ** (decimals - PRICE_DECIMALS), 1);
         } else {
-            return PaymentRatio(token, 1, uint128(10) ** (PRICE_DECIMALS - d));
+            return PaymentRatio(token, 1, uint128(10) ** (PRICE_DECIMALS - decimals));
         }
     }
 }

--- a/contracts/test/e2e/migration.test.ts
+++ b/contracts/test/e2e/migration.test.ts
@@ -204,7 +204,11 @@ describe("Migration", () => {
         { account },
       );
       await env.v2.ETHRenewerV1.write.renew(
-        [label, duration, env.erc20.MockUSDC.address, namehash("referrer")],
+        [
+          { label, duration, referrer: namehash("referrer") },
+          env.erc20.MockUSDC.address,
+          zeroAddress,
+        ],
         { account },
       );
     }

--- a/contracts/test/e2e/phasedMigration.test.ts
+++ b/contracts/test/e2e/phasedMigration.test.ts
@@ -268,15 +268,17 @@ describe("Phased migration rehearsal", () => {
     const referrer = zeroHash;
     const secret = zeroHash;
     const paymentToken = env.erc20.MockUSDC.address;
-
-    const commitment = await env.v2.ETHRegistrar.read.makeCommitment([
+    const commitData = {
       label,
-      account.address,
+      owner: account.address,
       secret,
       subregistry,
       resolver,
       duration,
       referrer,
+    };
+    const commitment = await env.v2.ETHRegistrar.read.makeCommitment([
+      commitData,
     ]);
     await env.v2.ETHRegistrar.write.commit([commitment], { account });
     await env.sync({ warpSec: 61 });
@@ -294,16 +296,7 @@ describe("Phased migration rehearsal", () => {
       { account },
     );
     await env.v2.ETHRegistrar.write.register(
-      [
-        label,
-        account.address,
-        secret,
-        subregistry,
-        resolver,
-        duration,
-        paymentToken,
-        referrer,
-      ],
+      [commitData, paymentToken, zeroAddress],
       { account },
     );
   }

--- a/contracts/test/fixtures/StandardRentPriceOracleFixture.sol
+++ b/contracts/test/fixtures/StandardRentPriceOracleFixture.sol
@@ -8,6 +8,8 @@ import {Test} from "forge-std/Test.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {StandardRentPriceOracle, PaymentRatio} from "~src/registrar/StandardRentPriceOracle.sol";
+import {NATIVE_ETH} from "~src/registrar/interfaces/IETHRenewer.sol";
+import {MockChainlinkAggregator} from "~test/mocks/MockChainlinkAggregator.sol";
 import {
     MockERC20,
     MockERC20Blacklist,
@@ -19,7 +21,10 @@ import {StandardRegistrar} from "~test/StandardRegistrar.sol";
 /// @dev Reusable testing fixture for StandardRentPriceOracle.
 contract StandardRentPriceOracleFixture is Test {
     StandardRentPriceOracle rentPriceOracle;
+    MockChainlinkAggregator ethOracle;
 
+    MockERC20 tokenETH = MockERC20(NATIVE_ETH);
+    MockERC20 tokenWETH;
     MockERC20 tokenUSDC;
     MockERC20 tokenDAI;
     MockERC20 tokenIdentity;
@@ -30,9 +35,11 @@ contract StandardRentPriceOracleFixture is Test {
     MockERC20[] paymentTokens;
 
     address beneficiary = makeAddr("beneficiary");
+    address refundTo = makeAddr("refundTo");
     IERC20 invalidPaymentToken = IERC20(makeAddr("invalidPaymentToken"));
 
     function deployStandardRentPriceOracleFixture() public {
+        tokenWETH = new MockERC20("WETH", 18);
         tokenUSDC = new MockERC20("USDC", 6);
         tokenDAI = new MockERC20("DAI", 18);
         tokenIdentity = new MockERC20("Identity", StandardRegistrar.PRICE_DECIMALS);
@@ -40,18 +47,24 @@ contract StandardRentPriceOracleFixture is Test {
         tokenVoid = new MockERC20VoidReturn();
         tokenFalse = new MockERC20FalseReturn();
 
-        paymentTokens = new MockERC20[](6);
+        ethOracle = new MockChainlinkAggregator(2000 * 10 ** 8, 8); // $2000
+
+        paymentTokens = new MockERC20[](7);
         paymentTokens[0] = tokenUSDC;
         paymentTokens[1] = tokenDAI;
         paymentTokens[2] = tokenIdentity;
         paymentTokens[3] = tokenBlack;
         paymentTokens[4] = tokenVoid;
         paymentTokens[5] = tokenFalse;
+        paymentTokens[6] = tokenWETH;
 
-        PaymentRatio[] memory paymentRatios = new PaymentRatio[](paymentTokens.length);
+        PaymentRatio[] memory paymentRatios = new PaymentRatio[](paymentTokens.length + 1); // room for eth
         for (uint256 i; i < paymentTokens.length; ++i) {
             paymentRatios[i] = StandardRegistrar.ratioFromStable(paymentTokens[i]);
         }
+        paymentRatios[paymentTokens.length] = StandardRegistrar.ratioFromStable(tokenWETH); // use weth
+        paymentRatios[paymentTokens.length].paymentToken = tokenETH; // replace with eth
+
         rentPriceOracle = new StandardRentPriceOracle(
             address(this),
             StandardRegistrar.getBaseRates(),
@@ -60,7 +73,9 @@ contract StandardRentPriceOracleFixture is Test {
             StandardRegistrar.PREMIUM_PRICE_INITIAL,
             StandardRegistrar.PREMIUM_HALVING_PERIOD,
             StandardRegistrar.PREMIUM_PERIOD,
-            paymentRatios
+            paymentRatios,
+            tokenWETH,
+            ethOracle
         );
 
         // give beneficiary non-zero balance
@@ -70,6 +85,7 @@ contract StandardRentPriceOracleFixture is Test {
     }
 
     function setupPaymentTokens(address owner, address approved) internal {
+        vm.deal(owner, 1e6 ether);
         for (uint256 i; i < paymentTokens.length; ++i) {
             MockERC20 token = paymentTokens[i];
             token.mint(owner, 1e9 * 10 ** token.decimals());

--- a/contracts/test/fixtures/StandardRentPriceOracleFixture.sol
+++ b/contracts/test/fixtures/StandardRentPriceOracleFixture.sol
@@ -22,6 +22,7 @@ import {StandardRegistrar} from "~test/StandardRegistrar.sol";
 contract StandardRentPriceOracleFixture is Test {
     StandardRentPriceOracle rentPriceOracle;
     MockChainlinkAggregator ethOracle;
+    MockChainlinkAggregator invalidOracle;
 
     MockERC20 tokenETH = MockERC20(NATIVE_ETH);
     MockERC20 tokenWETH;
@@ -33,6 +34,7 @@ contract StandardRentPriceOracleFixture is Test {
     MockERC20FalseReturn tokenFalse;
 
     MockERC20[] paymentTokens;
+    PaymentRatio[] paymentRatios;
 
     address beneficiary = makeAddr("beneficiary");
     address refundTo = makeAddr("refundTo");
@@ -47,7 +49,10 @@ contract StandardRentPriceOracleFixture is Test {
         tokenVoid = new MockERC20VoidReturn();
         tokenFalse = new MockERC20FalseReturn();
 
-        ethOracle = new MockChainlinkAggregator(2000 * 10 ** 8, 8); // $2000
+        uint8 decimals = 8; // arbitrary
+        uint256 ethPrice = StandardRegistrar.ETH_PRICE;
+        ethOracle = new MockChainlinkAggregator(int256(ethPrice * 10 ** decimals), decimals);
+        invalidOracle = new MockChainlinkAggregator(0, 0);
 
         paymentTokens = new MockERC20[](7);
         paymentTokens[0] = tokenUSDC;
@@ -58,12 +63,11 @@ contract StandardRentPriceOracleFixture is Test {
         paymentTokens[5] = tokenFalse;
         paymentTokens[6] = tokenWETH;
 
-        PaymentRatio[] memory paymentRatios = new PaymentRatio[](paymentTokens.length + 1); // room for eth
         for (uint256 i; i < paymentTokens.length; ++i) {
-            paymentRatios[i] = StandardRegistrar.ratioFromStable(paymentTokens[i]);
+            MockERC20 token = paymentTokens[i];
+            paymentRatios.push(StandardRegistrar.ratioFromParts(token, token.decimals()));
         }
-        paymentRatios[paymentTokens.length] = StandardRegistrar.ratioFromStable(tokenWETH); // use weth
-        paymentRatios[paymentTokens.length].paymentToken = tokenETH; // replace with eth
+        paymentRatios.push(StandardRegistrar.ratioFromParts(tokenETH, 18));
 
         rentPriceOracle = new StandardRentPriceOracle(
             address(this),

--- a/contracts/test/mocks/MockChainlinkAggregator.sol
+++ b/contracts/test/mocks/MockChainlinkAggregator.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IChainlinkAggregator} from "~src/registrar/interfaces/IChainlinkAggregator.sol";
+
+contract MockChainlinkAggregator is IChainlinkAggregator {
+    int256 public immutable ANSWER;
+    uint8 public immutable DECIMALS;
+    constructor(int256 answer, uint8 _decimals) {
+        ANSWER = answer;
+        DECIMALS = _decimals;
+    }
+    function latestAnswer() external view returns (int256) {
+        return ANSWER;
+    }
+    function decimals() external view returns (uint8) {
+        return DECIMALS;
+    }
+}

--- a/contracts/test/unit/registrar/ETHRegistrar.t.sol
+++ b/contracts/test/unit/registrar/ETHRegistrar.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-// solhint-disable no-console, private-vars-leading-underscore, state-visibility, func-name-mixedcase, contracts-v2/ordering, one-contract-per-file
-
 import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
@@ -13,8 +11,8 @@ import {LibLabel} from "~src/utils/LibLabel.sol";
 import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
 import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
-import {IETHRegistrar} from "~src/registrar/interfaces/IETHRegistrar.sol";
-import {IETHRenewer} from "~src/registrar/interfaces/IETHRenewer.sol";
+import {IETHRegistrar, CommitData} from "~src/registrar/interfaces/IETHRegistrar.sol";
+import {IETHRenewer, RenewData} from "~src/registrar/interfaces/IETHRenewer.sol";
 import {ETHRegistrar, REGISTRATION_ROLE_BITMAP} from "~src/registrar/ETHRegistrar.sol";
 import {MockERC20, MockERC20Blacklist} from "~test/mocks/MockERC20.sol";
 import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixture.sol";
@@ -173,13 +171,7 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
     }
 
     function test_register(uint32 available, uint32 duration) external {
-        vm.assume(
-            duration >= ethRegistrar.MIN_REGISTER_DURATION() &&
-            available < 2 * rentPriceOracle.PREMIUM_PERIOD()
-        );
-        vm.warp(ethRegistry.getExpiry(this.register()) + ethRegistrar.GRACE_PERIOD() + available);
-
-        testDuration = duration;
+        _ensurePriorRegistration(available, duration);
         (uint256 base, uint256 premium) =
             rentPriceOracle.getRegisterPrice(
                 testLabel,
@@ -221,11 +213,7 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
     }
 
     function test_register_balanceChanges(uint32 available, uint32 duration) external {
-        vm.assume(
-            duration >= ethRegistrar.MIN_REGISTER_DURATION() &&
-            available < 2 * rentPriceOracle.PREMIUM_PERIOD()
-        );
-        vm.warp(ethRegistry.getExpiry(this.register()) + ethRegistrar.GRACE_PERIOD() + available);
+        _ensurePriorRegistration(available, duration);
         uint256 owner0 = testPaymentToken.balanceOf(testOwner);
         uint256 beneficiary0 = testPaymentToken.balanceOf(beneficiary);
         (uint256 base, uint256 premium) =
@@ -235,11 +223,57 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
                 duration,
                 testPaymentToken
             );
-        testDuration = duration;
         this.register();
         uint256 amount = base + premium;
-        assertEq(owner0 - amount, testPaymentToken.balanceOf(testOwner), "owner");
+        assertEq(owner0 - amount, testPaymentToken.balanceOf(testOwner), "payer");
         assertEq(beneficiary0 + amount, testPaymentToken.balanceOf(beneficiary), "beneficiary");
+    }
+
+    function test_register_eth(uint32 available, uint32 duration) external {
+        _ensurePriorRegistration(available, duration);
+        (uint256 base, uint256 premium) =
+            rentPriceOracle.getRegisterPrice(
+                testLabel,
+                available + testCommitDelay, // commit-reveal
+                testDuration,
+                tokenETH
+            );
+        uint256 amount = base + premium;
+        uint256 overpay = amount / 100;
+        ethRegistrar.commit(_makeCommitment());
+        vm.warp(block.timestamp + testCommitDelay);
+        uint256 owner0 = testOwner.balance;
+        uint256 beneficiary0 = beneficiary.balance;
+        vm.prank(testOwner);
+        ethRegistrar.register{value: amount + overpay}(_commitData(), tokenETH, refundTo);
+        assertEq(owner0 - amount - overpay, testOwner.balance, "payer");
+        assertEq(beneficiary0 + amount, beneficiary.balance, "beneficiary");
+        assertEq(overpay, refundTo.balance, "refund");
+    }
+
+    function test_register_eth_insufficientETH() external {
+        (uint256 base, uint256 premium) =
+            rentPriceOracle.getRegisterPrice(testLabel, type(uint64).max, testDuration, tokenETH);
+        uint256 amount = base + premium;
+        ethRegistrar.commit(_makeCommitment());
+        vm.warp(block.timestamp + testCommitDelay);
+        vm.expectRevert(
+            abi.encodeWithSelector(IETHRenewer.InsufficientETH.selector, amount - 1, amount)
+        );
+        vm.prank(testOwner);
+        ethRegistrar.register{value: amount - 1}(
+            CommitData(
+                testLabel,
+                testOwner,
+                testSecret,
+                testRegistry,
+                testResolver,
+                testDuration,
+                testReferrer
+            ),
+            tokenETH,
+            address(0)
+        );
     }
 
     function test_register_whileRegistered(uint32 duration) external {
@@ -435,9 +469,9 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
         uint256 owner0 = testPaymentToken.balanceOf(testOwner);
         uint256 beneficiary0 = testPaymentToken.balanceOf(beneficiary);
         uint256 amount = ethRegistrar.getRenewPrice(testLabel, duration, testPaymentToken);
-        vm.prank(testOwner);
-        ethRegistrar.renew(testLabel, duration, testPaymentToken, testReferrer);
-        assertEq(owner0 - amount, testPaymentToken.balanceOf(testOwner), "owner");
+        testDuration = duration;
+        this.renew();
+        assertEq(owner0 - amount, testPaymentToken.balanceOf(testOwner), "payer");
         assertEq(beneficiary0 + amount, testPaymentToken.balanceOf(beneficiary), "beneficiary");
     }
 
@@ -499,6 +533,38 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
             )
         );
         this.renew();
+    }
+
+    function test_renew_eth(uint32 duration) external {
+        vm.assume(duration >= ethRegistrar.MIN_RENEW_DURATION());
+        this.register();
+        uint256 owner0 = testOwner.balance;
+        uint256 beneficiary0 = beneficiary.balance;
+        uint256 amount = ethRegistrar.getRenewPrice(testLabel, duration, tokenETH);
+        uint256 overpay = amount / 100;
+        vm.prank(testOwner);
+        ethRegistrar.renew{value: amount + overpay}(
+            RenewData(testLabel, duration, testReferrer),
+            tokenETH,
+            refundTo
+        );
+        assertEq(owner0 - amount - overpay, testOwner.balance, "payer");
+        assertEq(beneficiary0 + amount, beneficiary.balance, "beneficiary");
+        assertEq(overpay, refundTo.balance, "refund");
+    }
+
+    function test_renew_eth_insufficientETH() external {
+        this.register();
+        uint256 amount = ethRegistrar.getRenewPrice(testLabel, testDuration, tokenETH);
+        vm.prank(testOwner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IETHRenewer.InsufficientETH.selector, amount - 1, amount)
+        );
+        ethRegistrar.renew{value: amount - 1}(
+            RenewData(testLabel, testDuration, testReferrer),
+            tokenETH,
+            address(0)
+        );
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -568,9 +634,9 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
     // Helpers
     ////////////////////////////////////////////////////////////////////////
 
-    function _makeCommitment() internal view returns (bytes32) {
+    function _commitData() internal view returns (CommitData memory) {
         return
-            ethRegistrar.makeCommitment(
+            CommitData(
                 testLabel,
                 testOwner,
                 testSecret,
@@ -581,24 +647,32 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
             );
     }
 
+    function _makeCommitment() internal view returns (bytes32) {
+        return ethRegistrar.makeCommitment(_commitData());
+    }
+
     function register() external returns (uint256 tokenId) {
         ethRegistrar.commit(_makeCommitment());
         vm.warp(block.timestamp + testCommitDelay);
         vm.prank(testOwner);
-        tokenId = ethRegistrar.register(
-            testLabel,
-            testOwner,
-            testSecret,
-            testRegistry,
-            testResolver,
-            testDuration,
-            testPaymentToken,
-            testReferrer
-        );
+        tokenId = ethRegistrar.register(_commitData(), testPaymentToken, address(0));
     }
 
     function renew() external {
         vm.prank(testOwner);
-        ethRegistrar.renew(testLabel, testDuration, testPaymentToken, testReferrer);
+        ethRegistrar.renew(
+            RenewData(testLabel, testDuration, testReferrer),
+            testPaymentToken,
+            address(0)
+        );
+    }
+
+    function _ensurePriorRegistration(uint64 available, uint64 duration) internal {
+        vm.assume(
+            duration >= ethRegistrar.MIN_REGISTER_DURATION() &&
+            available < 2 * rentPriceOracle.PREMIUM_PERIOD()
+        );
+        vm.warp(ethRegistry.getExpiry(this.register()) + ethRegistrar.GRACE_PERIOD() + available);
+        testDuration = duration;
     }
 }

--- a/contracts/test/unit/registrar/ETHRegistrar.t.sol
+++ b/contracts/test/unit/registrar/ETHRegistrar.t.sol
@@ -652,10 +652,10 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
     function test_renew_eth_insufficientETH() external {
         this.register();
         uint256 amount = ethRegistrar.getRenewPrice(testLabel, testDuration, tokenETH);
-        vm.prank(testOwner);
         vm.expectRevert(
             abi.encodeWithSelector(IETHRenewer.InsufficientETH.selector, amount - 1, amount)
         );
+        vm.prank(testOwner);
         ethRegistrar.renew{value: amount - 1}(
             RenewData(testLabel, testDuration, testReferrer),
             tokenETH,

--- a/contracts/test/unit/registrar/ETHRegistrar.t.sol
+++ b/contracts/test/unit/registrar/ETHRegistrar.t.sol
@@ -118,7 +118,7 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
     ////////////////////////////////////////////////////////////////////////
 
     function test_commit() external {
-        bytes32 commitment = _makeCommitment();
+        bytes32 commitment = ethRegistrar.makeCommitment(_commitData());
         assertEq(
             commitment,
             keccak256(
@@ -157,7 +157,7 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
     }
 
     function test_commit_consumed() external {
-        bytes32 commitment = _makeCommitment();
+        bytes32 commitment = ethRegistrar.makeCommitment(_commitData());
         this.register();
         assertEq(ethRegistrar.commitmentAt(commitment), 0);
     }
@@ -240,7 +240,7 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
             );
         uint256 amount = base + premium;
         uint256 overpay = amount / 100;
-        ethRegistrar.commit(_makeCommitment());
+        ethRegistrar.commit(ethRegistrar.makeCommitment(_commitData()));
         vm.warp(block.timestamp + testCommitDelay);
         uint256 owner0 = testOwner.balance;
         uint256 beneficiary0 = beneficiary.balance;
@@ -255,7 +255,7 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
         (uint256 base, uint256 premium) =
             rentPriceOracle.getRegisterPrice(testLabel, type(uint64).max, testDuration, tokenETH);
         uint256 amount = base + premium;
-        ethRegistrar.commit(_makeCommitment());
+        ethRegistrar.commit(ethRegistrar.makeCommitment(_commitData()));
         vm.warp(block.timestamp + testCommitDelay);
         vm.expectRevert(
             abi.encodeWithSelector(IETHRenewer.InsufficientETH.selector, amount - 1, amount)
@@ -272,6 +272,72 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
                 testReferrer
             ),
             tokenETH,
+            address(0)
+        );
+    }
+
+    function test_register_eth_transferFailed_beneficiary() external {
+        vm.etch(beneficiary, address(ethRegistry).code); // no receive()
+        (uint256 base, uint256 premium) =
+            rentPriceOracle.getRegisterPrice(testLabel, type(uint64).max, testDuration, tokenETH);
+        ethRegistrar.commit(ethRegistrar.makeCommitment(_commitData()));
+        vm.warp(block.timestamp + testCommitDelay);
+        vm.expectRevert(abi.encodeWithSelector(IETHRenewer.ETHTransferFailed.selector, beneficiary));
+        vm.prank(testOwner);
+        ethRegistrar.register{value: base + premium}(
+            CommitData(
+                testLabel,
+                testOwner,
+                testSecret,
+                testRegistry,
+                testResolver,
+                testDuration,
+                testReferrer
+            ),
+            tokenETH,
+            refundTo
+        );
+    }
+
+    function test_register_eth_transferFailed_refund() external {
+        vm.etch(refundTo, address(ethRegistry).code); // no receive()
+        (uint256 base, uint256 premium) =
+            rentPriceOracle.getRegisterPrice(testLabel, type(uint64).max, testDuration, tokenETH);
+        ethRegistrar.commit(ethRegistrar.makeCommitment(_commitData()));
+        vm.warp(block.timestamp + testCommitDelay);
+        vm.expectRevert(abi.encodeWithSelector(IETHRenewer.ETHTransferFailed.selector, refundTo));
+        vm.prank(testOwner);
+        ethRegistrar.register{value: base + premium + 1}(
+            CommitData(
+                testLabel,
+                testOwner,
+                testSecret,
+                testRegistry,
+                testResolver,
+                testDuration,
+                testReferrer
+            ),
+            tokenETH,
+            refundTo
+        );
+    }
+
+    function test_register_unexpectedETH() external {
+        ethRegistrar.commit(ethRegistrar.makeCommitment(_commitData()));
+        vm.warp(block.timestamp + testCommitDelay);
+        vm.expectRevert(abi.encodeWithSelector(IETHRenewer.UnexpectedETH.selector, 1));
+        vm.prank(testOwner);
+        ethRegistrar.register{value: 1}(
+            CommitData(
+                testLabel,
+                testOwner,
+                testSecret,
+                testRegistry,
+                testResolver,
+                testDuration,
+                testReferrer
+            ),
+            testPaymentToken,
             address(0)
         );
     }
@@ -380,7 +446,7 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
         vm.expectRevert(
             abi.encodeWithSelector(
                 IETHRegistrar.CommitmentTooNew.selector,
-                _makeCommitment(),
+                ethRegistrar.makeCommitment(_commitData()),
                 t + dt,
                 t
             )
@@ -395,7 +461,7 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
         vm.expectRevert(
             abi.encodeWithSelector(
                 IETHRegistrar.CommitmentTooOld.selector,
-                _makeCommitment(),
+                ethRegistrar.makeCommitment(_commitData()),
                 t - dt,
                 t
             )
@@ -431,6 +497,36 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
         assertFalse(ethRegistrar.isRenewable(testLabel), "isRenewable");
         vm.expectRevert(abi.encodeWithSelector(IETHRegistrar.NameNotAvailable.selector, testLabel));
         this.register();
+    }
+
+    function test_registerBatch(uint8 n) external {
+        vm.assume(n < 10);
+        CommitData[] memory cds = new CommitData[](n);
+        uint256 total;
+        for (uint256 i; i < n; ++i) {
+            testLabel = _label(i);
+            cds[i] = _commitData();
+            ethRegistrar.commit(ethRegistrar.makeCommitment(cds[i]));
+            (uint256 base, uint256 premium) =
+                rentPriceOracle.getRegisterPrice(
+                    testLabel,
+                    type(uint64).max,
+                    testDuration,
+                    testPaymentToken
+                );
+            total += base + premium;
+        }
+        vm.warp(block.timestamp + testCommitDelay);
+        uint256 owner0 = testPaymentToken.balanceOf(testOwner);
+        uint256 beneficiary0 = testPaymentToken.balanceOf(beneficiary);
+        vm.prank(testOwner);
+        uint256[] memory tokenIds = ethRegistrar.registerBatch(cds, testPaymentToken, address(0));
+        assertEq(owner0 - total, testPaymentToken.balanceOf(testOwner), "payer");
+        assertEq(beneficiary0 + total, testPaymentToken.balanceOf(beneficiary), "beneficiary");
+        assertEq(tokenIds.length, n, "tokens");
+        for (uint256 i; i < n; ++i) {
+            assertEq(ethRegistry.ownerOf(tokenIds[i]), testOwner);
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -567,6 +663,37 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
         );
     }
 
+    function test_renewBatch(uint8 n) external {
+        vm.assume(n < 10);
+        RenewData[] memory rds = new RenewData[](n);
+        uint256 total;
+        for (uint256 i; i < n; ++i) {
+            testLabel = _label(i);
+            this.register();
+            uint64 duration = testDuration + uint64(i);
+            rds[i] = RenewData(testLabel, duration, testReferrer);
+            total += ethRegistrar.getRenewPrice(testLabel, duration, testPaymentToken);
+        }
+        uint256 owner0 = testPaymentToken.balanceOf(testOwner);
+        uint256 beneficiary0 = testPaymentToken.balanceOf(beneficiary);
+        vm.prank(testOwner);
+        ethRegistrar.renewBatch(rds, testPaymentToken, address(0));
+        assertEq(owner0 - total, testPaymentToken.balanceOf(testOwner), "payer");
+        assertEq(beneficiary0 + total, testPaymentToken.balanceOf(beneficiary), "beneficiary");
+    }
+
+    function test_renewBatch_repeated() external {
+        uint256 tokenId = this.register();
+        RenewData[] memory rds = new RenewData[](2);
+        for (uint256 i; i < rds.length; ++i) {
+            rds[i] = RenewData(testLabel, testDuration, testReferrer);
+        }
+        uint64 expiry = ethRegistry.getExpiry(tokenId);
+        vm.prank(testOwner);
+        ethRegistrar.renewBatch(rds, testPaymentToken, address(0));
+        assertEq(ethRegistry.getExpiry(tokenId), expiry + testDuration * rds.length);
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // Payment Processing
     ////////////////////////////////////////////////////////////////////////
@@ -647,12 +774,8 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
             );
     }
 
-    function _makeCommitment() internal view returns (bytes32) {
-        return ethRegistrar.makeCommitment(_commitData());
-    }
-
     function register() external returns (uint256 tokenId) {
-        ethRegistrar.commit(_makeCommitment());
+        ethRegistrar.commit(ethRegistrar.makeCommitment(_commitData()));
         vm.warp(block.timestamp + testCommitDelay);
         vm.prank(testOwner);
         tokenId = ethRegistrar.register(_commitData(), testPaymentToken, address(0));

--- a/contracts/test/unit/registrar/ETHRenewerV1.t.sol
+++ b/contracts/test/unit/registrar/ETHRenewerV1.t.sol
@@ -275,7 +275,7 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
             testPaymentToken,
             address(0)
         );
-        assertEq(owner0 - amount, testPaymentToken.balanceOf(testOwner), "owner");
+        assertEq(owner0 - amount, testPaymentToken.balanceOf(testOwner), "payer");
         assertEq(beneficiary0 + amount, testPaymentToken.balanceOf(beneficiary), "beneficiary");
     }
 
@@ -362,6 +362,37 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
             tokenETH,
             refundTo
         );
+    }
+
+    function test_renewBatch(uint8 n) external {
+        vm.assume(n < 10);
+        RenewData[] memory rds = new RenewData[](n);
+        uint256 total;
+        for (uint256 i; i < n; ++i) {
+            string memory label = _label(i);
+            registerUnwrapped(label);
+            uint64 duration = testDuration + uint64(i);
+            rds[i] = RenewData(label, duration, testReferrer);
+            total += ethRenewerV1.getRenewPrice(label, duration, testPaymentToken);
+        }
+        uint256 owner0 = testPaymentToken.balanceOf(testOwner);
+        uint256 beneficiary0 = testPaymentToken.balanceOf(beneficiary);
+        vm.prank(testOwner);
+        ethRenewerV1.renewBatch(rds, testPaymentToken, address(0));
+        assertEq(owner0 - total, testPaymentToken.balanceOf(testOwner), "payer");
+        assertEq(beneficiary0 + total, testPaymentToken.balanceOf(beneficiary), "beneficiary");
+    }
+
+    function test_renewBatch_repeated() external {
+        (, uint256 tokenIdV1) = registerUnwrapped(testLabel);
+        RenewData[] memory rds = new RenewData[](2);
+        for (uint256 i; i < rds.length; ++i) {
+            rds[i] = RenewData(testLabel, testDuration, testReferrer);
+        }
+        uint256 expiry = baseRegistrar.nameExpires(tokenIdV1);
+        vm.prank(testOwner);
+        ethRenewerV1.renewBatch(rds, testPaymentToken, address(0));
+        assertEq(baseRegistrar.nameExpires(tokenIdV1), expiry + testDuration * rds.length);
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/test/unit/registrar/ETHRenewerV1.t.sol
+++ b/contracts/test/unit/registrar/ETHRenewerV1.t.sol
@@ -11,7 +11,7 @@ import {IBaseRegistrar} from "@ens/contracts/ethregistrar/IBaseRegistrar.sol";
 import {LibLabel} from "~src/utils/LibLabel.sol";
 import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
-import {IETHRenewer} from "~src/registrar/interfaces/IETHRenewer.sol";
+import {IETHRenewer, RenewData} from "~src/registrar/interfaces/IETHRenewer.sol";
 import {ETHRenewerV1} from "~src/registrar/ETHRenewerV1.sol";
 import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixture.sol";
 import {StandardRentPriceOracleFixture} from "~test/fixtures/StandardRentPriceOracleFixture.sol";
@@ -135,7 +135,11 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
         );
         vm.prank(testOwner);
         uint256 g = gasleft();
-        ethRenewerV1.renew(testLabel, testDuration, testPaymentToken, testReferrer);
+        ethRenewerV1.renew(
+            RenewData(testLabel, testDuration, testReferrer),
+            testPaymentToken,
+            address(0)
+        );
         g -= gasleft();
         console.log("Gas: %s", g);
     }
@@ -150,7 +154,11 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
         uint256 expiryV1 = baseRegistrar.nameExpires(tokenIdV1);
         uint64 expiryV2 = ethRegistry.getExpiry(tokenIdV1);
         vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, duration, testPaymentToken, testReferrer);
+        ethRenewerV1.renew(
+            RenewData(testLabel, duration, testReferrer),
+            testPaymentToken,
+            address(0)
+        );
 
         assertEq(uint8(getStatusV1(tokenIdV1)), uint8(StatusV1.REGISTERED), "status"); // same
         assertEq(baseRegistrar.nameExpires(tokenIdV1), expiryV1 + duration, "expiryV1");
@@ -180,7 +188,11 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
 
         uint64 duration = gracePeriodV1;
         vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, duration, testPaymentToken, testReferrer);
+        ethRenewerV1.renew(
+            RenewData(testLabel, duration, testReferrer),
+            testPaymentToken,
+            address(0)
+        );
 
         assertEq(uint8(getStatusV1(tokenIdV1)), uint8(StatusV1.REGISTERED), "status");
         assertEq(ethRenewerV1.getRemainingGracePeriod(testLabel), 0, "remaining");
@@ -209,7 +221,11 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
         assertTrue(ethRenewerV1.isRenewable(testLabel), "isRenewable");
 
         vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, duration, testPaymentToken, testReferrer);
+        ethRenewerV1.renew(
+            RenewData(testLabel, duration, testReferrer),
+            testPaymentToken,
+            address(0)
+        );
 
         assertEq(uint8(getStatusV1(tokenIdV1)), uint8(StatusV1.GRACE), "status"); // still
         assertEq(
@@ -237,7 +253,11 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
         uint64 duration = ethRenewerV1.MIN_RENEW_DURATION();
         vm.expectRevert(abi.encodeWithSelector(IETHRenewer.NameNotRenewable.selector, testLabel));
         vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, duration, testPaymentToken, testReferrer);
+        ethRenewerV1.renew(
+            RenewData(testLabel, duration, testReferrer),
+            testPaymentToken,
+            address(0)
+        );
     }
 
     function test_renew_balanceChanges(uint32 during, uint32 duration) external {
@@ -250,7 +270,11 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
         uint256 beneficiary0 = testPaymentToken.balanceOf(beneficiary);
         uint256 amount = ethRenewerV1.getRenewPrice(testLabel, duration, testPaymentToken);
         vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, duration, testPaymentToken, testReferrer);
+        ethRenewerV1.renew(
+            RenewData(testLabel, duration, testReferrer),
+            testPaymentToken,
+            address(0)
+        );
         assertEq(owner0 - amount, testPaymentToken.balanceOf(testOwner), "owner");
         assertEq(beneficiary0 + amount, testPaymentToken.balanceOf(beneficiary), "beneficiary");
     }
@@ -261,7 +285,11 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
         registerUnwrapped(testLabel);
         vm.expectRevert(abi.encodeWithSelector(IETHRenewer.DurationTooShort.selector, duration, min));
         vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, duration, testPaymentToken, testReferrer);
+        ethRenewerV1.renew(
+            RenewData(testLabel, duration, testReferrer),
+            testPaymentToken,
+            address(0)
+        );
     }
 
     function test_renew_insufficientAllowance() external {
@@ -278,7 +306,11 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
             )
         );
         vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, testDuration, testPaymentToken, testReferrer);
+        ethRenewerV1.renew(
+            RenewData(testLabel, testDuration, testReferrer),
+            testPaymentToken,
+            address(0)
+        );
     }
 
     function test_renew_insufficientBalance() external {
@@ -294,7 +326,42 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
             )
         );
         vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, testDuration, testPaymentToken, testReferrer);
+        ethRenewerV1.renew(
+            RenewData(testLabel, testDuration, testReferrer),
+            testPaymentToken,
+            address(0)
+        );
+    }
+
+    function test_renew_eth() external {
+        registerUnwrapped(testLabel);
+        uint256 amount = ethRenewerV1.getRenewPrice(testLabel, testDuration, tokenETH);
+        uint256 overpay = amount / 100;
+        uint256 owner0 = testOwner.balance;
+        uint256 beneficiary0 = beneficiary.balance;
+        vm.prank(testOwner);
+        ethRenewerV1.renew{value: amount + overpay}(
+            RenewData(testLabel, testDuration, testReferrer),
+            tokenETH,
+            refundTo
+        );
+        assertEq(owner0 - amount - overpay, testOwner.balance, "payer");
+        assertEq(beneficiary0 + amount, beneficiary.balance, "beneficiary");
+        assertEq(overpay, refundTo.balance, "refund");
+    }
+
+    function test_renew_eth_insufficientETH() external {
+        registerUnwrapped(testLabel);
+        uint256 amount = ethRenewerV1.getRenewPrice(testLabel, testDuration, tokenETH);
+        vm.expectRevert(
+            abi.encodeWithSelector(IETHRenewer.InsufficientETH.selector, amount - 1, amount)
+        );
+        vm.prank(testOwner);
+        ethRenewerV1.renew{value: amount - 1}(
+            RenewData(testLabel, testDuration, testReferrer),
+            tokenETH,
+            refundTo
+        );
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/test/unit/registrar/StandardRentPriceOracle.t.sol
+++ b/contracts/test/unit/registrar/StandardRentPriceOracle.t.sol
@@ -249,8 +249,12 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
         (uint128 numer1, uint128 denom1) = rentPriceOracle.getPaymentTokenRatio(tokenWETH);
         assertEq(numer0, numer1, "same numer");
         assertEq(denom0, denom1, "same denom");
-        assertEq(numer1, 10 ** (18 - StandardRegistrar.PRICE_DECIMALS), "numer");
-        assertEq(denom0, 1, "denom");
+        assertEq(
+            numer1,
+            10 ** (tokenWETH.decimals() + ethOracle.decimals() - StandardRegistrar.PRICE_DECIMALS),
+            "numer"
+        );
+        assertEq(denom1, uint256(ethOracle.latestAnswer()), "denom");
     }
 
     function test_updatePaymentToken_add() external {

--- a/contracts/test/unit/registrar/StandardRentPriceOracle.t.sol
+++ b/contracts/test/unit/registrar/StandardRentPriceOracle.t.sol
@@ -233,7 +233,7 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
 
     function test_getPaymentTokenRatio_exists() external view {
         (uint128 numer, uint128 denom) = rentPriceOracle.getPaymentTokenRatio(tokenUSDC);
-        PaymentRatio memory pr = StandardRegistrar.ratioFromStable(tokenUSDC);
+        PaymentRatio memory pr = StandardRegistrar.ratioFromParts(tokenUSDC, tokenUSDC.decimals());
         assertEq(numer, pr.numer, "numer");
         assertEq(denom, pr.denom, "denom");
     }
@@ -493,6 +493,55 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
             StandardRegistrar.MIN_REGISTER_DURATION,
             invalidPaymentToken
         );
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Chainlink Oracle
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_ethOracle() external view {
+        assertEq(
+            uint256(ethOracle.latestAnswer()),
+            StandardRegistrar.ETH_PRICE * 10 ** ethOracle.decimals()
+        );
+    }
+
+    function test_ethOracle_null() external {
+        StandardRentPriceOracle oracle =
+            new StandardRentPriceOracle(
+                address(this),
+                StandardRegistrar.getBaseRates(),
+                StandardRegistrar.getDiscountPoints(),
+                StandardRegistrar.DISCOUNT_DENOMINATOR,
+                StandardRegistrar.PREMIUM_PRICE_INITIAL,
+                StandardRegistrar.PREMIUM_HALVING_PERIOD,
+                StandardRegistrar.PREMIUM_PERIOD,
+                paymentRatios,
+                tokenWETH,
+                IChainlinkAggregator(address(0))
+            );
+        (uint128 numer, uint128 denom) = oracle.getPaymentTokenRatio(tokenETH);
+        assertEq(numer, 0, "numer");
+        assertEq(denom, 0, "denom");
+    }
+
+    function test_ethOracle_invalidAnswer() external {
+        StandardRentPriceOracle oracle =
+            new StandardRentPriceOracle(
+                address(this),
+                StandardRegistrar.getBaseRates(),
+                StandardRegistrar.getDiscountPoints(),
+                StandardRegistrar.DISCOUNT_DENOMINATOR,
+                StandardRegistrar.PREMIUM_PRICE_INITIAL,
+                StandardRegistrar.PREMIUM_HALVING_PERIOD,
+                StandardRegistrar.PREMIUM_PERIOD,
+                paymentRatios,
+                tokenWETH,
+                invalidOracle
+            );
+        (uint128 numer, uint128 denom) = oracle.getPaymentTokenRatio(tokenETH);
+        assertEq(numer, 0, "numer");
+        assertEq(denom, 0, "denom");
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/test/unit/registrar/StandardRentPriceOracle.t.sol
+++ b/contracts/test/unit/registrar/StandardRentPriceOracle.t.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-// solhint-disable no-console, private-vars-leading-underscore, state-visibility, func-name-mixedcase, contracts-v2/ordering, one-contract-per-file
-
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
@@ -22,6 +20,7 @@ import {
     ROLE_CAN_NAME,
     ROLE_CAN_NAME_ADMIN
 } from "~src/registrar/StandardRentPriceOracle.sol";
+import {IChainlinkAggregator} from "~src/registrar/interfaces/IChainlinkAggregator.sol";
 import {StandardRentPriceOracleFixture} from "~test/fixtures/StandardRentPriceOracleFixture.sol";
 import {StandardRegistrar} from "~test/StandardRegistrar.sol";
 
@@ -110,7 +109,9 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
             0,
             0,
             0,
-            v
+            v,
+            IERC20(address(0)),
+            IChainlinkAggregator(address(0))
         );
     }
 
@@ -124,7 +125,9 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
             0,
             0,
             0,
-            new PaymentRatio[](0)
+            new PaymentRatio[](0),
+            IERC20(address(0)),
+            IChainlinkAggregator(address(0))
         );
     }
 
@@ -141,7 +144,9 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
             0,
             0,
             0,
-            new PaymentRatio[](0)
+            new PaymentRatio[](0),
+            IERC20(address(0)),
+            IChainlinkAggregator(address(0))
         );
     }
 
@@ -158,7 +163,9 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
             0,
             0,
             0,
-            new PaymentRatio[](0)
+            new PaymentRatio[](0),
+            IERC20(address(0)),
+            IChainlinkAggregator(address(0))
         );
     }
 
@@ -174,7 +181,9 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
             0,
             0,
             0,
-            new PaymentRatio[](0)
+            new PaymentRatio[](0),
+            IERC20(address(0)),
+            IChainlinkAggregator(address(0))
         );
     }
 
@@ -190,7 +199,9 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
             0,
             0,
             0,
-            new PaymentRatio[](0)
+            new PaymentRatio[](0),
+            IERC20(address(0)),
+            IChainlinkAggregator(address(0))
         );
     }
 
@@ -206,7 +217,9 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
             0,
             0,
             0,
-            v
+            v,
+            IERC20(address(0)),
+            IChainlinkAggregator(address(0))
         );
     }
 
@@ -229,6 +242,15 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
         (uint128 numer, uint128 denom) = rentPriceOracle.getPaymentTokenRatio(invalidPaymentToken);
         assertEq(numer, 0, "numer");
         assertEq(denom, 0, "denom");
+    }
+
+    function test_getPaymentTokenRatio_eth() external view {
+        (uint128 numer0, uint128 denom0) = rentPriceOracle.getPaymentTokenRatio(tokenETH);
+        (uint128 numer1, uint128 denom1) = rentPriceOracle.getPaymentTokenRatio(tokenWETH);
+        assertEq(numer0, numer1, "same numer");
+        assertEq(denom0, denom1, "same denom");
+        assertEq(numer1, 10 ** (18 - StandardRegistrar.PRICE_DECIMALS), "numer");
+        assertEq(denom0, 1, "denom");
     }
 
     function test_updatePaymentToken_add() external {
@@ -370,7 +392,9 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
                 256000,
                 1,
                 8,
-                new PaymentRatio[](0)
+                new PaymentRatio[](0),
+                IERC20(address(0)),
+                IChainlinkAggregator(address(0))
             );
         assertEq(oracle.getPremiumPriceAfter(0), 255000, "0");
         assertEq(oracle.getPremiumPriceAfter(1), 127000, "1");
@@ -436,8 +460,9 @@ contract StandardRentPriceOracleTest is StandardRentPriceOracleFixture {
         string memory label = new string(vm.randomUint(3, 255));
         uint64 duration = uint64(vm.randomUint(1, 10000 days));
         IERC20 paymentToken = randomPaymentToken();
+        uint256 price = rentPriceOracle.getRenewPrice(label, UNUSED_EXPIRY, duration, paymentToken);
         assertEq(
-            rentPriceOracle.getRenewPrice(label, UNUSED_EXPIRY, duration, paymentToken),
+            price,
             rentPriceOracle.convertUnits(rentPriceOracle.getBasePrice(label, duration), paymentToken)
         );
     }


### PR DESCRIPTION
- changed `IETHRegistrar` and `IETHRenewer` to use structs and support payable
    * use `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` for ether
- added `ETHRegistrar.registerBatch()` and `ETHRenewer.renewBatch()`
- added `IChainlinkAggregator`

---

TODO: change to v3 aggregator function