### PR TITLE
Expand migration docs and add devnet pre-migration tooling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,5 +36,6 @@
     "**/artifacts": true,
     "**/build": true,
     "**/deployments": true
-  }
+  },
+  "js/ts.experimental.useTsgo": true
 }

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.11",
         "husky": "^9.1.7",
-        "typescript": "^5.8.3",
+        "typescript": "^7.0.2",
       },
     },
     "contracts": {
@@ -41,12 +41,11 @@
         "chai": "^5.1.1",
         "ethers": "^6.15.0",
         "solgrid": "0.0.16",
-        "ts-node": "^10.9.2",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "3.1.3",
       },
       "peerDependencies": {
-        "typescript": "^5.8.3",
+        "typescript": "^7.0.2",
       },
     },
   },
@@ -77,8 +76,6 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
-
-    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
     "@ensdomains/address-encoder": ["@ensdomains/address-encoder@1.1.4", "", { "dependencies": { "@noble/curves": "^1.2.0", "@noble/hashes": "^1.3.2", "@scure/base": "^1.1.5" } }, "sha512-hBY6VxVw9A1cMPOKDIvPB2nlmgaw2dvrrj/p/9tkGWmD+qdfKYZTdZuSdFcUGxhhzEB4HeLG/a98ytlTq84KcA=="],
 
@@ -138,11 +135,7 @@
 
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
-    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
-
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
-
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@leichtgewicht/ip-codec": ["@leichtgewicht/ip-codec@2.0.5", "", {}, "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="],
 
@@ -288,14 +281,6 @@
 
     "@streamparser/json-node": ["@streamparser/json-node@0.0.22", "", { "dependencies": { "@streamparser/json": "^0.0.22" } }, "sha512-sJT2ptNRwqB1lIsQrQlCoWk5rF4tif9wDh+7yluAGijJamAhrHGYpFB/Zg3hJeceoZypi74ftXk8DHzwYpbZSg=="],
 
-    "@tsconfig/node10": ["@tsconfig/node10@1.0.12", "", {}, "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ=="],
-
-    "@tsconfig/node12": ["@tsconfig/node12@1.0.11", "", {}, "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="],
-
-    "@tsconfig/node14": ["@tsconfig/node14@1.0.3", "", {}, "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="],
-
-    "@tsconfig/node16": ["@tsconfig/node16@1.0.4", "", {}, "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="],
-
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -309,6 +294,46 @@
     "@types/prompts": ["@types/prompts@2.4.9", "", { "dependencies": { "@types/node": "*", "kleur": "^3.0.3" } }, "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA=="],
 
     "@types/qs": ["@types/qs@6.15.1", "", {}, "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@vitest/expect": ["@vitest/expect@3.1.3", "", { "dependencies": { "@vitest/spy": "3.1.3", "@vitest/utils": "3.1.3", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-7FTQQuuLKmN1Ig/h+h/GO+44Q1IlglPlR2es4ab7Yvfx+Uk5xsv+Ykk+MEt/M2Yn/xGmzaLKxGw2lgy2bwuYqg=="],
 
@@ -326,10 +351,6 @@
 
     "abitype": ["abitype@1.2.4", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg=="],
 
-    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
-
-    "acorn-walk": ["acorn-walk@8.3.5", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw=="],
-
     "adm-zip": ["adm-zip@0.4.16", "", {}, "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="],
 
     "aes-js": ["aes-js@4.0.0-beta.5", "", {}, "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="],
@@ -337,8 +358,6 @@
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "arg": ["arg@4.1.3", "", {}, "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -362,15 +381,11 @@
 
     "contracts": ["contracts@workspace:contracts"],
 
-    "create-require": ["create-require@1.1.1", "", {}, "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="],
-
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
-
-    "diff": ["diff@4.0.4", "", {}, "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ=="],
 
     "dns-packet": ["dns-packet@5.6.1", "", { "dependencies": { "@leichtgewicht/ip-codec": "^2.0.1" } }, "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw=="],
 
@@ -453,8 +468,6 @@
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
-
-    "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
 
     "micro-eth-signer": ["micro-eth-signer@0.14.0", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "micro-packed": "~0.7.2" } }, "sha512-5PLLzHiVYPWClEvZIXXFu5yutzpadb73rnQCpUqIHu3No3coFuWQNfE5tkBQJ7djuLYl6aRLaS0MgWJYGoqiBw=="],
 
@@ -554,15 +567,13 @@
 
     "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
 
-    "ts-node": ["ts-node@10.9.2", "", { "dependencies": { "@cspotcode/source-map-support": "^0.8.0", "@tsconfig/node10": "^1.0.7", "@tsconfig/node12": "^1.0.7", "@tsconfig/node14": "^1.0.0", "@tsconfig/node16": "^1.0.2", "acorn": "^8.4.1", "acorn-walk": "^8.1.1", "arg": "^4.1.0", "create-require": "^1.1.0", "diff": "^4.0.1", "make-error": "^1.1.1", "v8-compile-cache-lib": "^3.0.1", "yn": "3.1.1" }, "peerDependencies": { "@swc/core": ">=1.2.50", "@swc/wasm": ">=1.2.50", "@types/node": "*", "typescript": ">=2.7" }, "optionalPeers": ["@swc/core", "@swc/wasm"], "bin": { "ts-node": "dist/bin.js", "ts-script": "dist/bin-script-deprecated.js", "ts-node-cwd": "dist/bin-cwd.js", "ts-node-esm": "dist/bin-esm.js", "ts-node-script": "dist/bin-script.js", "ts-node-transpile-only": "dist/bin-transpile.js" } }, "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ=="],
-
     "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
 
     "tslib": ["tslib@2.7.0", "", {}, "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="],
 
     "tsx": ["tsx@4.22.3", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "undici": ["undici@6.26.0", "", {}, "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A=="],
 
@@ -571,8 +582,6 @@
     "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
-    "v8-compile-cache-lib": ["v8-compile-cache-lib@3.0.1", "", {}, "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="],
 
     "viem": ["viem@2.51.0", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "https://pkg.pr.new/ox@386a3439fe1ce76d237930f8c6e6bb493746069a", "ws": "8.20.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-8C0Ca+eEapXE29vHMUW59NqKENl1X4s9P6xSNC9Nvw6EvAeAhn/LNUlgztk6TOw7KN1Gzz5a/n9Wv4okUfmY9g=="],
 
@@ -591,8 +600,6 @@
     "ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
-
-    "yn": ["yn@3.1.1", "", {}, "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="],
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 

--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -30,6 +30,7 @@ deployments/*-fork/
 deployments/*-clean-*/
 deployments/v1/*
 !deployments/v1/sepolia/
+deployments/devnet*/
 
 # pre-migration
 preMigration.log

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -419,6 +419,46 @@ This runs `testNames()` which creates 17 names in various states. For details on
 - [Indexing Test Names](../docs/indexing-test-names.md) — what each test name does and which events it emits
 - [Indexing ENSv2 Events](../docs/indexing-ensv2-events.md) — full reference of all ENSv2 contract events
 
+### Mainnet Fork Mode
+
+Instead of a synthetic chain, the devnet can fork mainnet so that real ENS v1 names are present. Enable it by pointing at a mainnet RPC (these are also what [morticia](https://github.com/ensdomains/morticia)'s e2e runner uses):
+
+```sh
+FORK_URL=<mainnet-rpc> bun run devnet         # or --forkUrl <mainnet-rpc>
+FORK_URL=<mainnet-rpc> FORK_BLOCK=<block> bun run devnet   # pin the fork block (or --forkBlock)
+```
+
+On a fork you can also **pre-migrate** a curated set of real names — reserving them on the v2 registry (RESERVED state, `ENSV1Resolver` fallback) once the devnet is up, mirroring the DAO's pre-migration so the frontend can drive the v1 → v2 migrate flow:
+
+```sh
+FORK_URL=<mainnet-rpc> bun run devnet --preMigrate
+```
+
+Optionally reassign v1 ownership of the pre-migrated names to a devnet account (`deployer`/`owner`/`user`/`user2`, or a raw address) so a fixed test wallet owns them and can migrate in-app without impersonation:
+
+```sh
+FORK_URL=<mainnet-rpc> bun run devnet --preMigrate --preMigrateOwner user
+```
+
+Both flags have env-var equivalents (`DEVNET_PREMIGRATE=1`, `DEVNET_PREMIGRATE_OWNER=<account|address>`). `--preMigrate` requires a fork.
+
+The ten names cover every migration state (unwrapped, wrapped-locked, wrapped-unlocked):
+
+| Name                 | State                            | Notes                                                            |
+| -------------------- | -------------------------------- | ---------------------------------------------------------------- |
+| `swissborg.eth`      | unwrapped                        | normal happy-path name                                           |
+| `00relayer.eth`      | unwrapped                        | leading-zero label, small subtree                                |
+| `2718.eth`           | unwrapped                        | all-numeric label, multiple subnames                             |
+| `$beep.eth`          | wrapped-locked                   | special `$` char, minimal subtree                                |
+| `agi.eth`            | wrapped-locked                   | carries a locked child + a third-party child                     |
+| `ethscriptions.eth`  | wrapped-locked                   | burn-address owner, emancipated child                            |
+| `holer.eth`          | wrapped-**unlocked**/emancipated | no `CANNOT_UNWRAP`                                               |
+| `analyzes.eth`       | wrapped-locked                   | shared batch owner                                               |
+| `daomarketplace.eth` | wrapped-locked                   | shared batch owner                                               |
+| `alertbot.eth`       | wrapped-locked                   | `CANNOT_TRANSFER` — stays reserve-only under `--preMigrateOwner` |
+
+> The list is curated from [morticia](https://github.com/ensdomains/morticia)'s mainnet-fork e2e scenarios, whose states hold near mainnet block `25120743` (~2026-05). Every name's live state is read from the fork at runtime, so reservation stays correct at any block; a name no longer claimable on v1 is skipped with a log. For the documented locked/unlocked mix, fork near that block.
+
 ### Using Docker Compose
 
 1. Make sure you have Docker and Docker Compose installed

--- a/contracts/deployments/README.md
+++ b/contracts/deployments/README.md
@@ -17,6 +17,7 @@ deployments/
     .chain                # { chainId, genesisHash } the set was deployed against
     .migrations.json      # rocketh's record of completed deploy scripts (id → unix-epoch-seconds)
     .deployment.json      # { environment, chainId, deployedAt } — when this set was first deployed
+    .premigration.json    # pre-migration counts sidecar (names reserved/renewed/skipped/…), no label strings
     <Contract>.json       # one file per deployed contract (address, abi, bytecode, receipt, …)
   v1/
     <network>/            # local v1-reference overrides (searched before the bundled set)
@@ -24,12 +25,22 @@ deployments/
       <Contract>.json
 ```
 
-The `.chain`, `.migrations.json`, and `.deployment.json` dotfiles are metadata;
-rocketh loads only `.migrations.json` and the `<Contract>.json` artifacts and
-ignores every other dotfile, so `.deployment.json` is never mistaken for a
-contract. `.deployment.json` is written once, on the first deploy into a
-namespace, so its `deployedAt` records the original deployment time and survives
-idempotent re-runs.
+The `.chain`, `.migrations.json`, `.deployment.json`, and `.premigration.json`
+dotfiles are metadata; rocketh loads only `.migrations.json` and the
+`<Contract>.json` artifacts and ignores every other dotfile, so none of them are
+mistaken for a contract. `.deployment.json` is written once, on the first deploy
+into a namespace, so its `deployedAt` records the original deployment time and
+survives idempotent re-runs.
+
+`.premigration.json` is the durable record of the v1→v2 pre-migration run(s) that
+targeted this namespace. It holds counts only — never the reserved label strings
+(the corpus is large) — with one entry per logical run (`initial`, `final-sync`,
+or a standalone `run`, upserted by label) plus a `resolved` roll-up of the final
+numbers: names pre-migrated, expiry re-syncs, names skipped because they were
+never registered on v1 or lapsed past the v1 grace period, invalid labels, names
+already on v2, and failures. It is written by the pre-migration command whenever
+the target namespace persists (so `fork full` rehearsals without
+`--save-deployments` leave it untouched).
 
 A namespace is addressed by two inputs on every migration command:
 

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -1,98 +1,474 @@
 # Phased v1 → v2 Migration
 
-## Overview
+The v1 → v2 migration runs as seven explicit phases, driven by the `bun run migration` operator CLI
+from `contracts/`. Phases run **strictly in order**. To rehearse the whole thing in one command see
+[Quick start](#quick-start); to run it for real, work through [Phases](#phases) and the
+[Live deployment (Sepolia)](#live-deployment-sepolia) runbook.
 
-The v1 → v2 migration runs as seven explicit phases, orchestrated by three pieces:
+## Quick start
 
-- **Operator CLI** — [`script/migration.ts`](../script/migration.ts), run as `bun run migration -- <command>` from `contracts/`. Each phase is an individual subcommand; `fork full` and `clean-testnet` run all phases end-to-end as rehearsals.
-- **Hardhat plugin** — [`plugins/migration/index.ts`](../plugins/migration/index.ts), registering `migration <task>` tasks. These wrap the same phase functions but derive signers from the configured Hardhat network/keystore: `bunx hardhat --network <net> migration <task>`.
-- **Phased deploy scripts** — the scripts under [`deploy/`](../deploy/) carry migration tags (`migration:phase1:deploy-v2`, `migration:phase5:switch-urp-to-managed`, `migration:phase6:upgrade-managed-urp`, `migration:post-cutover:direct-urp-to-v2`) so each on-chain change is bound to a deploy step. Phase 1 (`phase deploy-v2`) runs only the `migration:phase1:deploy-v2` tag by default; the `…switch-urp-to-managed` / `…upgrade-managed-urp` tags drive the resolution cutover in phase 7 (their tag strings predate this numbering and are kept as stable identifiers).
+Rehearse all seven phases end-to-end against a throwaway local Anvil fork of the network — nothing
+touches a real chain:
 
-Phase numbering below matches the console output of the `runForkFull` orchestrator in [`script/migration.ts`](../script/migration.ts).
+```bash
+cd contracts
+bun run compile
+bun run migration -- fork full --network sepolia --csv-file ./csv-data/ens-registrations-sepolia.csv
+```
 
-> **Ordering note.** Renewal compatibility is enabled early (phase 4) so unmigrated v1 names stay renewable throughout the migration window, and the final pre-migration sync (phase 5) then picks up any renewed expiries. The Universal Resolver is cut over to v2 last (phase 7) so public resolution flips only once everything else is live.
+That impersonates every signer and runs phases 1–7 with smoke checks interleaved. To rehearse against
+a **live fork** (real v1 state) use a Tenderly virtual testnet — see
+[Tenderly virtual testnets](#tenderly-virtual-testnets). To stand up a fresh, fully-owned testnet
+stack instead, see [`clean-testnet`](#clean-testnet).
+
+## Deployment contexts
+
+Pick your path before running anything — it determines which phases apply:
+
+- **Live public network (sepolia/mainnet)** — v1 already exists on-chain; run phases **1–7** with real
+  signer keys. On mainnet the owner, URP admin, and v1 owner are the DAO/multisig, so owner-gated
+  phases run with `--calldata-only` (or deferred) and execute through a Safe. → [Live deployment
+  (Sepolia)](#live-deployment-sepolia).
+- **Clean testnet (fresh v1)** — no usable v1; deploy a fresh v1 stack first (**phase 0**), then
+  phases 1–7, always including `TestnetV1PremigrationRegistrar`. Sepolia only, via `clean-testnet`.
+  → [`clean-testnet`](#clean-testnet).
+- **Fork / Tenderly rehearsal** — dry-run phases 1–7 against a fork of the target network,
+  impersonating every signer. Local Anvil via [`fork full`](#fork-full); a live fork via a
+  [Tenderly virtual testnet](#tenderly-virtual-testnets).
+
+The Universal Resolver cutover (phase 7) has a further split: **sepolia is a reuse network** (the top
+proxy already fronts the intermediate one, so `switch-urp-to-managed` is skipped) while **mainnet and
+fresh chains are bootstrap** (run `switch-urp-to-managed` first). Details in
+[Phase 7](#phase-7-switch-the-universal-resolver-to-v2).
 
 ## Phases
 
-| Phase | Action | CLI command(s) | Signer |
-| --- | --- | --- | --- |
-| 0 † | Deploy fresh v1 contracts (clean-testnet only) | part of `clean-testnet` | `deployer` |
-| 1 | Deploy all v2 contracts (incl. reverse-registrar adapters), registrar deferred | `phase deploy-v2` | `deployer` / `owner` / `urManager` (+ one `v1Owner` tx, deferrable) |
-| 2 | Initial pre-migration: seed v1 names as reserved on v2 | `premigration run` / `resume`, then `premigration verify` | BatchRegistrar owner |
-| 3 | Disable v1 registrar controllers (v1 registration freeze) | `phase disable-v1-registrars`, then `phase verify-v1-registrars-disabled` | v1 owner |
-| 4 | Authorize `ETHRenewerV1` as a v1 controller so unmigrated names stay renewable | `phase authorize-v1-renewer` | v1 owner |
-| 5 | Final pre-migration sync from a fresh post-freeze export (picks up renewed expiries) | `premigration run`, then `premigration verify` | BatchRegistrar owner |
-| 6 | Enable the v2 controller: revoke `REGISTRAR \| RENEW` from `BatchRegistrar` → authorize v1 handoff controllers (`Graveyard`, testnet helper) → transfer v1 `BaseRegistrar` ownership to `ETHRenewerV1` → grant `REGISTRAR \| RENEW` to `ETHRegistrar` | `phase disable-batch-registrar`, `phase activate-v1-handoff-controllers`, `phase activate-v1-renewer`, `phase enable-v2-registrar` (+ the matching `verify-*`) | registry root-role admin + v1 owner |
-| 7 | Switch Universal Resolver to v2 (resolution cutover): intermediate URP → `UniversalResolverV2` (sepolia reuses the existing top URP → intermediate URP wiring; bootstrap networks first switch top URP → intermediate URP) | `phase upgrade-managed-urp`, then `phase verify-urp` (bootstrap also runs `phase switch-urp-to-managed` first) | `urManager` (intermediate URP admin); bootstrap also needs the top URP admin (DAO on mainnet) for the switch |
+Phase numbering matches the console output of the `fork full` orchestrator in
+[`script/migration.ts`](../script/migration.ts). Every command below also takes the shared
+[common options](#common-options) (`--network`, `--rpc-url`, deployment dirs); run any command with
+`--help` for its authoritative option list.
 
-† Phase 0 only exists in `clean-testnet`, which deploys a fresh v1 stack (from `lib/ens-contracts/deploy`) into a `deployments/v1/<namespace>` directory before running phases 1–7.
+| Phase | Action | Command(s) | Applies to | Signer |
+| --- | --- | --- | --- | --- |
+| 0 | Deploy fresh v1 contracts | part of `clean-testnet` | clean-testnet only | `deployer` |
+| 1 | Deploy all v2 contracts (registrar deferred) | `phase deploy-v2` | live + clean-testnet | `deployer` / `owner` / `urManager` (+ v1 owner) |
+| 2 | Seed v1 names as reserved on v2 | `premigration run` → `verify` | live + clean-testnet | BatchRegistrar owner |
+| 3 | Freeze v1 registrations | `phase disable-v1-registrars` (+ `verify-*`) | live + clean-testnet | v1 owner |
+| 4 | Keep unmigrated names renewable | `phase authorize-v1-renewer` | live + clean-testnet | v1 owner |
+| 5 | Final pre-migration sync | `premigration run` → `verify` | live + clean-testnet | BatchRegistrar owner |
+| 6 | Enable the v2 controller | `disable-batch-registrar` → `activate-v1-handoff-controllers` → `activate-v1-renewer` → `enable-v2-registrar` (+ `verify-*`) | live + clean-testnet | registry root-role admin + v1 owner |
+| 7 | Switch Universal Resolver to v2 (cutover) | `phase upgrade-managed-urp` (+ `switch-urp-to-managed` on bootstrap) (+ `verify-urp`) | live + clean-testnet (bootstrap step mainnet/fresh only) | `urManager` (+ top URP owner on bootstrap) |
 
-Every phase command takes `--network sepolia|mainnet` plus `--rpc-url` (or the `SEPOLIA_RPC_URL` / `MAINNET_RPC_URL` env var). Contract addresses default to the deployment JSON under `--deployments-dir` / `--deployment-network` (v2) and `--v1-deployments-dir` / `--v1-deployment-network` (v1); explicit address flags override. The v1-owner-signed and URP-admin phase commands (`disable-v1-registrars`, `set-v1-reverse-default-resolver`, `authorize-v1-renewer`, `activate-v1-graveyard`, `activate-v1-handoff-controllers`, `activate-v1-renewer`, `authorize-testnet-v1-premigration-registrar`, `switch-urp-to-managed`, `upgrade-managed-urp`) accept `--calldata-only` to print the transaction target and calldata for multisig execution instead of broadcasting. The registry root-role admin commands (`disable-batch-registrar`, `enable-v2-registrar`) broadcast or impersonate only.
+### Phase 0: deploy fresh v1 (clean-testnet only)
+
+- **Applies to:** clean-testnet only. Skipped for live deployments — sepolia/mainnet already have v1.
+- **Command:** no standalone phase command; it is the first step of [`clean-testnet`](#clean-testnet).
+- **Prerequisites:** none — it is the entry step of `clean-testnet`. Sepolia only.
+- **Env / args:** `--network sepolia`, `--rpc-url`, `--deployer <address>`. A funded deployer key is
+  required unless the RPC provides state controls (local node or Tenderly virtual testnet, which
+  impersonate instead).
+- **Expected outcome:** a fresh v1 ENS stack (from `lib/ens-contracts/deploy`) deployed into
+  `deployments/v1/<namespace>`, giving a v1 set to migrate from.
 
 ### Phase 1: deploy v2 contracts
 
-Runs all deploy scripts tagged `migration:phase1:deploy-v2` with the `deferV2Registrar` tag set, so [`deploy/03_ETHRegistrar.ts`](../deploy/03_ETHRegistrar.ts) deploys `ETHRegistrar` **without** granting it `REGISTRAR | RENEW` at the registry root — that grant is deferred to [phase 6](#phase-6-enable-the-v2-controller). `BatchRegistrar` holds the roles in the meantime for pre-migration seeding. The deploy also sets up the URP proxy chain pointing at the v1 `UniversalResolver` (see [universalResolver.md](./universalResolver.md)) and deploys the v2 reverse-registrar adapters ([`deploy/02_ReverseRegistrarAdapter.ts`](../deploy/02_ReverseRegistrarAdapter.ts) and [`deploy/02_DefaultReverseRegistrarAdapter.ts`](../deploy/02_DefaultReverseRegistrarAdapter.ts)), each authorized as a controller on the corresponding v1 reverse registrar via a v1-owner transaction.
+- **Applies to:** live + clean-testnet.
+- **Command:**
+  ```bash
+  bun run migration -- phase deploy-v2 --network sepolia
 
-Several steps require a v1-owner signature: pointing the v1 `.eth` resolver at `ENSV2Resolver` ([`deploy/00_ENSV2Resolver.ts`](../deploy/00_ENSV2Resolver.ts)) and the reverse-adapter controller grants above. With `--defer-v1-owner-transactions` (and `--deferred-v1-owner-transactions-file <path>`) such transactions are recorded to a JSONL file instead of broadcast; the owner executes them later with `phase execute-owner-txs --file <path> --role v1Owner`.
+  # On live networks, record the v1-owner txs instead of broadcasting, then replay them:
+  bun run migration -- phase deploy-v2 --network sepolia \
+    --defer-v1-owner-transactions \
+    --deferred-v1-owner-transactions-file .dev/phase1-v1owner.jsonl
+  bun run migration -- phase execute-owner-txs --network sepolia \
+    --role v1Owner --file .dev/phase1-v1owner.jsonl
+  ```
+  Add `--include-testnet-premigration-registrar` on testnet/clean runs to also deploy
+  `TestnetV1PremigrationRegistrar`. Re-run with `--resume` to continue an interrupted deploy.
+- **Prerequisites:** `bun run compile`; a freshly funded deployer (phase 1 sends many transactions).
+  Re-deploying onto an **already-migrated** chain first requires `phase
+  reclaim-v1-registrar-ownership` (the v1 `BaseRegistrar` is still owned by the prior `ETHRenewerV1`,
+  and one deferred tx is an owner-gated `setResolver`).
+- **Env / args:** `DEPLOYER_KEY` (also the `owner`/`urManager` fallback and the BatchRegistrar owner);
+  `SEPOLIA_V1_OWNER_KEY` / `V1_OWNER_KEY` for the deferred v1-owner replay. `phase deploy-v2` cannot
+  sign v1-owner transactions itself, hence the defer-then-replay flow above.
+- **Expected outcome:** all v2 contracts deployed with the `ETHRegistrar` grant **deferred** to
+  [phase 6](#phase-6-enable-the-v2-controller) (`BatchRegistrar` holds `REGISTRAR | RENEW` for
+  seeding); the URP proxy chain points at the v1 `UniversalResolver`
+  (see [universalResolver.md](./universalResolver.md)); the v2 reverse-registrar adapters are deployed
+  and authorized as controllers on the v1 reverse registrars; artifacts written to
+  `deployments/<network>/` (deploys fresh by default — see [Deployment artifacts](#deployment-artifacts)).
 
-`--include-testnet-premigration-registrar` additionally deploys `TestnetV1PremigrationRegistrar` (see [premigration.md](./premigration.md)).
-
-> The migration timeline also lists external deployments (e.g. an HCA component) that live outside this repository; they are out of scope for these contracts and are not driven by `phase deploy-v2`.
+> External deployments on the migration timeline (e.g. an HCA component) live outside this repo and
+> are not driven by `phase deploy-v2`.
 
 ### Phase 2: initial pre-migration
 
-Seeds every active or in-grace v1 `.eth` 2LD into the v2 registry as a **reserved** entry via `BatchRegistrar`, driven by a registration CSV — see [premigration.md](./premigration.md) for the CSV format, the bonus-period expiry rule, checkpointing, and verification. Each reservation's v2 expiry is the name's v1 expiry plus the configurable `--bonus-period-days` (default 62).
+- **Applies to:** live + clean-testnet.
+- **Command:**
+  ```bash
+  bun run migration -- premigration run --network sepolia \
+    --csv-file <registrations.csv> --work-dir .dev/premig-1
+  bun run migration -- premigration verify --network sepolia --csv-file <registrations.csv>
+  ```
+- **Prerequisites:** phase 1 complete. A current v1 registration CSV (Dune export for sepolia,
+  BigQuery for mainnet). See [premigration.md](./premigration.md) for the CSV format, expiry rule,
+  checkpointing, and verification.
+- **Env / args:** BatchRegistrar owner key (`PREMIGRATION_PRIVATE_KEY`, `BATCH_REGISTRAR_OWNER_KEY`,
+  or `DEPLOYER_KEY`); `--csv-file`, `--work-dir`, `--bonus-period-days` (default 62).
+- **Expected outcome:** every active or in-grace v1 `.eth` 2LD seeded as a **reserved** entry on v2,
+  with v2 expiry = v1 expiry + bonus period. `premigration verify` confirms the reservations.
 
 ### Phase 3: disable v1 registrars
 
-Removes `LegacyETHRegistrarController`, `ETHRegistrarController`, `WrappedETHRegistrarController`, and `NameWrapper` as v1 `BaseRegistrar` controllers (via `RegistrarSecurityController` when deployed, otherwise directly on `BaseRegistrar`). New v1 registrations are frozen from this point.
+- **Applies to:** live + clean-testnet.
+- **Command:**
+  ```bash
+  bun run migration -- phase disable-v1-registrars --network sepolia \
+    --private-key $SEPOLIA_V1_OWNER_KEY
+  bun run migration -- phase verify-v1-registrars-disabled --network sepolia
+  ```
+- **Prerequisites:** phase 2 complete (so no active name is stranded by the freeze). Signed by the v1
+  owner. This command takes the key via `--private-key` explicitly — the env fallback applies only
+  when it is run through `phase execute-owner-txs --role v1Owner`.
+- **Env / args:** v1 owner key via `--private-key` (or `SEPOLIA_V1_OWNER_KEY` / `V1_OWNER_KEY` through
+  execute-owner-txs). `--calldata-only` emits calldata for a multisig instead of broadcasting.
+- **Expected outcome:** `LegacyETHRegistrarController`, `ETHRegistrarController`,
+  `WrappedETHRegistrarController`, and `NameWrapper` removed as v1 `BaseRegistrar` controllers (via
+  `RegistrarSecurityController` when deployed); new v1 registrations frozen.
+  `verify-v1-registrars-disabled` confirms.
 
 ### Phase 4: authorize ETHRenewerV1
 
-`phase authorize-v1-renewer` authorizes `ETHRenewerV1` as a v1 `BaseRegistrar` controller (via `RegistrarSecurityController` when deployed). `ETHRenewerV1` *only renews* names already reserved on v2, so this does **not** reopen the registration freeze from phase 3 — it keeps unmigrated names renewable throughout the migration window, with each renewal extending both the v1 registration and the v2 reservation in a single transaction. The final lock-down step that transfers v1 `BaseRegistrar` ownership to `ETHRenewerV1` is deferred to phase 6, after the handoff controllers are authorized.
+- **Applies to:** live + clean-testnet.
+- **Command:**
+  ```bash
+  bun run migration -- phase authorize-v1-renewer --network sepolia
+  ```
+- **Prerequisites:** phase 2 complete — `ETHRenewerV1` can only renew names already `RESERVED` on v2,
+  so this phase is effective only after the initial pre-migration. Runs right after the phase 3 freeze.
+- **Env / args:** v1 owner key (`SEPOLIA_V1_OWNER_KEY` / `V1_OWNER_KEY`, read from env).
+  `--calldata-only` for a multisig.
+- **Expected outcome:** `ETHRenewerV1` authorized as a v1 `BaseRegistrar` controller; unmigrated names
+  stay renewable, each renewal extending both the v1 registration and the v2 reservation in one
+  transaction. This does **not** reopen the phase 3 registration freeze. The final lock-down that
+  transfers v1 `BaseRegistrar` ownership to `ETHRenewerV1` is deferred to
+  [phase 6](#phase-6-enable-the-v2-controller).
 
-Because `ETHRenewerV1` can only renew names that are already `RESERVED` on v2, this phase is effective only once the initial pre-migration (phase 2) has completed.
-
-> **Mainnet renewal continuity.** Renewals are paused between phase 3 (freeze) and phase 4 (authorize), and the phase 5 sync can run for days. When the v1 owner is a DAO/multisig, execute phases 3 and 4 **atomically in one v1-owner batch** — both support `--calldata-only`, so their calldata combines into a single Safe/multisend transaction.
+> **Mainnet renewal continuity.** Renewals are paused between phase 3 (freeze) and phase 4
+> (authorize), and the phase 5 sync can run for days. When the v1 owner is a DAO/multisig, execute
+> phases 3 and 4 **atomically in one v1-owner batch** — both support `--calldata-only`, so their
+> calldata combines into a single Safe/multisend transaction.
 
 ### Phase 5: final pre-migration sync
 
-After the freeze, export a fresh registration CSV (Dune for Sepolia, BigQuery for mainnet — see [premigration.md](./premigration.md#cli-reference)) and re-run pre-migration so names registered or renewed since phase 2 are caught up. Names already reserved on v2 are re-reserved with their bonus-adjusted expiry — picking up any expiry extensions from renewals performed via `ETHRenewerV1` since phase 4 — and newly eligible names are reserved for the first time.
+- **Applies to:** live + clean-testnet.
+- **Command:**
+  ```bash
+  bun run migration -- premigration run --network sepolia \
+    --csv-file <fresh-post-freeze.csv> --work-dir .dev/premig-2
+  bun run migration -- premigration verify --network sepolia --csv-file <fresh-post-freeze.csv>
+  ```
+- **Prerequisites:** phase 3 freeze done. Export a **fresh** post-freeze registration CSV so names
+  registered or renewed since phase 2 are caught up.
+- **Env / args:** same BatchRegistrar owner key as [phase 2](#phase-2-initial-pre-migration).
+- **Expected outcome:** names already reserved on v2 are re-reserved with their bonus-adjusted expiry
+  — picking up any expiry extensions from `ETHRenewerV1` renewals since phase 4 — and newly eligible
+  names are reserved for the first time.
 
 ### Phase 6: enable the v2 controller
 
-The "enable the v2 controller" cutover bundles four owner-gated steps, in order:
-
-1. **Disable the BatchRegistrar** (`phase disable-batch-registrar`) — revokes `REGISTRAR | RENEW` from `BatchRegistrar` on the v2 `ETHRegistry`, ending pre-migration seeding. On testnets, `TestnetV1PremigrationRegistrar` keeps its roles so test names can still be created. `phase batch-registrar-owner` prints (and optionally verifies) the BatchRegistrar owner beforehand.
-2. **Authorize v1 handoff controllers** (`phase activate-v1-handoff-controllers`) — authorizes `Graveyard` as a v1 `BaseRegistrar` controller, and (re-)authorizes `TestnetV1PremigrationRegistrar` when that deployment exists. The individual steps are also available as `phase activate-v1-graveyard` and `phase authorize-testnet-v1-premigration-registrar`.
-3. **Transfer v1 `BaseRegistrar` ownership to `ETHRenewerV1`** (`phase activate-v1-renewer`) — the final v1 lock-down (via `RegistrarSecurityController.transferRegistrarOwnership` when deployed). It re-authorizes `ETHRenewerV1` as a controller if needed, but the authorization usually already happened in phase 4. This must run **after** the handoff-controller grants above, because the v1 owner can no longer manage controllers once ownership has moved.
-4. **Enable the v2 `ETHRegistrar`** (`phase enable-v2-registrar`) — grants `REGISTRAR | RENEW` on the v2 `ETHRegistry` to `ETHRegistrar`, the grant deferred since phase 1, opening live v2 registrations. `phase verify-v2-registrar` confirms the grant.
+- **Applies to:** live + clean-testnet.
+- **Command:** four owner-gated steps, **in order**, then verify:
+  ```bash
+  bun run migration -- phase disable-batch-registrar          --network sepolia
+  bun run migration -- phase activate-v1-handoff-controllers  --network sepolia
+  bun run migration -- phase activate-v1-renewer              --network sepolia
+  bun run migration -- phase enable-v2-registrar              --network sepolia
+  bun run migration -- phase verify-v2-registrar              --network sepolia
+  ```
+- **Prerequisites:** phase 5 complete. Order matters — the handoff controllers must be authorized
+  **before** `activate-v1-renewer` transfers v1 `BaseRegistrar` ownership away from the v1 owner
+  (after which the v1 owner can no longer manage controllers).
+- **Env / args:** registry root-role admin key (`OWNER_KEY`, falls back to `DEPLOYER_KEY`) for
+  `disable-batch-registrar` and `enable-v2-registrar`; v1 owner key for the `activate-v1-*` steps. The
+  owner-gated and v1-owner steps accept `--calldata-only` for a multisig. On testnets
+  `TestnetV1PremigrationRegistrar` keeps its roles, re-authorized by `activate-v1-handoff-controllers`
+  (the individual steps are also available as `activate-v1-graveyard` and
+  `authorize-testnet-v1-premigration-registrar`).
+- **Expected outcome:** `BatchRegistrar` roles revoked (pre-migration seeding ends); `Graveyard` (+
+  testnet helper) authorized as v1 controllers; v1 `BaseRegistrar` ownership transferred to
+  `ETHRenewerV1` (final lock-down); `ETHRegistrar` granted `REGISTRAR | RENEW` on the v2 `ETHRegistry`
+  — live v2 registrations open. `verify-v2-registrar` confirms the grant. This bundle replaces the
+  all-at-once role swap done by [prepareMigration.md](./prepareMigration.md).
 
 ### Phase 7: switch the Universal Resolver to v2
 
-The resolution cutover, run last so public resolution flips to v2 only once everything else is live. On **reuse** networks (sepolia) the top `UpgradableUniversalResolverProxy` already fronts the long-lived intermediate `ManagedUniversalResolverProxy`, so the cutover is a single transaction — the intermediate URP admin (`urManager`) upgrades it to `UniversalResolverV2` (`phase upgrade-managed-urp`); the externally-administered top URP is never touched. On **bootstrap** networks (mainnet, fresh chains) the top URP admin first points the top URP at the intermediate URP (`phase switch-urp-to-managed`) before the upgrade. `phase verify-urp` confirms both implementations. See [universalResolver.md](./universalResolver.md) for the proxy chain, deploy scripts, and the optional post-cutover step.
+- **Applies to:** live + clean-testnet. The **`switch-urp-to-managed`** step is **bootstrap-only**
+  (mainnet and fresh chains); the sepolia reuse path skips it.
+- **Command:**
+  ```bash
+  # Reuse networks (sepolia): the top URP already fronts the intermediate URP, so only the upgrade runs
+  bun run migration -- phase upgrade-managed-urp --network sepolia
+  bun run migration -- phase verify-urp          --network sepolia
 
-> **Relation to `prepareMigration.ts`:** phase 6 replaces the all-at-once role swap performed by [prepareMigration.md](./prepareMigration.md); that script remains the path for non-phased deployments.
+  # Bootstrap networks (mainnet, fresh chains): point the top URP at the intermediate URP first
+  bun run migration -- phase switch-urp-to-managed --network mainnet
+  bun run migration -- phase upgrade-managed-urp   --network mainnet
+  bun run migration -- phase verify-urp            --network mainnet
+  ```
+- **Prerequisites:** phase 6 complete. Run **last**, so public resolution flips to v2 only once
+  everything else is live.
+- **Env / args:** intermediate URP admin key (`UR_MANAGER_KEY`, falls back to `DEPLOYER_KEY`) for
+  `upgrade-managed-urp`; top URP owner key (`SEPOLIA_TOP_URP_OWNER_KEY` / `TOP_URP_OWNER_KEY`) for the
+  bootstrap `switch-urp-to-managed`. `--calldata-only` for a multisig/DAO.
+- **Expected outcome:** the resolution cutover — the intermediate URP is upgraded to
+  `UniversalResolverV2` and public resolution serves v2. `verify-urp` confirms both proxy
+  implementations. See [universalResolver.md](./universalResolver.md) for the proxy chain and the
+  optional post-cutover step.
+
+## Live deployment (Sepolia)
+
+End-to-end runbook for a fresh Sepolia deployment against the canonical (live) v1. **Rehearse first**
+— [`fork full`](#fork-full), ideally against a [Tenderly live fork](#tenderly-virtual-testnets),
+exercises this exact sequence.
+
+### Signer keys
+
+Three keys cover every signature on the sepolia reuse path. The top URP owner key is **not** needed —
+the top URP already fronts the intermediate URP, so the cutover never touches it.
+
+| Key | Role |
+| --- | --- |
+| `DEPLOYER_KEY` | Deployer EOA; on sepolia also resolves as `owner` (registry root-role admin) and is the `BatchRegistrar` owner. Must be freshly funded — phase 1 sends many transactions. |
+| `SEPOLIA_V1_OWNER_KEY` | v1 owner (`0x0f32b753afc8abad9ca6fe589f707755f4df2353`); signs the deferred phase-1 v1-owner txs, phase 3, phase 4, and the phase-6 `activate-v1-*` steps. |
+| `UR_MANAGER_KEY` | Intermediate `ManagedUniversalResolverProxy` admin (`0x6d80F2172CFdEc5730fE683860C33d26fC42e6F1`, admin `0xffFffFFfFF52D316B7Bd028358089bc8066b8f80`); signs the phase-7 cutover. |
+
+### Setup
+
+```bash
+cd contracts
+bun run compile                                      # forge + hardhat → generated/artifacts
+
+export SEPOLIA_RPC_URL=<reliable paid sepolia RPC>   # phase 1 sends many txs
+export DEPLOYER_KEY=0x<fresh funded EOA>             # also owner / urManager / BatchRegistrar owner
+export SEPOLIA_V1_OWNER_KEY=0x<key for 0x0f32…2353>
+
+mkdir -p .dev/sepolia-live
+```
+
+Also export a **current** Sepolia registration CSV for the pre-migration phases (Dune export — see
+[premigration.md](./premigration.md)); the repo's `csv-data/ens-registrations-sepolia.csv` is a small
+sample, not a real export.
+
+> **Deployer and `.env` hygiene.** `DEPLOYER_KEY` should be a freshly funded EOA. If it happens to be
+> the same address as the v1 owner, `phase deploy-v2` wires that address with the v1-owner key so it
+> keeps a local signer. Keep `.env` values free of inline `#` comments — quote a value if it must
+> contain a literal `#`.
+
+### Run the phases
+
+Run the phases in order; each links to its entry in [Phases](#phases) for the exact command,
+prerequisites, and expected outcome:
+
+1. [Phase 1 — deploy fresh v2](#phase-1-deploy-v2-contracts), recording v1-owner txs with
+   `--defer-v1-owner-transactions --deferred-v1-owner-transactions-file .dev/sepolia-live/phase1-v1owner.jsonl`
+   and replaying them via `phase execute-owner-txs --role v1Owner`.
+2. [Phase 2 — initial pre-migration](#phase-2-initial-pre-migration) (`--work-dir .dev/sepolia-live/premig-1`).
+3. [Phase 3 — freeze v1 registrations](#phase-3-disable-v1-registrars) (`--private-key $SEPOLIA_V1_OWNER_KEY`).
+4. [Phase 4 — keep names renewable](#phase-4-authorize-ethrenewerv1). With an EOA v1 owner on Sepolia
+   you can run phases 3 and 4 back-to-back, so the renewal gap is small.
+5. [Phase 5 — final sync](#phase-5-final-pre-migration-sync) from a fresh post-freeze CSV
+   (`--work-dir .dev/sepolia-live/premig-2`).
+6. [Phase 6 — enable the v2 controller](#phase-6-enable-the-v2-controller).
+7. [Phase 7 — resolution cutover](#phase-7-switch-the-universal-resolver-to-v2): sepolia is a reuse
+   network, so only `upgrade-managed-urp` + `verify-urp` run.
+
+### After
+
+The new `deployments/sepolia/` namespace (and any dated archive) is committed automatically —
+`.gitignore` tracks real namespaces and ignores only the `-fork` / `-clean-` runtime sets (see
+[deployments/README.md](../deployments/README.md)). Pre-migration (phases 2 and 5) is the heavy,
+stateful part: it is checkpointed (`premigration resume`) and has its own flags — read
+[premigration.md](./premigration.md) and confirm the CSV export before the live run.
+
+> **Mainnet differs.** The owner, top URP admin, and v1 owner are all the DAO/multisig, so the
+> owner-signed and URP-admin phases run with `--calldata-only` (or deferred) and execute through the
+> Safe. Mainnet is also a **bootstrap** URP network, so phase 7 additionally runs
+> `switch-urp-to-managed` first.
+
+### Verify source code
+
+Once live, submit the deployed contracts for source verification on Etherscan and Sourcify. This reads
+the artifacts under `deployments/<network>/` — no recompile or redeploy is required:
+
+```bash
+cd contracts
+export ETHERSCAN_API_KEY=<etherscan v2 api key>   # one key covers all chains; not needed for Sourcify
+bun run verify:sepolia                            # → verify:mainnet for the mainnet set
+```
+
+`verify:<network>` runs [`script/verify.ts`](../script/verify.ts), which submits every contract to
+both Etherscan and Sourcify via [`@rocketh/verifier`](https://www.npmjs.com/package/@rocketh/verifier).
+It is idempotent and re-runnable: contracts already verified on a backend are detected and skipped. The
+verifier rebuilds the solc standard-JSON input from each artifact's metadata, backfilling source
+content from disk for forge-compiled artifacts, so a contract verifies regardless of which compiler
+produced it. Flags after `--` pass through (e.g. `bun run verify -- --network sepolia --etherscan-only`).
+
+## Rehearsals
+
+### `fork full`
+
+```bash
+bun run migration -- fork full --network sepolia --csv-file ./csv-data/ens-registrations-sepolia.csv \
+  [--work-dir <dir>] [--save-deployments] [--snapshot-file <path>]
+```
+
+Spawns a local Anvil fork of the network RPC (default port 8547 sepolia / 8548 mainnet), impersonates
+the deployer, owner, v1 owner, URP admins, and BatchRegistrar owner, and runs phases 1–7 in order with
+smoke checks interleaved:
+
+- v1 registration succeeds before phase 3 and is rejected after;
+- `ETHRenewerV1` is confirmed as an authorized v1 renewal controller after phase 4;
+- a pre-migrated name is migrated to v2 via `UnlockedMigrationController` after phase 5;
+- the v2 registrar rejects registrations before phase 6's grant, rejects pre-migrated reserved names
+  after it, and accepts a fresh name after enablement.
+
+When the target chain has already completed the v1 hand-off (re-running against an already-migrated
+Sepolia, or a repeat mainnet run), `fork full` detects this from the v1 registrar-controller state and
+skips the smoke checks that require live v1 registration, while still running the deploy,
+pre-migration, renewer authorization, the pre-enablement rejection, the fresh-name registration, and
+the URP cutover. A pristine chain runs all of them; there is no flag — it is detected automatically.
+
+`--direct` skips Anvil and targets `--rpc-url` directly (see
+[Tenderly virtual testnets](#tenderly-virtual-testnets)) — it requires explicit `--deployer` and
+`--ur-manager` addresses, plus `--owner` on sepolia (the Hardhat `migration fork-full` task derives
+them from the keystore). `--resume-from-phase 2` (requires `--work-dir`) skips phase 1 and reloads
+saved deployments. `--snapshot-file` records a pre-rehearsal `evm_snapshot` id, which the Hardhat
+`migration revert` task can restore.
+
+### `clean-testnet`
+
+`clean-testnet` stands up a **complete, throwaway v1 → v2 migration on public Sepolia using a fresh v1
+stack you fully own** — for integration testing or demos where you want a real, on-chain v1 + v2
+migrated set without depending on, or risking, the canonical ENS deployment.
+
+```bash
+bun run migration -- clean-testnet --network sepolia --rpc-url <url> --deployer <address>
+```
+
+Sepolia only. It runs **phase 0** — a fresh v1 stack deployed into `deployments/v1/<namespace>` — then
+phases 1–7 directly against the RPC, always including `TestnetV1PremigrationRegistrar`. The v2
+namespace defaults to `sepolia-clean-<timestamp>`; the command refuses to reuse the canonical
+`sepolia` namespace or any namespace that already contains deployment files. Without `--csv-file`,
+only the generated smoke labels are seeded. Against an RPC without state controls (anything other than
+a local node or a Tenderly virtual testnet) a configured deployer key is required — prefer the Hardhat
+`migration clean-testnet` task, which signs with the configured Hardhat account.
+
+### Tenderly virtual testnets
+
+Every command that impersonates signers also works against a **Tenderly Virtual TestNet** — an RPC
+whose host is `virtual.<...>.rpc.tenderly.co`. The CLI **auto-detects** these (there is no `--tenderly`
+flag) and uses Tenderly's state-control methods (`tenderly_setBalance`, `tenderly_impersonateAccount`,
+time-travel) to fund and impersonate every account, so **no signer keys are needed**.
+
+The main use is a **full dress rehearsal of a live network against a Tenderly live fork**: create a
+Virtual TestNet that forks live Sepolia or mainnet (so the real v1 ENS state is present) and run the
+whole migration against it in one command:
+
+```bash
+bun run migration -- fork full --direct --network sepolia \
+  --rpc-url https://virtual.<...>.rpc.tenderly.co/<id> \
+  --csv-file <fresh-sepolia.csv> \
+  --deployer <address> --ur-manager <address> --owner <address>   # --owner required on sepolia
+```
+
+`--direct` targets the Tenderly RPC directly instead of spawning Anvil; because it can't derive
+accounts from a Hardhat keystore, pass the signer **addresses** explicitly (`--deployer`,
+`--ur-manager`, and `--owner` on sepolia). Mainnet works the same way (`--network mainnet`; it is a
+bootstrap URP network). Individual [`phase`](#cli-commands) commands can likewise target a Tenderly RPC
+using their `--impersonate-account` / `--impersonate-owner` / `--impersonate-v1-owner` flags instead of
+keys.
+
+> `clean-testnet` also runs against a Tenderly virtual testnet, but it deploys a **fresh** v1 stack
+> (phase 0) rather than migrating the forked live v1 — use `fork full --direct` to rehearse the real
+> v1 → v2 migration of live Sepolia or mainnet.
+
+## Orchestration
+
+The migration is driven by three pieces:
+
+- **Operator CLI** — [`script/migration.ts`](../script/migration.ts), run as
+  `bun run migration -- <command>` from `contracts/`. Each phase is an individual subcommand;
+  `fork full` and `clean-testnet` run all phases end-to-end as rehearsals.
+- **Hardhat plugin** — [`plugins/migration/index.ts`](../plugins/migration/index.ts), registering
+  `migration <task>` tasks that wrap the same phase functions but derive signers from the configured
+  Hardhat network/keystore: `bunx hardhat --network <net> migration <task>`.
+- **Phased deploy scripts** — the scripts under [`deploy/`](../deploy/) carry migration tags
+  (`migration:phase1:deploy-v2`, `migration:phase5:switch-urp-to-managed`,
+  `migration:phase6:upgrade-managed-urp`, `migration:post-cutover:direct-urp-to-v2`) so each on-chain
+  change is bound to a deploy step. (The tag strings predate the current numbering and are kept as
+  stable identifiers.)
+
+> **Ordering.** Renewal compatibility is enabled early (phase 4) so unmigrated v1 names stay renewable
+> throughout the migration window, and the final pre-migration sync (phase 5) then picks up any
+> renewed expiries. The Universal Resolver is cut over to v2 last (phase 7) so public resolution flips
+> only once everything else is live.
 
 ## Deployment artifacts
 
-Phase 1 reads and writes rocketh deployment artifacts under [`deployments/`](../deployments/README.md), grouped into per-deployment **namespace** directories selected with `--deployments-dir` / `--deployment-network` (v1 references via `--v1-deployments-dir` / `--v1-deployment-network`).
+Phase 1 reads and writes rocketh deployment artifacts under
+[`deployments/`](../deployments/README.md), grouped into per-deployment **namespace** directories
+selected with `--deployments-dir` / `--deployment-network` (v1 references via `--v1-deployments-dir` /
+`--v1-deployment-network`).
 
-`phase deploy-v2` **deploys fresh by default** — it archives the current namespace to `deployments/<env>-<YYYYMMDD>-r<N>` and deploys into a clean one. Since phase 1 sends many transactions and can be interrupted, re-run with `--resume` to continue into the existing namespace instead (rocketh is idempotent, sending only the not-yet-deployed contracts). See [`deployments/README.md`](../deployments/README.md) for the namespace layout, archiving, git-tracking, and idempotency rules.
+`phase deploy-v2` **deploys fresh by default** — it archives the current namespace to
+`deployments/<env>-<YYYYMMDD>-r<N>` and deploys into a clean one. Since phase 1 sends many
+transactions and can be interrupted, re-run with `--resume` to continue into the existing namespace
+instead (rocketh is idempotent, sending only the not-yet-deployed contracts). See
+[`deployments/README.md`](../deployments/README.md) for the namespace layout, archiving, git-tracking,
+and idempotency rules.
 
-## CLI reference
+## Reference
 
-`bun run migration -- <command>` from `contracts/` (entrypoint [`script/migration.ts`](../script/migration.ts), wired through `package.json`). The CLI auto-loads `contracts/.env` (already-set environment variables win). Run `bun run migration -- <command> --help` for full options.
+### Common options
+
+Most commands share these option groups. Run `bun run migration -- <command> --help` for the
+authoritative per-command list — it is the source of truth for what each command accepts.
+
+- **Network** (every on-chain command): `--network sepolia|mainnet` (required),
+  `--rpc-url <url>` (falls back to `SEPOLIA_RPC_URL` / `MAINNET_RPC_URL`), `--chain-id <id>`.
+- **Deployments**: `--deployments-dir <path>`, `--deployment-network <name>` (v2 addresses);
+  `--v1-deployments-dir <path>`, `--v1-deployment-network <name>` (v1 addresses). Contract addresses
+  default to the deployment JSON under these dirs; explicit address flags (e.g. `--registry`,
+  `--batch-registrar`) override.
+- **Owner-gated writes** (v1-owner and URP-admin phases): `--private-key <key>`, `--impersonate-owner`
+  or `--impersonate-account <address>` (fork/Tenderly), `--calldata-only` (print the transaction
+  target and calldata for multisig execution instead of broadcasting).
+
+Two commands are **not** on-chain and intentionally omit the network options:
+
+- **`premigration status`** reads the local checkpoint file only — its sole option is `--work-dir`. It
+  does **not** accept `--network` / `--rpc-url`; passing them errors with `unknown option`.
+- **`fetch-data`** queries TheGraph, not a chain — it has its own `--network` (default `mainnet`) and
+  no `--rpc-url`.
+
+### CLI commands
+
+`bun run migration -- <command>` from `contracts/` (entrypoint
+[`script/migration.ts`](../script/migration.ts), wired through `package.json`). The CLI auto-loads
+`contracts/.env` (already-set environment variables win).
 
 | Command | Purpose |
 | --- | --- |
 | `fetch-data` | Export ENS registrations from the TheGraph subgraph (mainnet or sepolia) into a pre-migration CSV |
-| `premigration run` | Start pre-migration reservations from a fresh checkpoint (phases 2/4) |
+| `premigration run` | Start pre-migration reservations from a fresh checkpoint (phases 2/5) |
 | `premigration resume` | Resume pre-migration from the checkpoint |
-| `premigration status` | Print the current pre-migration checkpoint JSON |
+| `premigration status` | Print the current pre-migration checkpoint JSON (local; `--work-dir` only) |
 | `premigration verify` | Verify eligible CSV names were reserved or registered on v2 |
-| `phase deploy-v2` | Phase 1: deploy the v2 migration contracts (incl. reverse-registrar adapters) with the registrar deferred; archives any existing namespace and deploys fresh by default (`--resume` continues an interrupted deploy instead) |
-| `phase reclaim-v1-registrar-ownership` | Re-migration only: reclaim v1 `BaseRegistrar` ownership from a prior deployment's `ETHRenewerV1` back to the v1 owner (run before the Phase 1 deferred-tx replay on an already-migrated chain); signed by the prior renewer's owner / urManager |
+| `phase deploy-v2` | Phase 1: deploy the v2 migration contracts with the registrar deferred; archives any existing namespace and deploys fresh by default (`--resume` continues an interrupted deploy) |
+| `phase reclaim-v1-registrar-ownership` | Re-migration only: reclaim v1 `BaseRegistrar` ownership from a prior deployment's `ETHRenewerV1` back to the v1 owner (run before the Phase 1 deferred-tx replay on an already-migrated chain) |
 | `phase disable-v1-registrars` | Phase 3: disable v1 registrar controllers |
 | `phase set-v1-reverse-default-resolver` | Point the v1 `ReverseRegistrar` default resolver at the v1 `PublicResolver` (v1-owner write) |
 | `phase verify-v1-registrars-disabled` | Verify v1 registrar controllers are disabled |
@@ -107,13 +483,13 @@ Phase 1 reads and writes rocketh deployment artifacts under [`deployments/`](../
 | `phase activate-v1-renewer` | Phase 6: transfer v1 `BaseRegistrar` ownership to `ETHRenewerV1` (final lock-down) |
 | `phase enable-v2-registrar` | Phase 6: grant registrar/renew roles to `ETHRegistrar` |
 | `phase verify-v2-registrar` | Verify `ETHRegistrar` has registrar/renew roles |
-| `phase switch-urp-to-managed` | Phase 7: point the top URP at the managed URP |
+| `phase switch-urp-to-managed` | Phase 7 (bootstrap only): point the top URP at the managed URP |
 | `phase upgrade-managed-urp` | Phase 7: upgrade the managed URP to `UniversalResolverV2` (resolution cutover) |
 | `phase verify-urp` | Verify top and managed URP implementations |
-| `fork full` | Run the full phased migration rehearsal against an Anvil fork |
+| `fork full` | Run the full phased migration rehearsal against an Anvil fork (or a Tenderly fork with `--direct`) |
 | `clean-testnet` | Deploy fresh testnet v1 contracts and run the full phased migration (sepolia only) |
 
-## Hardhat plugin tasks
+### Hardhat plugin tasks
 
 Registered by [`plugins/migration/index.ts`](../plugins/migration/index.ts); invoke as:
 
@@ -121,7 +497,9 @@ Registered by [`plugins/migration/index.ts`](../plugins/migration/index.ts); inv
 bunx hardhat --network <net> migration <task> [--options]
 ```
 
-The tasks select the migration network with `--migration-network sepolia|mainnet` and use the Hardhat network's RPC and configured signer (so private keys can come from the Hardhat keystore instead of flags/env). See `bunx hardhat migration <task> --help` for options.
+The tasks select the migration network with `--migration-network sepolia|mainnet` and use the Hardhat
+network's RPC and configured signer (so private keys can come from the Hardhat keystore instead of
+flags/env). See `bunx hardhat migration <task> --help` for options.
 
 | Task | Purpose |
 | --- | --- |
@@ -136,7 +514,7 @@ The tasks select the migration network with `--migration-network sepolia|mainnet
 | `deploy-v2` | Deploy the v2 migration contracts (phase 1) |
 | `premigration-run` | Run pre-migration reservations (phases 2/5) with the Hardhat signer as BatchRegistrar owner |
 
-## Environment variables
+### Environment variables
 
 Resolved by [`script/migration.ts`](../script/migration.ts) (the CLI also auto-loads `contracts/.env`):
 
@@ -147,169 +525,26 @@ Resolved by [`script/migration.ts`](../script/migration.ts) (the CLI also auto-l
 | `OWNER_KEY` | Owner / registry root-role admin (`phase deploy-v2`, `disable-batch-registrar`, `enable-v2-registrar`; falls back to `DEPLOYER_KEY`) |
 | `UR_MANAGER_KEY` | Intermediate URP admin (`phase upgrade-managed-urp`; falls back to `DEPLOYER_KEY`) |
 | `SEPOLIA_V1_OWNER_KEY` / `V1_OWNER_KEY` | v1 owner (`disable-v1-registrars` †, `set-v1-reverse-default-resolver`, `authorize-v1-renewer`, `activate-v1-*`, `authorize-testnet-v1-premigration-registrar`) |
-| `SEPOLIA_TOP_URP_OWNER_KEY` / `TOP_URP_OWNER_KEY` | Top URP admin (`phase switch-urp-to-managed`) |
+| `SEPOLIA_TOP_URP_OWNER_KEY` / `TOP_URP_OWNER_KEY` | Top URP admin (`phase switch-urp-to-managed`, bootstrap networks only) |
 | `OWNER_TX_KEY` | Generic signer for `phase execute-owner-txs` when no role-specific key matches |
 | `<PREFIX>_MNEMONIC`, `<PREFIX>_MNEMONIC_PATH`, `<PREFIX>_MNEMONIC_INDEX`, `<PREFIX>_MNEMONIC_PASSPHRASE` | Mnemonic-backed signer alternatives for `phase execute-owner-txs`; prefixes `OWNER_TX`, `SEPOLIA_V1_OWNER` / `V1_OWNER`, `SEPOLIA_TOP_URP_OWNER` / `TOP_URP_OWNER` |
 | `PREMIGRATION_PRIVATE_KEY`, `BATCH_REGISTRAR_OWNER_KEY`, `DEPLOYER_KEY` | BatchRegistrar owner key fallbacks for `premigration run` / `resume` |
 | `THEGRAPH_API_KEY` / `GRAPH_API_KEY` | TheGraph Gateway key for `fetch-data` |
 | `ETHERSCAN_API_KEY` | Etherscan v2 (multichain) API key for source-code verification (`bun run verify:<network>`); not needed for Sourcify |
 
-† `phase disable-v1-registrars` takes the key via `--private-key`; the env fallbacks apply when it is executed through `phase execute-owner-txs` with `--role v1Owner`.
-
-For `phase execute-owner-txs`, the key is selected by the `--role` filter: `v1Owner` → the v1-owner variables, `sepolia-top-urp-owner` → the top-URP-owner variables, `deployer` → `DEPLOYER_KEY`; with no role, `OWNER_TX_KEY` and then the role-specific variables are tried in order.
-
-## Live deployment (Sepolia)
-
-End-to-end runbook for a real, fresh Sepolia deployment that replaces the live v2 set and re-runs every phase. Rehearse first (see [Rehearsals](#rehearsals)) — `fork full` exercises this exact sequence against forked state.
-
-### Signer keys
-
-Three keys cover every signature in the sepolia reuse flow. The deployer fills the `owner`/registry-root-admin role, the v1 owner is a separate account, and the intermediate URP admin is the wallet that controls the long-lived intermediate URP. The top URP owner key is **not** needed here — the top URP already fronts the intermediate URP, so the cutover never touches it:
-
-- **`DEPLOYER_KEY`** — the deployer EOA that signs phase-1 contract deployments. On Sepolia it also resolves as `owner` (registry root-role admin: `disable-batch-registrar`, `enable-v2-registrar`). It is also the `BatchRegistrar` owner that drives pre-migration. Must be a freshly funded account with enough Sepolia ETH for the many transactions in phase 1.
-- **`SEPOLIA_V1_OWNER_KEY`** — the v1 owner (`0x0f32b753afc8abad9ca6fe589f707755f4df2353`), which controls the v1 `BaseRegistrar` / `RegistrarSecurityController`. Signs the deferred phase-1 v1-owner transactions (pointing the v1 `.eth` resolver at the new `ENSV2Resolver` and authorizing the reverse-registrar adapters), plus `disable-v1-registrars` (phase 3), `authorize-v1-renewer` (phase 4), and `activate-v1-handoff-controllers` / `activate-v1-renewer` (phase 6).
-- **`UR_MANAGER_KEY`** — the admin of the long-lived intermediate `ManagedUniversalResolverProxy` (`0x6d80F2172CFdEc5730fE683860C33d26fC42e6F1`, admin `0xffFffFFfFF52D316B7Bd028358089bc8066b8f80`). Signs `upgrade-managed-urp` (phase 7), the v2 resolution cutover. Configured as `securityCouncil`/`urManager` for sepolia in the account config.
-
-> **`SEPOLIA_TOP_URP_OWNER_KEY`** is only needed on bootstrap networks (mainnet, fresh chains) where the top URP does not yet front an intermediate URP and the top URP admin (`0x69420f05A11f617B4B74fFe2E04B2D300dFA556F` on sepolia, the DAO on mainnet) must first run `switch-urp-to-managed`. On sepolia that switch is a no-op.
-
-> **`phase deploy-v2` cannot sign v1-owner transactions itself** — it only wires the deployer/owner keys. So phase 1 must record its v1-owner transactions with `--defer-v1-owner-transactions` and you replay them with `phase execute-owner-txs --role v1Owner`, which reads `SEPOLIA_V1_OWNER_KEY`. Every later v1-owner / top-URP command reads its key from env directly, except `disable-v1-registrars`, which takes `--private-key` explicitly.
-
-### Setup
-
-```bash
-cd contracts
-bun run compile                     # forge + hardhat → generated/artifacts
-
-export SEPOLIA_RPC_URL=<reliable paid sepolia RPC>     # phase 1 sends many txs
-export DEPLOYER_KEY=0x<fresh funded EOA>               # also owner / urManager / securityCouncil / BatchRegistrar owner
-export SEPOLIA_V1_OWNER_KEY=0x<key for 0x0f32…2353>
-export SEPOLIA_TOP_URP_OWNER_KEY=0x<key for 0x6942…556F>
-
-mkdir -p .dev/sepolia-live
-```
-
-Also prepare a **current** Sepolia registration CSV for the pre-migration phases (Dune export — see [premigration.md](./premigration.md)). The repo's `csv-data/ens-registrations-sepolia.csv` is a small sample, not a real export.
-
-### Phase 1 — deploy fresh v2
-
-```bash
-# deployer-signed deploy into deployments/sepolia/; v1-owner txs recorded, not broadcast
-bun run migration -- phase deploy-v2 --network sepolia \
-  --defer-v1-owner-transactions \
-  --deferred-v1-owner-transactions-file .dev/sepolia-live/phase1-v1owner.jsonl
-
-# Re-deploying onto an ALREADY-MIGRATED chain only: the v1 BaseRegistrar is still
-# owned by the prior deployment's ETHRenewerV1, so reclaim it to the v1 owner before
-# replaying the deferred txs — one of them is a v1 BaseRegistrar setResolver, which is
-# owner-gated. Signed by the prior renewer's owner (urManager). No-op on a pristine chain.
-bun run migration -- phase reclaim-v1-registrar-ownership --network sepolia \
-  --private-key $UR_MANAGER_KEY
-
-# v1 owner replays the deferred setResolver + reverse-adapter grants
-bun run migration -- phase execute-owner-txs --network sepolia \
-  --role v1Owner --file .dev/sepolia-live/phase1-v1owner.jsonl
-```
-
-`phase deploy-v2` archives any existing `sepolia` namespace (to `sepolia-<YYYYMMDD>-r<N>`) and deploys fresh into the default `sepolia` namespace; every later phase auto-resolves addresses from `deployments/sepolia/`. If phase 1 is interrupted, re-run the same command with `--resume` to continue.
-
-> **Deployer and `.env` hygiene.** `DEPLOYER_KEY` should be a freshly funded EOA. If it
-> happens to be the same address as the v1 owner, `phase deploy-v2` now wires that address
-> with the v1-owner key (from `SEPOLIA_V1_OWNER_KEY`/`V1_OWNER_KEY`, falling back to
-> `DEPLOYER_KEY`) so it keeps a local signer; previously a keyless same-address v1 owner
-> would shadow the deployer's signer and every deploy tx would fail node-side signing.
-> Keep `.env` values free of inline `#` comments — the loader trims a whitespace-introduced
-> inline comment, but quote the value if it must contain a literal `#`.
-
-### Phases 2–7 — wire up and cut over
-
-```bash
-# Phase 2 — initial pre-migration (BatchRegistrar owner = deployer). See premigration.md.
-bun run migration -- premigration run --network sepolia \
-  --csv-file <fresh-sepolia.csv> --work-dir .dev/sepolia-live/premig-1
-bun run migration -- premigration verify --network sepolia --csv-file <fresh-sepolia.csv>
-
-# Phase 3 — freeze v1 registrations (v1 owner; this command needs --private-key)
-bun run migration -- phase disable-v1-registrars --network sepolia \
-  --private-key $SEPOLIA_V1_OWNER_KEY
-bun run migration -- phase verify-v1-registrars-disabled --network sepolia
-
-# Phase 4 — keep unmigrated names renewable (v1 owner via env)
-bun run migration -- phase authorize-v1-renewer --network sepolia
-
-# Phase 5 — final sync from a fresh post-freeze CSV export
-bun run migration -- premigration run --network sepolia \
-  --csv-file <fresh-sepolia-post-freeze.csv> --work-dir .dev/sepolia-live/premig-2
-bun run migration -- premigration verify --network sepolia --csv-file <fresh-sepolia-post-freeze.csv>
-
-# Phase 6 — enable v2 controller (registry root admin = deployer/owner; + v1 owner)
-bun run migration -- phase disable-batch-registrar --network sepolia
-bun run migration -- phase activate-v1-handoff-controllers --network sepolia
-bun run migration -- phase activate-v1-renewer --network sepolia
-bun run migration -- phase enable-v2-registrar --network sepolia
-bun run migration -- phase verify-v2-registrar --network sepolia
-
-# Phase 7 — resolution cutover (intermediate URP admin = UR_MANAGER_KEY).
-# The top URP already fronts the intermediate URP, so only the upgrade is needed.
-bun run migration -- phase upgrade-managed-urp --network sepolia
-bun run migration -- phase verify-urp --network sepolia
-```
-
-### After
-
-The new `deployments/sepolia/` namespace (and any dated archive) is committed automatically — `.gitignore` tracks real namespaces by default and ignores only the `-fork` / `-clean-` runtime sets (see [deployments/README.md](../deployments/README.md)).
-
-Two things to plan for:
-
-- **Renewal gap (phases 3→5).** Between the freeze and the end of the long final sync renewals are paused until `authorize-v1-renewer` (phase 4) reopens them. With an EOA v1 owner on Sepolia you can run phases 3 and 4 back-to-back, so the window is small. (The atomic-batch guidance under [phase 4](#phase-4-authorize-ethrenewerv1) is a mainnet/multisig concern.)
-- **Pre-migration is the heavy, stateful part.** Phases 2 and 5 are checkpointed (`premigration resume`) and have their own flags (`--registry`, `--batch-registrar`, `--batch-size`, the v1-expiry RPC). Read [premigration.md](./premigration.md) and confirm the CSV export before the live run.
-
-> **Mainnet differs.** There the owner, top URP admin, and v1 owner are all the DAO/multisig, so the owner-signed and URP-admin phases are run with `--calldata-only` (or deferred) and executed through the Safe rather than with local keys.
-
-### Verify source code
-
-Once the deployment is live, submit the deployed contracts for source-code verification on Etherscan and Sourcify. This reads the deployment artifacts under `deployments/<network>/` (each carries the solc metadata and constructor args needed) — no recompilation or redeploy is required.
-
-```bash
-cd contracts
-export ETHERSCAN_API_KEY=<etherscan v2 api key>   # one key covers all chains; not needed for Sourcify
-bun run verify:sepolia                            # → verify:mainnet for the mainnet set
-```
-
-`verify:<network>` runs [`script/verify.ts`](../script/verify.ts), which submits every contract to both Etherscan and Sourcify via [`@rocketh/verifier`](https://www.npmjs.com/package/@rocketh/verifier). It is idempotent and re-runnable: contracts already verified on a backend are detected and skipped, so it is safe to re-run after a partial deploy or to pick up newly added contracts. Proxy entries are verified from their `*_Proxy` / `*_Implementation` artifacts.
-
-The verifier rebuilds the solc standard-JSON input from each artifact's recorded metadata, which needs the literal content of every source file. Hardhat-compiled artifacts embed that content, but forge-compiled ones record only each source's hash and URLs; for those, `verify.ts` backfills the missing content from disk (keyed by the metadata source paths and checked against the recorded hash) before submitting, so a contract verifies regardless of which compiler produced its artifact. Flags after `--` pass through to the underlying CLI (e.g. `bun run verify -- --network sepolia --etherscan-only`).
-
-## Rehearsals
-
-### `fork full`
-
-```bash
-bun run migration -- fork full --network sepolia --csv-file ./csv-data/ens-registrations-sepolia.csv \
-  [--work-dir <dir>] [--save-deployments] [--snapshot-file <path>]
-```
-
-Spawns a local Anvil fork of the network RPC (default port 8547 sepolia / 8548 mainnet), impersonates the deployer, owner, v1 owner, URP admins, and BatchRegistrar owner, and runs phases 1–7 in order with smoke checks interleaved:
-
-- v1 registration succeeds before phase 3 and is rejected after;
-- `ETHRenewerV1` is confirmed as an authorized v1 renewal controller after phase 4;
-- a pre-migrated name is migrated to v2 via `UnlockedMigrationController` after phase 5;
-- the v2 registrar rejects registrations before phase 6's grant, rejects pre-migrated reserved names after it, and accepts a fresh name after enablement.
-
-When the target chain has already completed the v1 hand-off — re-running against an already-migrated Sepolia, or a repeat mainnet run after a redeploy — `fork full` detects this from the v1 registrar-controller state and skips the smoke checks that require live v1 registration (the v1-registration bullet and the pre-migrated-reserved-name rejection in the last bullet), while still running the deploy, pre-migration, renewer authorization, the pre-enablement rejection, the fresh-name registration, and the URP cut-over. A pristine chain runs all of them. There is no flag for this; it is detected automatically.
-
-`--direct` skips Anvil and targets `--rpc-url` directly (e.g. a Tenderly virtual testnet) — it requires explicit `--deployer` and `--ur-manager` addresses, plus `--owner` on sepolia (the Hardhat `migration fork-full` task derives them from the keystore). `--resume-from-phase 2` (requires `--work-dir`) skips phase 1 and reloads saved deployments. `--snapshot-file` records a pre-rehearsal `evm_snapshot` id, which the Hardhat `migration revert` task can restore.
-
-### `clean-testnet`
-
-```bash
-bun run migration -- clean-testnet --network sepolia --rpc-url <url> --deployer <address>
-```
-
-Sepolia only. Runs phase 0 — a fresh v1 stack deployed into `deployments/v1/<namespace>` — then phases 1–7 directly against the RPC, always including `TestnetV1PremigrationRegistrar`. The v2 namespace defaults to `sepolia-clean-<timestamp>`; the command refuses to reuse the canonical `sepolia` namespace or any namespace that already contains deployment files. Without `--csv-file`, only the generated smoke labels are seeded. Against an RPC without state controls (anything other than a local node or a Tenderly virtual testnet), a configured deployer key is required — prefer the Hardhat `migration clean-testnet` task, which signs with the configured Hardhat account.
+† `phase disable-v1-registrars` takes the key via `--private-key`; the env fallbacks apply when it is
+executed through `phase execute-owner-txs` with `--role v1Owner`. For `phase execute-owner-txs`, the
+key is selected by the `--role` filter: `v1Owner` → the v1-owner variables, `sepolia-top-urp-owner` →
+the top-URP-owner variables, `deployer` → `DEPLOYER_KEY`; with no role, `OWNER_TX_KEY` then the
+role-specific variables are tried in order.
 
 ## Related docs
 
-- [deployments/README.md](../deployments/README.md) — deployment artifact layout, namespace naming, and the idempotency rule for fresh re-deploys.
-- [premigration.md](./premigration.md) — the `BatchRegistrar` seeding step in detail (phases 2 and 5): CSV format, continuity expiry, checkpoints, verification.
-- [universalResolver.md](./universalResolver.md) — the URP proxy chain behind phase 7, and the post-cutover step.
-- [prepareMigration.md](./prepareMigration.md) — the non-phased, all-at-once role hand-off script that phase 6 supersedes.
+- [premigration.md](./premigration.md) — the `BatchRegistrar` seeding step in detail (phases 2 and 5):
+  CSV format, continuity expiry, checkpoints, verification.
+- [universalResolver.md](./universalResolver.md) — the URP proxy chain behind phase 7, and the
+  post-cutover step.
+- [prepareMigration.md](./prepareMigration.md) — the non-phased, all-at-once role hand-off script that
+  phase 6 supersedes.
+- [deployments/README.md](../deployments/README.md) — deployment artifact layout, namespace naming,
+  and the idempotency rule for fresh re-deploys.

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -59,6 +59,15 @@ Phase numbering matches the console output of the `fork full` orchestrator in
 | 6 | Enable the v2 controller | `disable-batch-registrar` → `activate-v1-handoff-controllers` → `activate-v1-renewer` → `enable-v2-registrar` (+ `verify-*`) | live + clean-testnet | registry root-role admin + v1 owner |
 | 7 | Switch Universal Resolver to v2 (cutover) | `phase upgrade-managed-urp` (+ `switch-urp-to-managed` on bootstrap) (+ `verify-urp`) | live + clean-testnet (bootstrap step mainnet/fresh only) | `urManager` (+ top URP owner on bootstrap) |
 
+> **Re-deploying fresh onto an already-migrated network.** "Re-deploying fresh" means deploying a
+> brand-new v2 set onto a network whose v1 a previous deployment already migrated — the earlier v2 set
+> is archived (see [Deployment artifacts](#deployment-artifacts)) and left orphaned on-chain. Phase 1
+> is where the fresh deploy happens; the later phases re-seed and re-wire v1 to the **new** contract
+> addresses rather than the archived ones. Phases below carry a **Re-deploying fresh** note wherever
+> that changes what you run — most importantly, phase 1 needs a `reclaim-v1-registrar-ownership` prep
+> step and phase 3 becomes a no-op. The one-command shortcut is [`fork full`](#fork-full), which
+> detects an already-migrated chain and adjusts automatically.
+
 ### Phase 0: deploy fresh v1 (clean-testnet only)
 
 - **Applies to:** clean-testnet only. Skipped for live deployments — sepolia/mainnet already have v1.
@@ -87,9 +96,6 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   Add `--include-testnet-premigration-registrar` on testnet/clean runs to also deploy
   `TestnetV1PremigrationRegistrar`. Re-run with `--resume` to continue an interrupted deploy.
 - **Prerequisites:** `bun run compile`; a freshly funded deployer (phase 1 sends many transactions).
-  Re-deploying onto an **already-migrated** chain first requires `phase
-  reclaim-v1-registrar-ownership` (the v1 `BaseRegistrar` is still owned by the prior `ETHRenewerV1`,
-  and one deferred tx is an owner-gated `setResolver`).
 - **Env / args:** `DEPLOYER_KEY` (also the `owner`/`urManager` fallback and the BatchRegistrar owner);
   `SEPOLIA_V1_OWNER_KEY` / `V1_OWNER_KEY` for the deferred v1-owner replay. `phase deploy-v2` cannot
   sign v1-owner transactions itself, hence the defer-then-replay flow above.
@@ -99,6 +105,13 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   (see [universalResolver.md](./universalResolver.md)); the v2 reverse-registrar adapters are deployed
   and authorized as controllers on the v1 reverse registrars; artifacts written to
   `deployments/<network>/` (deploys fresh by default — see [Deployment artifacts](#deployment-artifacts)).
+- **Re-deploying fresh:** `deploy-v2` archives the existing `deployments/<network>/` namespace and
+  deploys a brand-new v2 set with new addresses (`--resume` is only for continuing an *interrupted*
+  deploy into the same namespace, not for a fresh redeploy). First run
+  [`phase reclaim-v1-registrar-ownership`](#cli-commands): the v1 `BaseRegistrar` is still owned by the
+  prior deployment's `ETHRenewerV1`, and one deferred phase-1 tx is an owner-gated `setResolver` the v1
+  owner must sign. Every later phase then seeds and wires v1 to this **new** set; the prior set stays
+  on-chain but orphaned.
 
 > External deployments on the migration timeline (e.g. an HCA component) live outside this repo and
 > are not driven by `phase deploy-v2`.
@@ -119,6 +132,9 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   or `DEPLOYER_KEY`); `--csv-file`, `--work-dir`, `--bonus-period-days` (default 62).
 - **Expected outcome:** every active or in-grace v1 `.eth` 2LD seeded as a **reserved** entry on v2,
   with v2 expiry = v1 expiry + bonus period. `premigration verify` confirms the reservations.
+- **Re-deploying fresh:** the new v2 registry is empty, so this seeds it from scratch exactly like a
+  first run. Reservations from the prior deployment lived on the now-archived registry and do **not**
+  carry over. Use a fresh `--work-dir` so no stale `preMigration-checkpoint.json` is picked up.
 
 ### Phase 3: disable v1 registrars
 
@@ -138,6 +154,10 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   `WrappedETHRegistrarController`, and `NameWrapper` removed as v1 `BaseRegistrar` controllers (via
   `RegistrarSecurityController` when deployed); new v1 registrations frozen.
   `verify-v1-registrars-disabled` confirms.
+- **Re-deploying fresh:** normally a **no-op you can skip** — the v1 registrars were removed by the
+  prior deployment and stay frozen (reclaiming v1 `BaseRegistrar` ownership in phase 1 does not
+  re-enable them). Re-running is harmless (each controller logs "already disabled"); prefer just
+  `verify-v1-registrars-disabled` to confirm the freeze is still in place.
 
 ### Phase 4: authorize ETHRenewerV1
 
@@ -155,6 +175,10 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   transaction. This does **not** reopen the phase 3 registration freeze. The final lock-down that
   transfers v1 `BaseRegistrar` ownership to `ETHRenewerV1` is deferred to
   [phase 6](#phase-6-enable-the-v2-controller).
+- **Re-deploying fresh:** authorizes the **newly-deployed** `ETHRenewerV1` (a new address) as a v1
+  controller — must be re-run. The prior deployment's `ETHRenewerV1` remains an authorized controller
+  (orphaned but harmless); the tooling does not deauthorize it, so remove it manually only if you want
+  a clean controller set.
 
 > **Mainnet renewal continuity.** Renewals are paused between phase 3 (freeze) and phase 4
 > (authorize), and the phase 5 sync can run for days. When the v1 owner is a DAO/multisig, execute
@@ -176,6 +200,8 @@ Phase numbering matches the console output of the `fork full` orchestrator in
 - **Expected outcome:** names already reserved on v2 are re-reserved with their bonus-adjusted expiry
   — picking up any expiry extensions from `ETHRenewerV1` renewals since phase 4 — and newly eligible
   names are reserved for the first time.
+- **Re-deploying fresh:** same as [phase 2](#phase-2-initial-pre-migration) — re-seeds the new
+  registry against a fresh post-freeze CSV and a fresh `--work-dir`.
 
 ### Phase 6: enable the v2 controller
 
@@ -202,6 +228,11 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   `ETHRenewerV1` (final lock-down); `ETHRegistrar` granted `REGISTRAR | RENEW` on the v2 `ETHRegistry`
   — live v2 registrations open. `verify-v2-registrar` confirms the grant. This bundle replaces the
   all-at-once role swap done by [prepareMigration.md](./prepareMigration.md).
+- **Re-deploying fresh:** re-points v1 at the new set and must be re-run —
+  `activate-v1-handoff-controllers` authorizes the new `Graveyard`, `activate-v1-renewer` transfers v1
+  `BaseRegistrar` ownership to the new `ETHRenewerV1` (the ownership you reclaimed in phase 1), and
+  `enable-v2-registrar` grants the new `ETHRegistrar`. The prior deployment's `Graveyard`/`ETHRenewerV1`
+  remain authorized as orphaned v1 controllers.
 
 ### Phase 7: switch the Universal Resolver to v2
 
@@ -227,6 +258,11 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   `UniversalResolverV2` and public resolution serves v2. `verify-urp` confirms both proxy
   implementations. See [universalResolver.md](./universalResolver.md) for the proxy chain and the
   optional post-cutover step.
+- **Re-deploying fresh:** on a reuse network (sepolia) the top **and** intermediate URPs are adopted by
+  address and never redeployed — phase 1 deploys a fresh `UniversalResolverV2` implementation and
+  `upgrade-managed-urp` re-points the reused intermediate URP at it, orphaning the prior
+  implementation. Bootstrap networks (mainnet/fresh) deploy a fresh intermediate URP instead. Must be
+  re-run to serve the new implementation.
 
 ## Live deployment (Sepolia)
 
@@ -284,6 +320,11 @@ prerequisites, and expected outcome:
 6. [Phase 6 — enable the v2 controller](#phase-6-enable-the-v2-controller).
 7. [Phase 7 — resolution cutover](#phase-7-switch-the-universal-resolver-to-v2): sepolia is a reuse
    network, so only `upgrade-managed-urp` + `verify-urp` run.
+
+> **Re-deploying onto an already-migrated Sepolia?** This runbook assumes a first migration. On a
+> repeat deploy the order is unchanged, but read each phase's **Re-deploying fresh** note first: run
+> [`phase reclaim-v1-registrar-ownership`](#cli-commands) before phase 1, skip phase 3 (v1 is already
+> frozen), and expect phases 2, 4, 5, 6, and 7 to re-seed and re-wire v1 to the new contract set.
 
 ### After
 

--- a/contracts/docs/premigration.md
+++ b/contracts/docs/premigration.md
@@ -1,19 +1,49 @@
 # ENS Pre-Migration Script
 
-## Overview
+The pre-migration script (`contracts/script/preMigration.ts`) seeds ENS v1 `.eth` second-level (2LD)
+registrations into the v2 registry. It reads a CSV export of v1 registrations, verifies each name
+on-chain against the v1 `BaseRegistrar`, and reserves or renews it on v2 via the `BatchRegistrar`
+contract. Names are written in a **reserved** state (owner `address(0)`) with the v1 expiry preserved
+(plus a configurable bonus period) and `ENSV1Resolver` set as the fallback resolver; ownership
+transfer happens in a later migration phase.
 
-The pre-migration script (`contracts/script/preMigration.ts`) seeds ENS v1 `.eth` second-level (2LD) registrations into the v2 registry. It reads a CSV export of v1 registrations, verifies each name on-chain against the v1 `BaseRegistrar`, and reserves or renews it on v2 via the `BatchRegistrar` contract.
+## Quick start
 
-Names are written to v2 in a **reserved** state (owner `address(0)`) with the v1 expiry preserved (plus a configurable bonus period) and `ENSV1Resolver` set as the fallback resolver. Ownership transfer happens in a later migration phase.
+Run from `contracts/` after `forge build`. Dry-run first (full pipeline, sends nothing), then execute;
+resume with `--continue` after any interruption:
 
-In the phased migration this script is driven through the operator CLI (`bun run migration -- premigration run` / `resume`, then `verify`); see [migration.md](./migration.md). The reference below documents the underlying script directly.
+```bash
+export PREMIGRATION_PRIVATE_KEY=0x...   # BatchRegistrar owner key
+
+# 1. Dry run — parses, verifies, computes expiries, checkpoints; sends no transactions
+bun run script/preMigration.ts \
+  --rpc-url <url> --registry <addr> --batch-registrar <addr> \
+  --v1-resolver <addr> --csv-file ./data/v1-registrations.csv --dry-run
+
+# 2. Execute (drop --dry-run)
+bun run script/preMigration.ts \
+  --rpc-url <url> --registry <addr> --batch-registrar <addr> \
+  --v1-resolver <addr> --csv-file ./data/v1-registrations.csv
+
+# 3. Resume from the last checkpoint after an interruption (same options as before)
+bun run script/preMigration.ts --continue \
+  --rpc-url <url> --registry <addr> --batch-registrar <addr> \
+  --v1-resolver <addr> --csv-file ./data/v1-registrations.csv
+```
+
+In the phased migration this script is driven through the operator CLI
+(`bun run migration -- premigration run` / `resume`, then `verify`) — see
+[migration.md](./migration.md). The reference below documents the underlying script directly.
 
 ## Prerequisites
 
 - **Bun** runtime, and forge artifacts compiled (`forge build` in `contracts/`).
-- **Deployed contracts:** the v2 `PermissionedRegistry`, `BatchRegistrar` (owned by the signer), and `ENSV1Resolver`.
-- **Signer key** for the `BatchRegistrar` owner — `--private-key` or the `PREMIGRATION_PRIVATE_KEY` env var.
-- **RPC endpoint** where both v1 and v2 contracts live (chain ID auto-detected). Optionally a separate `--mainnet-rpc-url` for v1 reads (e.g. when v2 runs on a devnet with its own v1 set).
+- **Deployed contracts:** the v2 `PermissionedRegistry`, `BatchRegistrar` (owned by the signer), and
+  `ENSV1Resolver`.
+- **Signer key** for the `BatchRegistrar` owner — `--private-key` or the `PREMIGRATION_PRIVATE_KEY`
+  env var.
+- **RPC endpoint** where both v1 and v2 contracts live (chain ID auto-detected). Optionally a separate
+  `--mainnet-rpc-url` for v1 reads (e.g. when v2 runs on a devnet with its own v1 set).
 - **CSV file** of v1 registrations (see [CSV input](#csv-input)).
 
 ## CLI Reference
@@ -23,6 +53,12 @@ Run from `contracts/`:
 ```bash
 bun run script/preMigration.ts [options]
 ```
+
+> In the phased flow these options map onto the operator-CLI subcommands `premigration run` /
+> `resume` / `verify`, which additionally accept the shared
+> [common options](./migration.md#common-options) (`--network`, deployment dirs). `premigration
+> status` is a separate, local checkpoint read that takes **only** `--work-dir` — it does not touch an
+> RPC. Run `bun run migration -- premigration <sub> --help` for the authoritative per-subcommand list.
 
 ### Required
 
@@ -49,11 +85,17 @@ bun run script/preMigration.ts [options]
 | `--bonus-period-days <days>` | `62` | Days added to each name's v1 expiry to compute its v2 expiry. `0` preserves v1 expiries exactly. |
 | `--v1-base-registrar <address>` | mainnet `BaseRegistrar` | v1 `BaseRegistrar` for expiry lookups (override for testing). |
 
-> Eligibility is independently gated by v1's hard-coded 90-day grace: a name expired more than 90 days ago is past grace and skipped, regardless of `--bonus-period-days`. Choose a bonus period large enough that the deepest in-grace name you want migrated does not compute a past v2 expiry (which would fail registration).
+> Eligibility is independently gated by v1's hard-coded 90-day grace: a name expired more than 90 days
+> ago is past grace and skipped, regardless of `--bonus-period-days`. Choose a bonus period large
+> enough that the deepest in-grace name you want migrated does not compute a past v2 expiry (which
+> would fail registration).
 
 ## CSV input
 
-Parsing is **header-driven**: the first line is the header, the label column is located by name, everything else is ignored. Two column names are accepted (case-insensitive, trimmed): **`labelName`** (v1 subgraph schema, preferred) or **`label`** (the `exportTheGraphRegistrations.ts` exporter). Both work with no flag:
+Parsing is **header-driven**: the first line is the header, the label column is located by name,
+everything else is ignored. Two column names are accepted (case-insensitive, trimmed): **`labelName`**
+(v1 subgraph schema, preferred) or **`label`** (the `exportTheGraphRegistrations.ts` exporter). Both
+work with no flag:
 
 ```csv
 node,name,labelHash,owner,parentName,parentLabelHash,labelName,registrationDate,expiryDate
@@ -65,17 +107,28 @@ name,label,labelhash,registrant,expiryDate,registrationDate
 vitalik.eth,vitalik,0x...,0x...,...,...
 ```
 
-Quoted fields and `""`-escaped quotes are handled; a UTF-8 BOM, a single trailing blank line, and CRLF endings are tolerated.
+Quoted fields and `""`-escaped quotes are handled; a UTF-8 BOM, a single trailing blank line, and CRLF
+endings are tolerated.
 
-**Strict structural parsing.** Any structural problem aborts the run with the CSV path and 1-based line number (header = line 1); fix the file and re-run. Aborts on: missing both `labelName` and `label` columns; unbalanced quotes (header or row); a data row whose column count differs from the header; an empty/whitespace-only label cell; a blank line anywhere but a single trailing one; an empty file.
+**Strict structural parsing.** Any structural problem aborts the run with the CSV path and 1-based
+line number (header = line 1); fix the file and re-run. Aborts on: missing both `labelName` and
+`label` columns; unbalanced quotes (header or row); a data row whose column count differs from the
+header; an empty/whitespace-only label cell; a blank line anywhere but a single trailing one; an empty
+file.
 
-**Application-level filtering** happens *after* structural parsing and does **not** abort: labels longer than 255 bytes and the bracketed-labelhash form (`[0x…]`) are skipped and counted as `invalidLabelCount`.
+**Application-level filtering** happens *after* structural parsing and does **not** abort: labels
+longer than 255 bytes and the bracketed-labelhash form (`[0x…]`) are skipped and counted as
+`invalidLabelCount`.
 
-> **Limitation:** `readline` splits on `\n`, so a field containing a literal newline inside quotes is misread. No exporter we control produces these; pre-process the file if you have one.
+> **Limitation:** `readline` splits on `\n`, so a field containing a literal newline inside quotes is
+> misread. No exporter we control produces these; pre-process the file if you have one.
 
 ## How it works
 
-Names stream from the CSV in batches of `--batch-size`. Each batch is verified with a single multicall (two RPC calls regardless of size) reading v2 state (`PermissionedRegistry.getState()`) and v1 expiry (`BaseRegistrar.nameExpires()`), then submitted as one `BatchRegistrar.batchRegister()` transaction. Per-name action:
+Names stream from the CSV in batches of `--batch-size`. Each batch is verified with a single multicall
+(two RPC calls regardless of size) reading v2 state (`PermissionedRegistry.getState()`) and v1 expiry
+(`BaseRegistrar.nameExpires()`), then submitted as one `BatchRegistrar.batchRegister()` transaction.
+Per-name action:
 
 | v2 status | v1 status | Action |
 |---|---|---|
@@ -85,47 +138,43 @@ Names stream from the CSV in batches of `--batch-size`. Each batch is verified w
 | Registered (2) | Any | **Fail** (already fully owned on v2) |
 | Any | Never registered, or past v1's 90-day grace | **Skip** (v1 owner lost the claim) |
 
-Reserved names are written with owner/registry `address(0)`, resolver = `ENSV1Resolver`, roleBitmap `0`, and the computed expiry.
+Reserved names are written with owner/registry `address(0)`, resolver = `ENSV1Resolver`, roleBitmap
+`0`, and the computed expiry.
 
-**Gas safety.** Before submitting, the script estimates gas; if it exceeds 80% of the block limit the batch is split in half and re-estimated (recursively). If a batch reverts at execution, it is recursively halved and retried (binary search) until failing names are isolated — preserving partial progress. A checkpoint is saved after each batch.
+**Gas safety.** Before submitting, the script estimates gas; if it exceeds 80% of the block limit the
+batch is split in half and re-estimated (recursively). If a batch reverts at execution, it is
+recursively halved and retried (binary search) until failing names are isolated — preserving partial
+progress. A checkpoint is saved after each batch.
 
 ## Checkpoint & resume
 
-A checkpoint (`preMigration-checkpoint.json`) is written after each batch, tracking the last processed line and accumulated counters (reserved, renewed, skipped, invalid, failed). `--continue` loads it, sets `--start-index` to the last processed line, and resumes; counters accumulate across runs.
-
-```bash
-bun run script/preMigration.ts --continue [same options as before]
-```
+A checkpoint (`preMigration-checkpoint.json`) is written after each batch, tracking the last processed
+line and accumulated counters (reserved, renewed, skipped, invalid, failed). `--continue` loads it,
+sets `--start-index` to the last processed line, and resumes; counters accumulate across runs. See the
+resume command in [Quick start](#quick-start).
 
 ## Dry run
 
-`--dry-run` runs the full pipeline — CSV parse, v1/v2 verification, expiry computation, checkpointing — and logs what would happen, but sends no transactions.
+`--dry-run` runs the full pipeline — CSV parse, v1/v2 verification, expiry computation, checkpointing
+— and logs what would happen, but sends no transactions. It is the default first step in
+[Quick start](#quick-start).
 
 ## Output
 
-Informational output goes to `preMigration.log` and errors to `preMigration-errors.log`; the console mirrors progress with a final summary table (processed / reserved / renewed / skipped / invalid / failed / success rate). Non-CSV failures (individual name reverts, RPC timeouts at a 30s per-call limit, checkpoint write errors) are counted and logged without aborting the run.
-
-## Examples
-
-```bash
-export PREMIGRATION_PRIVATE_KEY=0x...
-
-# Dry run first
-bun run script/preMigration.ts \
-  --rpc-url <url> --registry <addr> --batch-registrar <addr> \
-  --v1-resolver <addr> --csv-file ./data/v1-registrations.csv --dry-run
-
-# Execute (drop --dry-run); resume after an interruption with --continue
-bun run script/preMigration.ts \
-  --rpc-url <url> --registry <addr> --batch-registrar <addr> \
-  --v1-resolver <addr> --csv-file ./data/v1-registrations.csv
-```
+Informational output goes to `preMigration.log` and errors to `preMigration-errors.log`; the console
+mirrors progress with a final summary table (processed / reserved / renewed / skipped / invalid /
+failed / success rate). Non-CSV failures (individual name reverts, RPC timeouts at a 30s per-call
+limit, checkpoint write errors) are counted and logged without aborting the run.
 
 ## Testing on a Sepolia fork
 
-To rehearse pre-migration against real Sepolia v1 state without a full `fork full` run, deploy the v2 stack onto a local Anvil fork (v2 is not on real Sepolia) and run pre-migration against it.
+To rehearse pre-migration against real Sepolia v1 state without a full `fork full` run, deploy the v2
+stack onto a local Anvil fork (v2 is not on real Sepolia) and run pre-migration against it.
 
-> **Account requirement:** the deployer/owner must be an address with **no code** on Sepolia. The standard Anvil test accounts carry an EIP-7702 delegation there, so their `onERC1155Received` does not return the ERC-1155 acceptance value and the `eth` 2LD mint during deploy reverts. Use a fresh throwaway key funded via `anvil_setBalance`.
+> **Account requirement:** the deployer/owner must be an address with **no code** on Sepolia. The
+> standard Anvil test accounts carry an EIP-7702 delegation there, so their `onERC1155Received` does
+> not return the ERC-1155 acceptance value and the `eth` 2LD mint during deploy reverts. Use a fresh
+> throwaway key funded via `anvil_setBalance`.
 
 ```bash
 # 1. Fork Sepolia
@@ -150,4 +199,5 @@ bun run migration -- premigration verify --network sepolia --rpc-url http://127.
   --csv-file ./csv-data/ens-registrations-sepolia.csv
 ```
 
-For the full phased rehearsal instead, see the `fork full` command in [migration.md](./migration.md#rehearsals).
+For the full phased rehearsal instead, see the `fork full` command in
+[migration.md](./migration.md#rehearsals).

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -29,12 +29,11 @@
     "chai": "^5.1.1",
     "ethers": "^6.15.0",
     "solgrid": "0.0.16",
-    "ts-node": "^10.9.2",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "3.1.3"
   },
   "peerDependencies": {
-    "typescript": "^5.8.3"
+    "typescript": "^7.0.2"
   },
   "engineStrict": true,
   "engines": {

--- a/contracts/script/migration.ts
+++ b/contracts/script/migration.ts
@@ -52,6 +52,8 @@ import {
 } from "./deploy-constants.js";
 import { main as exportRegistrationsMain } from "./exportTheGraphRegistrations.js";
 import {
+  CHECKPOINT_FILE,
+  type Checkpoint,
   createFreshCheckpoint,
   isValidLabel,
   loadCheckpoint,
@@ -396,9 +398,7 @@ function csvLabelColumnIndex(header: string[]): number {
 // Quote a CSV field when it contains a delimiter, quote, or newline so labels
 // with such characters survive a round-trip through the premigration reader.
 function escapeCsvField(value: string): string {
-  return /[",\n\r]/.test(value)
-    ? `"${value.replace(/"/g, '""')}"`
-    : value;
+  return /[",\n\r]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
 }
 
 function readLabelsFromCsv(csvFile: string, limit?: number): string[] {
@@ -407,9 +407,7 @@ function readLabelsFromCsv(csvFile: string, limit?: number): string[] {
   const header = parseCSVLine(lines[0]);
   const labelIndex = csvLabelColumnIndex(header);
   if (labelIndex < 0) {
-    throw new Error(
-      `CSV must contain a labelName or label column: ${csvFile}`,
-    );
+    throw new Error(`CSV must contain a labelName or label column: ${csvFile}`);
   }
   const labels: string[] = [];
   for (const line of lines.slice(1)) {
@@ -1111,6 +1109,8 @@ export async function runPreMigrationCommand(
     v1BaseRegistrar?: Address;
     workDir?: string;
     dryRun?: boolean;
+    metadataLabel?: string;
+    persistMetadata?: boolean;
   },
   resume: boolean,
 ) {
@@ -1190,6 +1190,24 @@ export async function runPreMigrationCommand(
       args.push("--bonus-period-days", opts.bonusPeriodDays);
     if (resume) args.push("--continue");
     await preMigrationMain(args);
+
+    // Persist a durable counts sidecar into the deployment namespace. Skipped on
+    // dry runs and when the caller opts out (e.g. a fork rehearsal that does not
+    // save deployments), so a committed namespace is never touched by a throwaway
+    // run. The checkpoint lands in the workDir (or cwd when none was set).
+    if (!opts.dryRun && (opts.persistMetadata ?? true)) {
+      const cpDir = opts.workDir ? resolve(opts.workDir) : previousCwd;
+      const checkpoint = loadCheckpoint(join(cpDir, CHECKPOINT_FILE));
+      if (checkpoint) {
+        recordPreMigrationMetadata({
+          deploymentsDir,
+          deploymentNetwork,
+          network,
+          label: opts.metadataLabel ?? "run",
+          checkpoint,
+        });
+      }
+    }
   } finally {
     process.chdir(previousCwd);
   }
@@ -1398,9 +1416,7 @@ async function verifyPreMigration(opts: {
   console.log(`eligible v1 names: ${eligible}`);
   console.log(`skipped ineligible names: ${skipped}`);
   console.log(`verified active names: ${verifiedActive}`);
-  console.log(
-    `verified expired-bonus names: ${verifiedExpiredBonus}`,
-  );
+  console.log(`verified expired-bonus names: ${verifiedExpiredBonus}`);
   console.log(`verified names: ${verifiedActive + verifiedExpiredBonus}`);
   if (errors.length > 0) {
     console.error(errors.slice(0, 20).join("\n"));
@@ -1527,7 +1543,8 @@ async function sendAdminWrite(opts: {
     );
     return;
   }
-  if (opts.impersonateAccount) await impersonate(opts.client, opts.impersonateAccount);
+  if (opts.impersonateAccount)
+    await impersonate(opts.client, opts.impersonateAccount);
   const wallet = walletClient({
     rpcUrl: opts.rpcUrl,
     chain: opts.chain,
@@ -2154,7 +2171,11 @@ function resolveRegistry(opts: {
 }): ContractRef {
   const registry = opts.registry
     ? null
-    : loadV2Deployment(opts.deploymentsDir, opts.deploymentNetwork, "ETHRegistry");
+    : loadV2Deployment(
+        opts.deploymentsDir,
+        opts.deploymentNetwork,
+        "ETHRegistry",
+      );
   return {
     address: opts.registry ?? registry!.address,
     abi: registry?.abi ?? Artifact_PermissionedRegistry.abi,
@@ -2201,7 +2222,11 @@ async function enableV2Registrar(opts: {
     deploymentNetwork,
     "ETHRegistrar",
   );
-  const beforeEnabled = await readHasRegistrarRoles(client, registry, ethRegistrar);
+  const beforeEnabled = await readHasRegistrarRoles(
+    client,
+    registry,
+    ethRegistrar,
+  );
   console.log(`v2 registrar already enabled: ${beforeEnabled}`);
   if (beforeEnabled) return;
 
@@ -2216,7 +2241,11 @@ async function enableV2Registrar(opts: {
     privateKey: opts.privateKey,
     impersonateAccount: opts.impersonateAccount,
   });
-  const afterEnabled = await readHasRegistrarRoles(client, registry, ethRegistrar);
+  const afterEnabled = await readHasRegistrarRoles(
+    client,
+    registry,
+    ethRegistrar,
+  );
   console.log(`v2 registrar enabled after phase: ${afterEnabled}`);
 }
 
@@ -2789,7 +2818,8 @@ function signerKeyForAccount(
   const keys = candidates.filter((key): key is `0x${string}` => Boolean(key));
   if (!target) return keys[0];
   return keys.find(
-    (key) => getAddress(privateKeyToAccount(key).address) === getAddress(target),
+    (key) =>
+      getAddress(privateKeyToAccount(key).address) === getAddress(target),
   );
 }
 
@@ -3134,7 +3164,9 @@ async function deployV1(opts: DeployV1Options) {
 export async function deployV2(opts: DeployV2Options) {
   const network = NETWORKS[opts.network];
   const deploymentNetwork = opts.deploymentNetwork ?? network.environment;
-  const deploymentsDir = resolve(opts.deploymentsDir ?? DEFAULT_DEPLOYMENTS_DIR);
+  const deploymentsDir = resolve(
+    opts.deploymentsDir ?? DEFAULT_DEPLOYMENTS_DIR,
+  );
   // A fresh deployment archives any existing namespace and therefore must
   // persist the new one, so it implies saving regardless of the flag.
   const persist = Boolean(opts.saveDeployments) || Boolean(opts.fresh);
@@ -3742,7 +3774,11 @@ function loadV2MigrationDeployments(
       deploymentNetwork,
       "ETHRenewerV1",
     ),
-    mockUsdc: maybeLoadV2Deployment(deploymentsDir, deploymentNetwork, "MockUSDC"),
+    mockUsdc: maybeLoadV2Deployment(
+      deploymentsDir,
+      deploymentNetwork,
+      "MockUSDC",
+    ),
     unlockedMigrationController: loadV2Deployment(
       deploymentsDir,
       deploymentNetwork,
@@ -4097,10 +4133,11 @@ export async function runForkFull(opts: RunForkFullOptions) {
     // Signer for the v1-owner-gated controller changes (disable registrars,
     // authorize the renewer, hand off ownership). On a fork we impersonate the
     // owner; for a live run we require the key that controls it.
-    const v1OwnerSigner: { impersonateOwner: true } | { privateKey: `0x${string}` } =
-      useRpcStateControls
-        ? { impersonateOwner: true }
-        : { privateKey: requirePrivateKeyForAddress(v1Owner, keys, "v1 owner") };
+    const v1OwnerSigner:
+      | { impersonateOwner: true }
+      | { privateKey: `0x${string}` } = useRpcStateControls
+      ? { impersonateOwner: true }
+      : { privateKey: requirePrivateKeyForAddress(v1Owner, keys, "v1 owner") };
 
     // The migration wraps whatever the canonical top proxy currently serves.
     // When reusing a long-lived intermediate URP, the top proxy already fronts
@@ -4224,6 +4261,8 @@ export async function runForkFull(opts: RunForkFullOptions) {
         batchSize: opts.batchSize,
         limit: opts.initialLimit,
         workDir,
+        metadataLabel: "initial",
+        persistMetadata: Boolean(opts.saveDeployments),
       },
       resumeFromPhase === 2,
     );
@@ -4303,9 +4342,7 @@ export async function runForkFull(opts: RunForkFullOptions) {
           "ETHRenewerV1 was not authorized as a v1 BaseRegistrar controller in phase 4",
         );
       }
-      console.log(
-        "smoke ETHRenewerV1 authorized as a v1 renewal controller",
-      );
+      console.log("smoke ETHRenewerV1 authorized as a v1 renewal controller");
     }
 
     console.log("phase 5: sync remaining names and finish pre-migration");
@@ -4326,8 +4363,10 @@ export async function runForkFull(opts: RunForkFullOptions) {
         batchSize: opts.batchSize,
         limit: opts.finishLimit,
         workDir: finalSyncWorkDir,
+        metadataLabel: "final-sync",
+        persistMetadata: Boolean(opts.saveDeployments),
       },
-      existsSync(join(finalSyncWorkDir, "preMigration-checkpoint.json")),
+      existsSync(join(finalSyncWorkDir, CHECKPOINT_FILE)),
     );
     if (!postMigration) {
       await assertV2State({
@@ -4366,7 +4405,9 @@ export async function runForkFull(opts: RunForkFullOptions) {
         status: STATUS.REGISTERED,
         owner: smokeMigrationOwner,
       });
-      console.log(`smoke migration registered ${smokeLabels.migrate}.eth on v2`);
+      console.log(
+        `smoke migration registered ${smokeLabels.migrate}.eth on v2`,
+      );
     }
 
     console.log(
@@ -4781,11 +4822,7 @@ function addV1OwnerWriteOptions(command: Command): Command {
   return command
     .option("--private-key <key>", "V1 owner private key")
     .option("--impersonate-owner", "Impersonate owner on a fork", false)
-    .option(
-      "--calldata-only",
-      "Print transaction target and calldata",
-      false,
-    );
+    .option("--calldata-only", "Print transaction target and calldata", false);
 }
 
 function assertCleanDeploymentNamespace(
@@ -4837,6 +4874,125 @@ function recordDeploymentMetadata(
   );
 }
 
+const PREMIGRATION_METADATA_FILE = ".premigration.json";
+
+// One summary entry per logical pre-migration run (initial, final-sync, or a
+// standalone run). Counts only — never label strings.
+interface PreMigrationRunSummary {
+  label: string;
+  finishedAt: string;
+  totalExpected: number;
+  totalProcessed: number;
+  reserved: number;
+  renewed: number;
+  skippedNeverRegistered: number;
+  skippedExpiredPastGrace: number;
+  invalidLabels: number;
+  alreadyOnV2: number;
+  failed: number;
+}
+
+interface PreMigrationMetadata {
+  network: string;
+  deploymentNetwork: string;
+  chainId?: number;
+  updatedAt: string;
+  resolved: {
+    finishedAt: string;
+    totalNames: number;
+    namesPreMigrated: number;
+    newReservations: number;
+    expiryResyncs: number;
+    skippedNeverRegistered: number;
+    skippedExpiredPastGrace: number;
+    invalidLabels: number;
+    alreadyOnV2: number;
+    failed: number;
+  };
+  runs: PreMigrationRunSummary[];
+}
+
+function checkpointToRunSummary(
+  label: string,
+  checkpoint: Checkpoint,
+): PreMigrationRunSummary {
+  return {
+    label,
+    finishedAt: checkpoint.timestamp,
+    totalExpected: checkpoint.totalExpected,
+    totalProcessed: checkpoint.totalProcessed,
+    reserved: checkpoint.successCount,
+    renewed: checkpoint.renewedCount,
+    skippedNeverRegistered: checkpoint.skippedNeverRegisteredCount,
+    skippedExpiredPastGrace: checkpoint.skippedPastGraceCount,
+    invalidLabels: checkpoint.invalidLabelCount,
+    alreadyOnV2: checkpoint.alreadyRegisteredCount,
+    failed: checkpoint.failureCount,
+  };
+}
+
+// The resolved roll-up reflects the run that finished most recently, which in
+// the phased flow is the final-sync pass that re-scans the whole corpus and so
+// represents the end state. `namesPreMigrated` = names currently reserved on v2
+// (newly reserved this run + already-reserved names whose expiry was re-synced).
+function resolveFromRuns(
+  runs: PreMigrationRunSummary[],
+): PreMigrationMetadata["resolved"] {
+  const latest = runs.reduce((a, b) => (b.finishedAt >= a.finishedAt ? b : a));
+  return {
+    finishedAt: latest.finishedAt,
+    totalNames: latest.totalExpected,
+    namesPreMigrated: latest.reserved + latest.renewed,
+    newReservations: latest.reserved,
+    expiryResyncs: latest.renewed,
+    skippedNeverRegistered: latest.skippedNeverRegistered,
+    skippedExpiredPastGrace: latest.skippedExpiredPastGrace,
+    invalidLabels: latest.invalidLabels,
+    alreadyOnV2: latest.alreadyOnV2,
+    failed: latest.failed,
+  };
+}
+
+// Persists a compact pre-migration counts sidecar into the deployment
+// namespace, alongside `.deployment.json`. A dotfile so rocketh's loader ignores
+// it (it only reads `.migrations.json` + non-dot `*.json` artifacts). Each run
+// is upserted by `label` so a resume that re-writes its accumulated checkpoint
+// updates its own entry in place instead of appending a duplicate.
+function recordPreMigrationMetadata(opts: {
+  deploymentsDir: string;
+  deploymentNetwork: string;
+  network: MigrationNetwork;
+  label: string;
+  checkpoint: Checkpoint;
+}) {
+  const dir = join(opts.deploymentsDir, opts.deploymentNetwork);
+  if (!existsSync(dir)) return;
+  const metadataPath = join(dir, PREMIGRATION_METADATA_FILE);
+
+  let existing: PreMigrationMetadata | undefined;
+  if (existsSync(metadataPath)) {
+    try {
+      existing = JSON.parse(readFileSync(metadataPath, "utf-8"));
+    } catch {
+      existing = undefined;
+    }
+  }
+
+  const runs = (existing?.runs ?? []).filter((run) => run.label !== opts.label);
+  runs.push(checkpointToRunSummary(opts.label, opts.checkpoint));
+
+  const metadata: PreMigrationMetadata = {
+    network: opts.network,
+    deploymentNetwork: opts.deploymentNetwork,
+    chainId: NETWORKS[opts.network].chain.id,
+    updatedAt: new Date().toISOString(),
+    resolved: resolveFromRuns(runs),
+    runs,
+  };
+
+  writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+}
+
 // Resolves a namespace's deploy time, preferring the recorded metadata and
 // falling back to the latest `.migrations.json` entry (unix-epoch seconds).
 function readDeploymentDeployedAt(path: string): string | undefined {
@@ -4850,8 +5006,9 @@ function readDeploymentDeployedAt(path: string): string | undefined {
   const migrationsPath = join(path, ".migrations.json");
   if (existsSync(migrationsPath)) {
     try {
-      const migrations = JSON.parse(readFileSync(migrationsPath, "utf-8")) as
-        Record<string, number>;
+      const migrations = JSON.parse(
+        readFileSync(migrationsPath, "utf-8"),
+      ) as Record<string, number>;
       const timestamps = Object.values(migrations).filter(
         (value) => typeof value === "number" && Number.isFinite(value),
       );
@@ -4873,8 +5030,7 @@ function archiveExistingDeploymentNamespace(root: string, environment: string) {
     (file) => file.endsWith(".json") || file === ".chain",
   );
   if (!hasArtifacts) return;
-  const deployedAt =
-    readDeploymentDeployedAt(path) ?? new Date().toISOString();
+  const deployedAt = readDeploymentDeployedAt(path) ?? new Date().toISOString();
   const stamp = deployedAt.slice(0, 10).replace(/-/g, "");
   let revision = 1;
   let archive = `${environment}-${stamp}-r${revision}`;
@@ -5080,6 +5236,7 @@ export async function main(argv = process.argv): Promise<void> {
       await runPreMigrationCommand(
         {
           ...networkOpts,
+          metadataLabel: "run",
         },
         false,
       );
@@ -5093,6 +5250,7 @@ export async function main(argv = process.argv): Promise<void> {
       await runPreMigrationCommand(
         {
           ...networkOpts,
+          metadataLabel: "run",
         },
         true,
       );
@@ -5284,8 +5442,7 @@ export async function main(argv = process.argv): Promise<void> {
         const networkOpts = withNetworkRpc(opts);
         await setV1ReverseDefaultResolver({
           ...networkOpts,
-          privateKey:
-            v1OwnerKeyFromEnv(opts),
+          privateKey: v1OwnerKeyFromEnv(opts),
         });
       },
     ),
@@ -5398,8 +5555,7 @@ export async function main(argv = process.argv): Promise<void> {
         const networkOpts = withNetworkRpc(opts);
         await authorizeTestnetV1PremigrationRegistrar({
           ...networkOpts,
-          privateKey:
-            v1OwnerKeyFromEnv(opts),
+          privateKey: v1OwnerKeyFromEnv(opts),
         });
       },
     ),
@@ -5427,8 +5583,7 @@ export async function main(argv = process.argv): Promise<void> {
         const networkOpts = withNetworkRpc(opts);
         await activateV1Graveyard({
           ...networkOpts,
-          privateKey:
-            v1OwnerKeyFromEnv(opts),
+          privateKey: v1OwnerKeyFromEnv(opts),
         });
       },
     ),
@@ -5463,8 +5618,7 @@ export async function main(argv = process.argv): Promise<void> {
         const networkOpts = withNetworkRpc(opts);
         await activateV1HandoffControllers({
           ...networkOpts,
-          privateKey:
-            v1OwnerKeyFromEnv(opts),
+          privateKey: v1OwnerKeyFromEnv(opts),
         });
       },
     ),
@@ -5492,8 +5646,7 @@ export async function main(argv = process.argv): Promise<void> {
         const networkOpts = withNetworkRpc(opts);
         await authorizeV1Renewer({
           ...networkOpts,
-          privateKey:
-            v1OwnerKeyFromEnv(opts),
+          privateKey: v1OwnerKeyFromEnv(opts),
         });
       },
     ),
@@ -5521,8 +5674,7 @@ export async function main(argv = process.argv): Promise<void> {
         const networkOpts = withNetworkRpc(opts);
         await activateV1RenewerAndTransferOwnership({
           ...networkOpts,
-          privateKey:
-            v1OwnerKeyFromEnv(opts),
+          privateKey: v1OwnerKeyFromEnv(opts),
         });
       },
     ),
@@ -5557,8 +5709,7 @@ export async function main(argv = process.argv): Promise<void> {
         const networkOpts = withNetworkRpc(opts);
         await reclaimV1RegistrarOwnership({
           ...networkOpts,
-          v1Owner:
-            opts.v1Owner ?? NETWORKS[networkOpts.network].defaultV1Owner,
+          v1Owner: opts.v1Owner ?? NETWORKS[networkOpts.network].defaultV1Owner,
           privateKey:
             opts.privateKey ?? envPrivateKey("OWNER_KEY", "DEPLOYER_KEY"),
         });

--- a/contracts/script/preMigrateDevnetNames.ts
+++ b/contracts/script/preMigrateDevnetNames.ts
@@ -1,0 +1,210 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  getAddress,
+  isAddress,
+  keccak256,
+  namehash,
+  parseEther,
+  stringToBytes,
+  zeroAddress,
+  type Address,
+} from "viem";
+
+import {
+  FUSES,
+  PREMIGRATION_BONUS_PERIOD,
+  SEC_PER_DAY,
+  STATUS,
+} from "./deploy-constants.js";
+import { main as preMigrationMain } from "./preMigration.js";
+import { buildMainArgs, createCSVFile, verifyV2State } from "./preMigrationUtils.js";
+import type { DevnetEnvironment } from "./setup.js";
+
+// Curated real-mainnet .eth 2LDs sourced from morticia's e2e scenario config
+// (test/e2e/test-e2e-mainnet-fork-config.json). Chosen to span every migration
+// criterion in ten names: unwrapped, wrapped-locked, and wrapped-but-unlocked,
+// so the frontend has both migration paths and the notable fuse edge cases.
+// Only labels are pinned; every live property (wrap state, owner, fuses,
+// expiry) is read from the fork at runtime, so the set survives any fork block.
+const CURATED_NAMES: { label: string; note: string }[] = [
+  { label: "swissborg", note: "normal unwrapped happy-path (alphabetic, resolver set)" },
+  { label: "00relayer", note: "unwrapped, leading-zero label, small subtree" },
+  { label: "2718", note: "unwrapped, all-numeric label, multi-subname" },
+  { label: "$beep", note: "wrapped-locked, special '$' char, minimal subtree" },
+  { label: "agi", note: "wrapped-locked, carries a locked child + third-party child" },
+  { label: "ethscriptions", note: "wrapped-locked, burn-address owner, emancipated child" },
+  { label: "holer", note: "wrapped-but-UNLOCKED/emancipated (no CANNOT_UNWRAP)" },
+  { label: "analyzes", note: "wrapped-locked, shared batch owner" },
+  { label: "daomarketplace", note: "wrapped-locked, shared batch owner" },
+  { label: "alertbot", note: "wrapped-locked + CANNOT_TRANSFER (reassignment skipped)" },
+];
+
+export interface PreMigrateDevnetOptions {
+  // A devnet named account key (deployer/owner/user/user2) or a raw address to
+  // receive v1 ownership of the reserved names. When unset, names are left
+  // reserved-only (still owned by their real forked mainnet owners).
+  reassignOwnerTo?: string;
+  // Override the curated label set (for tests and smoke runs).
+  labels?: string[];
+}
+
+// The BaseRegistrar ERC-721 id is the labelhash; the NameWrapper ERC-1155 id
+// is the namehash of the full 2LD.
+function baseRegistrarId(label: string): bigint {
+  return BigInt(keccak256(stringToBytes(label)));
+}
+function nameWrapperId(label: string): bigint {
+  return BigInt(namehash(`${label}.eth`));
+}
+
+function resolveTarget(env: DevnetEnvironment, keyOrAddress: string): Address {
+  if (keyOrAddress in env.namedAccounts) {
+    return env.namedAccounts[
+      keyOrAddress as keyof DevnetEnvironment["namedAccounts"]
+    ].address;
+  }
+  if (isAddress(keyOrAddress)) {
+    return getAddress(keyOrAddress);
+  }
+  throw new Error(
+    `--preMigrateOwner must be a named account (${Object.keys(
+      env.namedAccounts,
+    ).join(", ")}) or an address, got: ${keyOrAddress}`,
+  );
+}
+
+async function fund(env: DevnetEnvironment, address: Address): Promise<void> {
+  await env.client.setBalance({ address, value: parseEther("100") });
+}
+
+// Move v1 ownership of a reserved name to `target` so a fixed devnet wallet
+// owns it and can drive the migration in-app. Anvil autoImpersonate lets us
+// send from the real owner directly. Returns how the name was handled.
+async function reassignOwner(
+  env: DevnetEnvironment,
+  label: string,
+  target: Address,
+): Promise<"wrapped" | "unwrapped" | "skipped"> {
+  const [wrapperOwner, fuses] = await env.v1.NameWrapper.read.getData([
+    nameWrapperId(label),
+  ]);
+
+  if (wrapperOwner !== zeroAddress) {
+    if ((Number(fuses) & FUSES.CANNOT_TRANSFER) !== 0) {
+      console.log(`  ⊘ ${label}.eth: CANNOT_TRANSFER burned — left reserve-only`);
+      return "skipped";
+    }
+    await fund(env, wrapperOwner);
+    await env.waitFor(
+      env.v1.NameWrapper.write.safeTransferFrom(
+        [wrapperOwner, target, nameWrapperId(label), 1n, "0x"],
+        { account: wrapperOwner },
+      ),
+    );
+    return "wrapped";
+  }
+
+  const labelId = baseRegistrarId(label);
+  const registrant = await env.v1.BaseRegistrar.read.ownerOf([labelId]);
+  if (registrant === zeroAddress) {
+    console.log(`  ⊘ ${label}.eth: no v1 owner — left reserve-only`);
+    return "skipped";
+  }
+  await fund(env, registrant);
+  await env.waitFor(
+    env.v1.BaseRegistrar.write.transferFrom([registrant, target, labelId], {
+      account: registrant,
+    }),
+  );
+  // Align the ENS registry record with the new token owner. Non-fatal.
+  try {
+    await fund(env, target);
+    await env.waitFor(
+      env.v1.BaseRegistrar.write.reclaim([labelId, target], { account: target }),
+    );
+  } catch (err) {
+    console.log(`  ! ${label}.eth: reclaim skipped (${err})`);
+  }
+  return "unwrapped";
+}
+
+// Pre-migrate the curated names on a running fork devnet: reserve them on v2
+// (RESERVED state, ENSV1Resolver fallback) and optionally reassign v1 ownership
+// to a devnet account. Intended to be called after env.activateV2() in fork mode.
+export async function preMigrateDevnetNames(
+  env: DevnetEnvironment,
+  opts: PreMigrateDevnetOptions = {},
+): Promise<void> {
+  // Resolve the reassignment target up front so a bad value fails before the
+  // reservation work.
+  const target = opts.reassignOwnerTo
+    ? resolveTarget(env, opts.reassignOwnerTo)
+    : undefined;
+
+  const names = opts.labels
+    ? opts.labels.map((label) => ({ label, note: "override" }))
+    : CURATED_NAMES;
+  const labels = names.map((n) => n.label);
+  console.log(`\n========== Pre-migrating ${labels.length} names ==========`);
+  for (const { label, note } of names) {
+    console.log(`  • ${label}.eth — ${note}`);
+  }
+
+  const csvPath = join(tmpdir(), `devnet-premigrate-${env.client.chain.id}.csv`);
+  createCSVFile(csvPath, labels);
+  // Mirror the DAO pre-migration by extending each v2 expiry with the
+  // production bonus period, so names within the v1 grace period (or expiring
+  // during testing) stay RESERVED on v2 rather than reading back as AVAILABLE.
+  await preMigrationMain(
+    buildMainArgs(env, csvPath, {
+      limit: labels.length,
+      bonusPeriodDays: Number(PREMIGRATION_BONUS_PERIOD / SEC_PER_DAY),
+    }),
+  );
+
+  if (target) {
+    console.log(`\nReassigning v1 ownership to ${target}...`);
+    // Default anvil accounts carry an EIP-7702 delegation on mainnet; the
+    // ERC-1155 acceptance check reverts against delegated code, so clear it and
+    // let the target receive wrapped names as a plain EOA.
+    await env.client.setCode({ address: target, bytecode: "0x" });
+  }
+
+  const summary: {
+    Name: string;
+    Status: string;
+    Reassigned: string;
+  }[] = [];
+  for (const { label } of names) {
+    const { status } = await verifyV2State(env, label);
+    const statusLabel =
+      status === STATUS.RESERVED
+        ? "reserved"
+        : status === STATUS.REGISTERED
+          ? "registered"
+          : "available";
+
+    let reassigned = "—";
+    if (target) {
+      if (status === STATUS.RESERVED) {
+        try {
+          reassigned = await reassignOwner(env, label, target);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.log(`  ✗ ${label}.eth: reassignment failed — ${msg}`);
+          reassigned = "failed";
+        }
+      } else {
+        reassigned = "skipped (not reserved)";
+      }
+    }
+    summary.push({
+      Name: `${label}.eth`,
+      Status: statusLabel,
+      Reassigned: reassigned,
+    });
+  }
+
+  console.table(summary);
+}

--- a/contracts/script/preMigration.ts
+++ b/contracts/script/preMigration.ts
@@ -5,6 +5,7 @@ import {
   createReadStream,
   existsSync,
   readFileSync,
+  rmSync,
   writeFileSync,
 } from "node:fs";
 import {
@@ -118,13 +119,21 @@ export interface Checkpoint {
   successCount: number;
   renewedCount: number;
   failureCount: number;
+  /// Aggregate of the two skip sub-counters below (names not claimable on v1).
   skippedCount: number;
+  /// Names skipped because they were never registered on v1.
+  skippedNeverRegisteredCount: number;
+  /// Names skipped because their v1 registration lapsed past the grace period.
+  skippedPastGraceCount: number;
+  /// Names skipped because they are already registered (owned) on v2. Tracked
+  /// separately from genuine failures.
+  alreadyRegisteredCount: number;
   invalidLabelCount: number;
   timestamp: string;
 }
 
 // Constants
-const CHECKPOINT_FILE = "preMigration-checkpoint.json";
+export const CHECKPOINT_FILE = "preMigration-checkpoint.json";
 const ERROR_LOG_FILE = "preMigration-errors.log";
 const INFO_LOG_FILE = "preMigration.log";
 
@@ -151,6 +160,9 @@ export function createFreshCheckpoint(): Checkpoint {
     renewedCount: 0,
     failureCount: 0,
     skippedCount: 0,
+    skippedNeverRegisteredCount: 0,
+    skippedPastGraceCount: 0,
+    alreadyRegisteredCount: 0,
     invalidLabelCount: 0,
     timestamp: new Date().toISOString(),
   };
@@ -300,20 +312,23 @@ class PreMigrationLogger extends Logger {
       `  → ⊘ Skipping: ${domainName} (invalid label name)`,
     );
   }
-
 }
 
 const logger = new PreMigrationLogger();
 
 // Checkpoint management
-export function loadCheckpoint(): Checkpoint | null {
-  if (!existsSync(CHECKPOINT_FILE)) {
+export function loadCheckpoint(
+  path: string = CHECKPOINT_FILE,
+): Checkpoint | null {
+  if (!existsSync(path)) {
     return null;
   }
 
   try {
-    const data = readFileSync(CHECKPOINT_FILE, "utf-8");
-    return JSON.parse(data);
+    const data = readFileSync(path, "utf-8");
+    // Spread over a fresh checkpoint so counters added after an older run was
+    // written default to 0 rather than undefined (which would break `count++`).
+    return { ...createFreshCheckpoint(), ...JSON.parse(data) };
   } catch (error) {
     logger.error(`Failed to load checkpoint: ${error}`);
     return null;
@@ -325,6 +340,18 @@ export function saveCheckpoint(checkpoint: Checkpoint): void {
     writeFileSync(CHECKPOINT_FILE, JSON.stringify(checkpoint, null, 2));
   } catch (error) {
     logger.error(`Failed to save checkpoint: ${error}`);
+  }
+}
+
+// Removes any checkpoint left in the work directory so a fresh run cannot
+// inherit stale counts from a previous one. A run that processes zero batches
+// writes no new checkpoint, so without this a lingering file would otherwise be
+// mistaken for this run's result by anything that reads the checkpoint after.
+export function clearCheckpoint(path: string = CHECKPOINT_FILE): void {
+  try {
+    rmSync(path, { force: true });
+  } catch (error) {
+    logger.error(`Failed to clear checkpoint: ${error}`);
   }
 }
 
@@ -979,7 +1006,7 @@ async function processBatch(
       logger.error(
         `Name ${registration.labelName}.eth is already registered with owner: ${result.v2LatestOwner}`,
       );
-      checkpoint.failureCount++;
+      checkpoint.alreadyRegisteredCount++;
       checkpoint.totalProcessed++;
       logger.finishedName(registration.labelName, "failed");
       continue;
@@ -989,12 +1016,17 @@ async function processBatch(
     }
 
     if (!result.v1IsClaimable) {
-      const reason =
-        result.v1Expiry === 0n
-          ? "never registered on v1"
-          : `past v1 ${V1_GRACE_PERIOD_DAYS}-day grace period`;
+      const neverRegistered = result.v1Expiry === 0n;
+      const reason = neverRegistered
+        ? "never registered on v1"
+        : `past v1 ${V1_GRACE_PERIOD_DAYS}-day grace period`;
       logger.v1NotRegistered(registration.labelName, reason);
       checkpoint.skippedCount++;
+      if (neverRegistered) {
+        checkpoint.skippedNeverRegisteredCount++;
+      } else {
+        checkpoint.skippedPastGraceCount++;
+      }
       checkpoint.totalProcessed++;
       logger.finishedName(registration.labelName, "skipped");
       continue;
@@ -1096,8 +1128,20 @@ function printFinalSummary(checkpoint: Checkpoint): void {
     cyan(checkpoint.renewedCount.toString()),
   );
   logger.config(
-    "Skipped (already up-to-date/expired)",
+    "Skipped (not claimable on v1)",
     yellow(checkpoint.skippedCount.toString()),
+  );
+  logger.config(
+    "  → never registered on v1",
+    yellow(checkpoint.skippedNeverRegisteredCount.toString()),
+  );
+  logger.config(
+    "  → expired past v1 grace period",
+    yellow(checkpoint.skippedPastGraceCount.toString()),
+  );
+  logger.config(
+    "Already registered on v2",
+    yellow(checkpoint.alreadyRegisteredCount.toString()),
   );
   logger.config(
     "Invalid labels",
@@ -1263,6 +1307,8 @@ export async function main(argv = process.argv): Promise<void> {
         );
         logger.info(`Resuming from CSV line ${config.startIndex}`);
       }
+    } else if (!config.disableCheckpoint) {
+      clearCheckpoint();
     }
     logger.info("");
 

--- a/contracts/script/preMigrationUtils.ts
+++ b/contracts/script/preMigrationUtils.ts
@@ -1,0 +1,92 @@
+import { writeFileSync } from "node:fs";
+import { keccak256, stringToBytes, type Address } from "viem";
+import type { DevnetEnvironment } from "./setup.js";
+
+// Default anvil/test-mnemonic account 0, which is the devnet deployer and the
+// BatchRegistrar owner. Used to sign pre-migration reservations on the devnet.
+export const DEPLOYER_PRIVATE_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as const;
+
+// LibLabel.id() — the .eth token id derived from a label.
+function idFromLabel(label: string): bigint {
+  return BigInt(keccak256(stringToBytes(label)));
+}
+
+const CSV_HEADER =
+  "node,name,labelHash,owner,parentName,parentLabelHash,labelName,registrationDate,expiryDate";
+
+export function createCSVFile(filePath: string, labels: string[]) {
+  const rows = labels.map((label) => `,,,,,,${label},,`);
+  const content = [CSV_HEADER, ...rows].join("\n");
+  writeFileSync(filePath, content);
+}
+
+export function buildMainArgs(
+  env: DevnetEnvironment,
+  csvFilePath: string,
+  overrides: {
+    dryRun?: boolean;
+    limit?: number;
+    continue?: boolean;
+    bonusPeriodDays?: number;
+    batchSize?: number;
+    useEnvVarForPrivateKey?: boolean;
+    omitPrivateKey?: boolean;
+  } = {},
+): string[] {
+  const rpcUrl = `http://${env.hostPort}`;
+  const registryAddress = env.v2.ETHRegistry.address;
+
+  const args = [
+    "node",
+    "script",
+    "--rpc-url",
+    rpcUrl,
+    "--registry",
+    registryAddress,
+    "--batch-registrar",
+    env.rocketh.get("BatchRegistrar").address,
+    "--csv-file",
+    csvFilePath,
+    "--v1-resolver",
+    env.v2.ENSV1Resolver.address,
+    "--mainnet-rpc-url",
+    rpcUrl,
+    "--bonus-period-days",
+    String(overrides.bonusPeriodDays ?? 0),
+    "--v1-base-registrar",
+    env.v1.BaseRegistrar.address,
+  ];
+
+  if (overrides.useEnvVarForPrivateKey) {
+    process.env.PREMIGRATION_PRIVATE_KEY = DEPLOYER_PRIVATE_KEY;
+  } else if (!overrides.omitPrivateKey) {
+    args.push("--private-key", DEPLOYER_PRIVATE_KEY);
+  }
+
+  if (overrides.dryRun) {
+    args.push("--dry-run");
+  }
+  if (overrides.limit !== undefined) {
+    args.push("--limit", String(overrides.limit));
+  }
+  if (overrides.continue) {
+    args.push("--continue");
+  }
+  if (overrides.batchSize !== undefined) {
+    args.push("--batch-size", String(overrides.batchSize));
+  }
+
+  return args;
+}
+
+export async function verifyV2State(
+  env: DevnetEnvironment,
+  label: string,
+): Promise<{
+  status: number;
+  expiry: bigint;
+  latestOwner: Address;
+}> {
+  return env.v2.ETHRegistry.read.getState([idFromLabel(label)]);
+}

--- a/contracts/script/runDevnet.ts
+++ b/contracts/script/runDevnet.ts
@@ -1,6 +1,7 @@
 import { createServer } from "node:http";
 import { parseArgs } from "node:util";
 import { getAddress } from "viem";
+import { preMigrateDevnetNames } from "./preMigrateDevnetNames.js";
 import { setupDevnet } from "./setup.js";
 import { testNames } from "./testNames.js";
 import { COIN_TYPE_ETH } from "../test/utils/utils.js";
@@ -15,6 +16,12 @@ const args = parseArgs({
     },
     testNames: {
       type: "boolean",
+    },
+    preMigrate: {
+      type: "boolean",
+    },
+    preMigrateOwner: {
+      type: "string",
     },
     chainId: {
       type: "string",
@@ -38,9 +45,19 @@ const args = parseArgs({
 const forkUrl = args.values.forkUrl ?? process.env.FORK_URL;
 const forkBlock = args.values.forkBlock ?? process.env.FORK_BLOCK;
 const quiet = args.values.quiet ?? process.env.DEVNET_QUIET === "1";
+const preMigrate =
+  args.values.preMigrate ?? process.env.DEVNET_PREMIGRATE === "1";
+const preMigrateOwner =
+  args.values.preMigrateOwner ?? process.env.DEVNET_PREMIGRATE_OWNER;
 
 if (forkUrl && args.values.testNames) {
   console.error("--testNames is incompatible with --forkUrl");
+  process.exit(2);
+}
+
+// Pre-migration reserves real v1 names, which only exist on a mainnet fork.
+if (preMigrate && !forkUrl) {
+  console.error("--preMigrate requires --forkUrl");
   process.exit(2);
 }
 
@@ -87,10 +104,17 @@ if (!quiet) {
     await Promise.all(
       Object.entries(env.rocketh.deployments).map(
         async ([name, { address }]) => {
-          const [primary] = await env.v2.UniversalResolver.read.reverse([
-            address,
-            COIN_TYPE_ETH,
-          ]);
+          // On a mainnet fork, reverse resolution for freshly-deployed
+          // contracts can revert; fall back to no primary name rather than
+          // crashing the whole table.
+          let primary = "";
+          try {
+            const result = await env.v2.UniversalResolver.read.reverse([
+              address,
+              COIN_TYPE_ETH,
+            ]);
+            primary = result[0];
+          } catch {}
           return {
             "Contract Name": name,
             "Contract Address": getAddress(address),
@@ -125,6 +149,9 @@ await env.sync({ warpSec: "local" });
 // expected to grant controller roles themselves via test-side setup.
 if (forkUrl) {
   await env.activateV2();
+  if (preMigrate) {
+    await preMigrateDevnetNames(env, { reassignOwnerTo: preMigrateOwner });
+  }
 }
 
 console.log(new Date(), `Ready! <${Date.now() - t0}ms>`);

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -246,16 +246,19 @@ contract WrapperRegistry is
     /// @inheritdoc PermissionedRegistry
     /// @dev Override for token-dependent logic:
     ///
-    /// * if root and account is token owner, remap to virtual owner.
+    /// * if root and account is token owner or approved, remap to virtual owner.
     ///
     function _getRoles(uint256 resource, address account) internal view override returns (uint256) {
         if (resource == ROOT_RESOURCE) {
             address parent = address(_parentRegistry); // virtual owner
-            if (
-                parent != address(0) &&
-                account == PermissionedRegistry(parent).findOwner(_childLabel)
-            ) {
-                return super._getRoles(resource, parent); // replace, instead of OR
+            if (parent != address(0)) {
+                address owner = PermissionedRegistry(parent).findOwner(_childLabel);
+                if (
+                    account == owner ||
+                    PermissionedRegistry(parent).isApprovedForAll(owner, account)
+                ) {
+                    return super._getRoles(resource, parent); // replace, instead of OR
+                }
             }
         }
         return super._getRoles(resource, account);

--- a/contracts/test/e2e/devnet.test.ts
+++ b/contracts/test/e2e/devnet.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { expectVar } from "../utils/expectVar.js";
 
 describe("Devnet", () => {
-  const { env, setupEnv, resetInitialState } = process.env.TEST_GLOBALS!;
+  const { env, setupEnv, resetInitialState } = process.TEST_GLOBALS!;
 
   setupEnv({ resetOnEach: true });
 

--- a/contracts/test/e2e/migration.test.ts
+++ b/contracts/test/e2e/migration.test.ts
@@ -45,7 +45,7 @@ const defaultProfile = {
 } as const satisfies Partial<KnownProfile>;
 
 describe("Migration", () => {
-  const { env, setupEnv } = process.env.TEST_GLOBALS!;
+  const { env, setupEnv } = process.TEST_GLOBALS!;
 
   setupEnv({
     resetOnEach: true,

--- a/contracts/test/e2e/phasedMigration.test.ts
+++ b/contracts/test/e2e/phasedMigration.test.ts
@@ -35,7 +35,7 @@ const MIN_V2_REGISTRATION_SECONDS = 28n * 24n * 60n * 60n;
 const REGISTRAR_ROLES = ROLES.REGISTRY.REGISTRAR | ROLES.REGISTRY.RENEW;
 
 describe("Phased migration rehearsal", () => {
-  const { env, setupEnv } = process.env.TEST_GLOBALS!;
+  const { env, setupEnv } = process.TEST_GLOBALS!;
   const csvFilePath = join(process.cwd(), "test-phased-migration.csv");
   const cleanupFiles = [
     csvFilePath,

--- a/contracts/test/e2e/preMigrateDevnetNames.test.ts
+++ b/contracts/test/e2e/preMigrateDevnetNames.test.ts
@@ -14,7 +14,7 @@ import { idFromLabel } from "../utils/utils.js";
 const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60;
 
 describe("preMigrateDevnetNames", () => {
-  const { env, setupEnv } = process.env.TEST_GLOBALS!;
+  const { env, setupEnv } = process.TEST_GLOBALS!;
 
   const cleanupFiles = [
     "preMigration-checkpoint.json",

--- a/contracts/test/e2e/preMigrateDevnetNames.test.ts
+++ b/contracts/test/e2e/preMigrateDevnetNames.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, setDefaultTimeout } from "bun:test";
+setDefaultTimeout(60_000);
+
+import { existsSync, unlinkSync } from "node:fs";
+import { STATUS } from "../../script/deploy-constants.js";
+import { preMigrateDevnetNames } from "../../script/preMigrateDevnetNames.js";
+import {
+  registerV1Name,
+  setupBaseRegistrarController,
+  verifyV2State,
+} from "../utils/mockPreMigration.js";
+import { idFromLabel } from "../utils/utils.js";
+
+const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60;
+
+describe("preMigrateDevnetNames", () => {
+  const { env, setupEnv } = process.env.TEST_GLOBALS!;
+
+  const cleanupFiles = [
+    "preMigration-checkpoint.json",
+    "preMigration-errors.log",
+    "preMigration.log",
+  ];
+
+  setupEnv({
+    resetOnEach: true,
+    async initialize() {
+      await setupBaseRegistrarController(env);
+    },
+  });
+
+  afterEach(() => {
+    for (const file of cleanupFiles) {
+      if (existsSync(file)) {
+        try {
+          unlinkSync(file);
+        } catch {}
+      }
+    }
+  });
+
+  it("reserves the given names on v2", async () => {
+    const labels = ["premigone", "premigtwo"];
+    const { user } = env.namedAccounts;
+    for (const label of labels) {
+      await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
+    }
+
+    await preMigrateDevnetNames(env, { labels });
+
+    for (const label of labels) {
+      const state = await verifyV2State(env, label);
+      expect(state.status).toBe(STATUS.RESERVED);
+    }
+  });
+
+  it("reassigns v1 ownership of an unwrapped name to a devnet account", async () => {
+    const label = "reassignme";
+    const { user, user2 } = env.namedAccounts;
+    await registerV1Name(env, label, user2.address, ONE_YEAR_SECONDS);
+
+    await preMigrateDevnetNames(env, {
+      labels: [label],
+      reassignOwnerTo: "user",
+    });
+
+    const state = await verifyV2State(env, label);
+    expect(state.status).toBe(STATUS.RESERVED);
+
+    const owner = await env.v1.BaseRegistrar.read.ownerOf([idFromLabel(label)]);
+    expect(owner.toLowerCase()).toBe(user.address.toLowerCase());
+  });
+});

--- a/contracts/test/e2e/preMigration.test.ts
+++ b/contracts/test/e2e/preMigration.test.ts
@@ -263,12 +263,7 @@ describe("PreMigration", () => {
     const { user } = env.namedAccounts;
 
     const fiveDays = 5 * 24 * 60 * 60;
-    const v1Expiry = await registerV1Name(
-      env,
-      label,
-      user.address,
-      fiveDays,
-    );
+    const v1Expiry = await registerV1Name(env, label, user.address, fiveDays);
 
     createCSVFile(csvFilePath, [label]);
     const bonusPeriodDays = 90;
@@ -368,7 +363,9 @@ describe("PreMigration", () => {
     await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
 
     createCSVFile(csvFilePath, [label]);
-    const args = buildMainArgs(env, csvFilePath, { useEnvVarForPrivateKey: true });
+    const args = buildMainArgs(env, csvFilePath, {
+      useEnvVarForPrivateKey: true,
+    });
     await main(args);
 
     const state = await verifyV2State(env, label);
@@ -381,7 +378,8 @@ describe("PreMigration", () => {
 
     await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
 
-    process.env.PREMIGRATION_PRIVATE_KEY = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    process.env.PREMIGRATION_PRIVATE_KEY =
+      "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 
     createCSVFile(csvFilePath, [label]);
     const args = buildMainArgs(env, csvFilePath);
@@ -426,7 +424,12 @@ describe("PreMigration", () => {
 
     const expiries: bigint[] = [];
     for (const label of labels) {
-      const expiry = await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
+      const expiry = await registerV1Name(
+        env,
+        label,
+        user.address,
+        ONE_YEAR_SECONDS,
+      );
       expiries.push(expiry);
     }
 
@@ -452,7 +455,11 @@ describe("PreMigration", () => {
     await registerV1Name(env, expiredLabel, user.address, 1);
     await setTimeout(2000);
 
-    createCSVFile(csvFilePath, [validLabel, expiredLabel, neverRegisteredLabel]);
+    createCSVFile(csvFilePath, [
+      validLabel,
+      expiredLabel,
+      neverRegisteredLabel,
+    ]);
     const args = buildMainArgs(env, csvFilePath);
     await main(args);
 
@@ -473,7 +480,12 @@ describe("PreMigration", () => {
     const neverLabel = "bvnever";
     const { user, deployer } = env.namedAccounts;
 
-    const validExpiry = await registerV1Name(env, validLabel, user.address, ONE_YEAR_SECONDS);
+    const validExpiry = await registerV1Name(
+      env,
+      validLabel,
+      user.address,
+      ONE_YEAR_SECONDS,
+    );
     await registerV1Name(env, expiredLabel, user.address, 1);
     await registerV1Name(env, registeredLabel, user.address, ONE_YEAR_SECONDS);
     await setTimeout(2000);
@@ -489,7 +501,9 @@ describe("PreMigration", () => {
 
     const rpcUrl = `http://${env.hostPort}`;
     const client = createWalletClient({
-      account: privateKeyToAccount("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"),
+      account: privateKeyToAccount(
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+      ),
       chain: mainnet,
       transport: http(rpcUrl, { retryCount: 0, timeout: 30000 }),
     }).extend(publicActions);
@@ -560,7 +574,12 @@ describe("PreMigration", () => {
 
     const expiries: bigint[] = [];
     for (const label of labels) {
-      const expiry = await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
+      const expiry = await registerV1Name(
+        env,
+        label,
+        user.address,
+        ONE_YEAR_SECONDS,
+      );
       expiries.push(expiry);
     }
 
@@ -588,7 +607,12 @@ describe("PreMigration", () => {
 
     const expiries: bigint[] = [];
     for (const label of labels) {
-      const expiry = await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
+      const expiry = await registerV1Name(
+        env,
+        label,
+        user.address,
+        ONE_YEAR_SECONDS,
+      );
       expiries.push(expiry);
     }
 
@@ -608,16 +632,17 @@ describe("PreMigration", () => {
   });
 
   it("handles batch of names with long labels (higher calldata cost)", async () => {
-    const labels = [
-      "a".repeat(63),
-      "b".repeat(63),
-      "c".repeat(63),
-    ];
+    const labels = ["a".repeat(63), "b".repeat(63), "c".repeat(63)];
     const { user } = env.namedAccounts;
 
     const expiries: bigint[] = [];
     for (const label of labels) {
-      const expiry = await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
+      const expiry = await registerV1Name(
+        env,
+        label,
+        user.address,
+        ONE_YEAR_SECONDS,
+      );
       expiries.push(expiry);
     }
 
@@ -652,11 +677,13 @@ describe("PreMigration", () => {
     expect(checkpoint).not.toBeNull();
     expect(checkpoint!.successCount).toBe(2);
     expect(checkpoint!.skippedCount).toBe(1);
+    expect(checkpoint!.skippedNeverRegisteredCount).toBe(1);
+    expect(checkpoint!.skippedPastGraceCount).toBe(0);
     expect(checkpoint!.failureCount).toBe(0);
     expect(checkpoint!.totalProcessed).toBe(3);
   });
 
-  it("checkpoint tracks failures for already-registered names", async () => {
+  it("checkpoint tracks already-registered names separately from failures", async () => {
     const registeredLabel = "cptregfail";
     const validLabel = "cptregvalid";
     const { user, deployer } = env.namedAccounts;
@@ -680,7 +707,8 @@ describe("PreMigration", () => {
     const checkpoint = readTestCheckpoint();
     expect(checkpoint).not.toBeNull();
     expect(checkpoint!.successCount).toBe(1);
-    expect(checkpoint!.failureCount).toBe(1);
+    expect(checkpoint!.alreadyRegisteredCount).toBe(1);
+    expect(checkpoint!.failureCount).toBe(0);
   });
 
   it("checkpoint tracks renewed count separately", async () => {
@@ -705,6 +733,25 @@ describe("PreMigration", () => {
     const checkpointAfter = readTestCheckpoint();
     expect(checkpointAfter!.renewedCount).toBe(1);
     expect(checkpointAfter!.successCount).toBe(0);
+  });
+
+  it("fresh run clears a stale checkpoint left by a previous run", async () => {
+    writeTestCheckpoint(
+      createTestCheckpoint({
+        totalProcessed: 5,
+        successCount: 5,
+        totalExpected: 5,
+      }),
+    );
+
+    // Header-only CSV: a fresh run processes zero batches and writes no new
+    // checkpoint, so the stale one must be cleared rather than left to be
+    // mistaken for this run's result.
+    createCSVFile(csvFilePath, []);
+    const args = buildMainArgs(env, csvFilePath);
+    await main(args);
+
+    expect(readTestCheckpoint()).toBeNull();
   });
 
   // ─── Invalid label handling ────────────────────────────────────────
@@ -744,10 +791,7 @@ describe("PreMigration", () => {
   });
 
   it("fails fast when header has no labelName or label column", async () => {
-    const csvContent = [
-      "node,name,owner",
-      "n,foo,0x00",
-    ].join("\n");
+    const csvContent = ["node,name,owner", "n,foo,0x00"].join("\n");
     writeFileSync(csvFilePath, csvContent);
 
     const args = buildMainArgs(env, csvFilePath);
@@ -793,13 +837,12 @@ describe("PreMigration", () => {
 
     await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
 
-    const csvContent =
-      [
-        "node,name,labelHash,owner,parentName,parentLabelHash,labelName,registrationDate,expiryDate",
-        `,,,,,,${label},,`,
-        "",
-        "",
-      ].join("\n");
+    const csvContent = [
+      "node,name,labelHash,owner,parentName,parentLabelHash,labelName,registrationDate,expiryDate",
+      `,,,,,,${label},,`,
+      "",
+      "",
+    ].join("\n");
     writeFileSync(csvFilePath, csvContent);
 
     const args = buildMainArgs(env, csvFilePath);
@@ -837,10 +880,9 @@ describe("PreMigration", () => {
 
     await registerV1Name(env, winning, user.address, ONE_YEAR_SECONDS);
 
-    const csvContent = [
-      "label,labelName,extra",
-      `${losing},${winning},x`,
-    ].join("\n");
+    const csvContent = ["label,labelName,extra", `${losing},${winning},x`].join(
+      "\n",
+    );
     writeFileSync(csvFilePath, csvContent);
 
     const args = buildMainArgs(env, csvFilePath);
@@ -863,10 +905,7 @@ describe("PreMigration", () => {
     writeFileSync(csvFilePath, csvContent);
 
     const args = buildMainArgs(env, csvFilePath);
-    await expectMainToExitWithCsvError(args, [
-      `${csvFilePath}:3`,
-      "is blank",
-    ]);
+    await expectMainToExitWithCsvError(args, [`${csvFilePath}:3`, "is blank"]);
   });
 
   it("skips labels exceeding 255 bytes and encoded labelhashes in CSV", async () => {
@@ -900,7 +939,10 @@ describe("PreMigration", () => {
   // ─── Edge cases ────────────────────────────────────────────────────
 
   it("handles empty CSV file gracefully", async () => {
-    writeFileSync(csvFilePath, "node,name,labelHash,owner,parentName,parentLabelHash,labelName,registrationDate,expiryDate\n");
+    writeFileSync(
+      csvFilePath,
+      "node,name,labelHash,owner,parentName,parentLabelHash,labelName,registrationDate,expiryDate\n",
+    );
 
     const args = buildMainArgs(env, csvFilePath);
     await main(args);
@@ -913,7 +955,12 @@ describe("PreMigration", () => {
     const label = "singlename";
     const { user } = env.namedAccounts;
 
-    const expiry = await registerV1Name(env, label, user.address, ONE_YEAR_SECONDS);
+    const expiry = await registerV1Name(
+      env,
+      label,
+      user.address,
+      ONE_YEAR_SECONDS,
+    );
 
     createCSVFile(csvFilePath, [label]);
     const args = buildMainArgs(env, csvFilePath);
@@ -1139,7 +1186,10 @@ describe("PreMigration", () => {
     }
 
     createCSVFile(csvFilePath, labels);
-    const args = buildMainArgs(env, csvFilePath, { dryRun: true, batchSize: 1 });
+    const args = buildMainArgs(env, csvFilePath, {
+      dryRun: true,
+      batchSize: 1,
+    });
     await main(args);
 
     for (const label of labels) {
@@ -1182,7 +1232,7 @@ describe("PreMigration", () => {
     expect(checkpoint!.failureCount).toBe(0);
   });
 
-  it("multiple registered names in batch are all counted as failures", async () => {
+  it("multiple already-registered names in batch are all counted separately from failures", async () => {
     const registeredLabels = ["mreg1", "mreg2"];
     const validLabel = "mregvalid";
     const { user, deployer } = env.namedAccounts;
@@ -1208,7 +1258,8 @@ describe("PreMigration", () => {
 
     const checkpoint = readTestCheckpoint();
     expect(checkpoint!.successCount).toBe(1);
-    expect(checkpoint!.failureCount).toBe(2);
+    expect(checkpoint!.alreadyRegisteredCount).toBe(2);
+    expect(checkpoint!.failureCount).toBe(0);
   });
 
   it("re-running same batch after successful reservation uses renewal path", async () => {

--- a/contracts/test/e2e/preMigration.test.ts
+++ b/contracts/test/e2e/preMigration.test.ts
@@ -41,7 +41,7 @@ import {
 const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60;
 
 describe("PreMigration", () => {
-  const { env, setupEnv } = process.env.TEST_GLOBALS!;
+  const { env, setupEnv } = process.TEST_GLOBALS!;
 
   const csvFilePath = join(tmpdir(), "test-premigration.csv");
   const cleanupFiles = [

--- a/contracts/test/e2e/prepareMigration.test.ts
+++ b/contracts/test/e2e/prepareMigration.test.ts
@@ -14,7 +14,7 @@ const ROLE_RENEW = ROLES.REGISTRY.RENEW;
 const ROLE_RENEW_ADMIN = ROLES.ADMIN.REGISTRY.RENEW;
 
 describe("PrepareMigration", () => {
-  const { env, setupEnv } = process.env.TEST_GLOBALS!;
+  const { env, setupEnv } = process.TEST_GLOBALS!;
 
   setupEnv({
     resetOnEach: true,

--- a/contracts/test/e2e/resolve.test.ts
+++ b/contracts/test/e2e/resolve.test.ts
@@ -23,7 +23,7 @@ const COIN_TYPE_OPTIMISM = coinTypeFromChain(10);
 const itLiveDns = process.env.RUN_LIVE_DNS_TESTS === "1" ? it : it.skip;
 
 describe("Resolve", () => {
-  const { env, setupEnv } = process.env.TEST_GLOBALS!;
+  const { env, setupEnv } = process.TEST_GLOBALS!;
 
   setupEnv({ resetOnEach: true });
 

--- a/contracts/test/e2e/runPreMigrationCommandSigner.test.ts
+++ b/contracts/test/e2e/runPreMigrationCommandSigner.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
 import {
   existsSync,
   mkdirSync,
@@ -28,6 +36,9 @@ let capturedArgs: string[] | null = null;
 let checkpointToWrite: Checkpoint | null = null;
 
 const realPreMigration = await import("../../script/preMigration.js");
+// Capture the real export before mocking: mock.module rebinds the live
+// namespace, so realPreMigration.main would otherwise resolve to the stub.
+const realMain = realPreMigration.main;
 
 mock.module("../../script/preMigration.js", () => ({
   ...realPreMigration,
@@ -41,6 +52,16 @@ mock.module("../../script/preMigration.js", () => ({
     }
   },
 }));
+
+// bun's mock.module is global and persists past this file, so a later suite
+// that imports preMigration.main would run the stub. Restore the real module
+// once these tests finish.
+afterAll(() => {
+  mock.module("../../script/preMigration.js", () => ({
+    ...realPreMigration,
+    main: realMain,
+  }));
+});
 
 const { runPreMigrationCommand } = await import("../../script/migration.js");
 

--- a/contracts/test/e2e/runPreMigrationCommandSigner.test.ts
+++ b/contracts/test/e2e/runPreMigrationCommandSigner.test.ts
@@ -1,5 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { privateKeyToAccount } from "viem/accounts";
+import type { Checkpoint } from "../../script/preMigration.js";
 
 // The BatchRegistrar owner that fork/clean-testnet runs impersonate. The env
 // deployer key below does NOT control it.
@@ -12,6 +23,9 @@ const DEPLOYER_KEY =
 const deployerAccount = privateKeyToAccount(DEPLOYER_KEY);
 
 let capturedArgs: string[] | null = null;
+// When set, the mocked pre-migration run writes this checkpoint to its workDir,
+// standing in for the real run so the metadata-persistence path can be exercised.
+let checkpointToWrite: Checkpoint | null = null;
 
 const realPreMigration = await import("../../script/preMigration.js");
 
@@ -19,10 +33,20 @@ mock.module("../../script/preMigration.js", () => ({
   ...realPreMigration,
   main: async (args: string[]) => {
     capturedArgs = args;
+    if (checkpointToWrite) {
+      writeFileSync(
+        realPreMigration.CHECKPOINT_FILE,
+        JSON.stringify(checkpointToWrite),
+      );
+    }
   },
 }));
 
 const { runPreMigrationCommand } = await import("../../script/migration.js");
+
+function makeCheckpoint(overrides: Partial<Checkpoint>): Checkpoint {
+  return { ...realPreMigration.createFreshCheckpoint(), ...overrides };
+}
 
 function flagValue(args: string[], flag: string): string | undefined {
   const i = args.indexOf(flag);
@@ -92,5 +116,189 @@ describe("runPreMigrationCommand signer resolution", () => {
     );
     expect(flagValue(capturedArgs!, "--private-key")).toBe(OWNER_KEY);
     expect(flagValue(capturedArgs!, "--account")).toBe(ownerAccount.address);
+  });
+});
+
+describe("runPreMigrationCommand metadata persistence", () => {
+  let deploymentsDir: string;
+  let workDir: string;
+  const deploymentNetwork = "mainnet";
+
+  beforeEach(() => {
+    process.env.DEPLOYER_KEY = DEPLOYER_KEY;
+    deploymentsDir = mkdtempSync(join(tmpdir(), "premigration-meta-deploy-"));
+    workDir = mkdtempSync(join(tmpdir(), "premigration-meta-work-"));
+    // The namespace dir must exist for the sidecar to be written.
+    mkdirSync(join(deploymentsDir, deploymentNetwork), { recursive: true });
+  });
+
+  afterEach(() => {
+    checkpointToWrite = null;
+    delete process.env.DEPLOYER_KEY;
+    rmSync(deploymentsDir, { recursive: true, force: true });
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  const metadataPath = () =>
+    join(deploymentsDir, deploymentNetwork, ".premigration.json");
+
+  const readMetadata = () => JSON.parse(readFileSync(metadataPath(), "utf-8"));
+
+  it("writes a run summary and resolved roll-up, upserting by label", async () => {
+    checkpointToWrite = makeCheckpoint({
+      totalExpected: 9,
+      totalProcessed: 9,
+      successCount: 5,
+      renewedCount: 0,
+      skippedCount: 3,
+      skippedNeverRegisteredCount: 2,
+      skippedPastGraceCount: 1,
+      alreadyRegisteredCount: 0,
+      invalidLabelCount: 1,
+      failureCount: 0,
+      timestamp: "2026-01-01T00:00:00.000Z",
+    });
+    await runPreMigrationCommand(
+      {
+        ...baseOpts,
+        deploymentsDir,
+        deploymentNetwork,
+        workDir,
+        metadataLabel: "initial",
+      },
+      false,
+    );
+
+    let metadata = readMetadata();
+    expect(metadata.chainId).toBe(1);
+    expect(metadata.runs).toHaveLength(1);
+    expect(metadata.runs[0]).toMatchObject({
+      label: "initial",
+      reserved: 5,
+      renewed: 0,
+      skippedNeverRegistered: 2,
+      skippedExpiredPastGrace: 1,
+      invalidLabels: 1,
+      alreadyOnV2: 0,
+      failed: 0,
+    });
+
+    // Resume re-writes the same label's accumulated checkpoint: upsert, not append.
+    checkpointToWrite = makeCheckpoint({
+      totalExpected: 9,
+      totalProcessed: 9,
+      successCount: 6,
+      skippedCount: 3,
+      skippedNeverRegisteredCount: 2,
+      skippedPastGraceCount: 1,
+      invalidLabelCount: 0,
+      timestamp: "2026-01-01T01:00:00.000Z",
+    });
+    await runPreMigrationCommand(
+      {
+        ...baseOpts,
+        deploymentsDir,
+        deploymentNetwork,
+        workDir,
+        metadataLabel: "initial",
+      },
+      true,
+    );
+    metadata = readMetadata();
+    expect(metadata.runs).toHaveLength(1);
+    expect(metadata.runs[0].reserved).toBe(6);
+
+    // A second logical run (final-sync) appends and drives the resolved section,
+    // being the most recently finished run.
+    checkpointToWrite = makeCheckpoint({
+      totalExpected: 10,
+      totalProcessed: 10,
+      successCount: 1,
+      renewedCount: 5,
+      skippedCount: 3,
+      skippedNeverRegisteredCount: 2,
+      skippedPastGraceCount: 1,
+      alreadyRegisteredCount: 1,
+      invalidLabelCount: 1,
+      failureCount: 0,
+      timestamp: "2026-01-02T00:00:00.000Z",
+    });
+    await runPreMigrationCommand(
+      {
+        ...baseOpts,
+        deploymentsDir,
+        deploymentNetwork,
+        workDir,
+        metadataLabel: "final-sync",
+      },
+      false,
+    );
+    metadata = readMetadata();
+    expect(metadata.runs).toHaveLength(2);
+    expect(metadata.resolved).toMatchObject({
+      finishedAt: "2026-01-02T00:00:00.000Z",
+      totalNames: 10,
+      namesPreMigrated: 6,
+      newReservations: 1,
+      expiryResyncs: 5,
+      skippedNeverRegistered: 2,
+      skippedExpiredPastGrace: 1,
+      invalidLabels: 1,
+      alreadyOnV2: 1,
+      failed: 0,
+    });
+  });
+
+  it("skips the write on dry run and when persistMetadata is false", async () => {
+    checkpointToWrite = makeCheckpoint({
+      successCount: 1,
+      timestamp: "2026-01-01T00:00:00.000Z",
+    });
+
+    await runPreMigrationCommand(
+      {
+        ...baseOpts,
+        deploymentsDir,
+        deploymentNetwork,
+        workDir,
+        metadataLabel: "run",
+        dryRun: true,
+      },
+      false,
+    );
+    expect(existsSync(metadataPath())).toBe(false);
+
+    await runPreMigrationCommand(
+      {
+        ...baseOpts,
+        deploymentsDir,
+        deploymentNetwork,
+        workDir,
+        metadataLabel: "run",
+        persistMetadata: false,
+      },
+      false,
+    );
+    expect(existsSync(metadataPath())).toBe(false);
+  });
+
+  it("does not write when the namespace directory is absent", async () => {
+    checkpointToWrite = makeCheckpoint({
+      successCount: 1,
+      timestamp: "2026-01-01T00:00:00.000Z",
+    });
+    await runPreMigrationCommand(
+      {
+        ...baseOpts,
+        deploymentsDir,
+        deploymentNetwork: "does-not-exist",
+        workDir,
+        metadataLabel: "run",
+      },
+      false,
+    );
+    expect(
+      existsSync(join(deploymentsDir, "does-not-exist", ".premigration.json")),
+    ).toBe(false);
   });
 });

--- a/contracts/test/e2e/test-setup.ts
+++ b/contracts/test/e2e/test-setup.ts
@@ -8,9 +8,8 @@ import {
 } from "../../script/setup.js";
 
 declare global {
-  // Add DevnetEnvironment type to NodeJS.ProcessEnv for type safety
   namespace NodeJS {
-    interface ProcessEnv {
+    interface Process {
       TEST_GLOBALS?: {
         env: DevnetEnvironment;
         resetInitialState: StateSnapshot;
@@ -51,7 +50,7 @@ console.log(new Date(), `Ready! <${Date.now() - t0}ms>`);
 let resetEachState: StateSnapshot | undefined = resetInitialState; // default to full reset
 
 // the environment is shared between all tests
-process.env.TEST_GLOBALS = {
+process.TEST_GLOBALS = {
   env,
   resetInitialState,
   setupEnv({ resetOnEach, initialize }) {

--- a/contracts/test/unit/migration/LockedMigrationController.t.sol
+++ b/contracts/test/unit/migration/LockedMigrationController.t.sol
@@ -580,6 +580,49 @@ contract LockedMigrationControllerTest is MigrationControllerFixture {
         );
     }
 
+    function test_migrate_setApprovalForAll() external {
+        bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
+        bytes32 node = NameCoder.namehash(name, 0);
+        LibMigration.Data memory md = _lockedData(name);
+
+        vm.prank(testOwner);
+        nameWrapper.safeTransferFrom(
+            testOwner,
+            address(migrationController),
+            uint256(node),
+            1,
+            abi.encode(md)
+        );
+
+        IPermissionedRegistry registry =
+            IPermissionedRegistry(address(ethRegistry.getSubregistry(md.label)));
+        address virtualOwner = address(ethRegistry);
+
+        assertEq(registry.roles(registry.ROOT_RESOURCE(), actor), 0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                registry.ROOT_RESOURCE(),
+                RegistryRolesLib.ROLE_REGISTRAR,
+                actor
+            )
+        );
+        vm.prank(actor);
+        registry.register(testLabel, actor, testRegistry, testResolver, 0, _soon());
+
+        vm.prank(testOwner);
+        ethRegistry.setApprovalForAll(actor, true);
+
+        assertEq(
+            registry.roles(registry.ROOT_RESOURCE(), actor),
+            registry.roles(registry.ROOT_RESOURCE(), testOwner)
+        );
+
+        vm.prank(actor);
+        registry.register(testLabel, actor, testRegistry, testResolver, 0, _soon());
+    }
+
     function test_migrate_transferRegistryControl() external {
         bytes memory name = registerWrappedETH2LD(testLabel, CANNOT_UNWRAP);
         bytes32 node = NameCoder.namehash(name, 0);

--- a/contracts/test/utils/mockPreMigration.ts
+++ b/contracts/test/utils/mockPreMigration.ts
@@ -1,10 +1,15 @@
-import { writeFileSync } from "node:fs";
 import type { Address } from "viem";
 import type { DevnetEnvironment } from "../../script/setup.js";
 import { idFromLabel } from "./utils.js";
 
-const DEPLOYER_PRIVATE_KEY =
-  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as const;
+// Pre-migration helpers shared with the devnet runner live in script/ so
+// production code doesn't import from test/. Re-exported here for tests.
+export {
+  DEPLOYER_PRIVATE_KEY,
+  createCSVFile,
+  buildMainArgs,
+  verifyV2State,
+} from "../../script/preMigrationUtils.js";
 
 export async function setupBaseRegistrarController(env: DevnetEnvironment) {
   const { deployer, owner } = env.namedAccounts;
@@ -40,84 +45,4 @@ export async function renewV1Name(
   await env.v1.BaseRegistrar.write.renew([tokenId, BigInt(additionalDuration)]);
   const expiry = await env.v1.BaseRegistrar.read.nameExpires([tokenId]);
   return expiry;
-}
-
-const CSV_HEADER =
-  "node,name,labelHash,owner,parentName,parentLabelHash,labelName,registrationDate,expiryDate";
-
-export function createCSVFile(filePath: string, labels: string[]) {
-  const rows = labels.map((label) => `,,,,,,${label},,`);
-  const content = [CSV_HEADER, ...rows].join("\n");
-  writeFileSync(filePath, content);
-}
-
-export function buildMainArgs(
-  env: DevnetEnvironment,
-  csvFilePath: string,
-  overrides: {
-    dryRun?: boolean;
-    limit?: number;
-    continue?: boolean;
-    bonusPeriodDays?: number;
-    batchSize?: number;
-    useEnvVarForPrivateKey?: boolean;
-    omitPrivateKey?: boolean;
-  } = {},
-): string[] {
-  const rpcUrl = `http://${env.hostPort}`;
-  const registryAddress = env.v2.ETHRegistry.address;
-
-  const args = [
-    "node",
-    "script",
-    "--rpc-url",
-    rpcUrl,
-    "--registry",
-    registryAddress,
-    "--batch-registrar",
-    env.rocketh.get("BatchRegistrar").address,
-    "--csv-file",
-    csvFilePath,
-    "--v1-resolver",
-    env.v2.ENSV1Resolver.address,
-    "--mainnet-rpc-url",
-    rpcUrl,
-    "--bonus-period-days",
-    String(overrides.bonusPeriodDays ?? 0),
-    "--v1-base-registrar",
-    env.v1.BaseRegistrar.address,
-  ];
-
-  if (overrides.useEnvVarForPrivateKey) {
-    process.env.PREMIGRATION_PRIVATE_KEY = DEPLOYER_PRIVATE_KEY;
-  } else if (!overrides.omitPrivateKey) {
-    args.push("--private-key", DEPLOYER_PRIVATE_KEY);
-  }
-
-  if (overrides.dryRun) {
-    args.push("--dry-run");
-  }
-  if (overrides.limit !== undefined) {
-    args.push("--limit", String(overrides.limit));
-  }
-  if (overrides.continue) {
-    args.push("--continue");
-  }
-  if (overrides.batchSize !== undefined) {
-    args.push("--batch-size", String(overrides.batchSize));
-  }
-
-  return args;
-}
-
-
-export async function verifyV2State(
-  env: DevnetEnvironment,
-  label: string,
-): Promise<{
-  status: number;
-  expiry: bigint;
-  latestOwner: Address;
-}> {
-  return env.v2.ETHRegistry.read.getState([idFromLabel(label)]);
 }

--- a/contracts/tsconfig.json
+++ b/contracts/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "NodeNext",
     "outDir": "build",
     "skipLibCheck": true,
+    "types": ["bun"],
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "paths": {
@@ -25,11 +26,6 @@
     "./deploy/**/*.ts",
     "./script/**/*.ts"
   ],
-  "ts-node": {
-    "experimentalResolver": true,
-    "experimentalSpecifierResolution": "node",
-    "files": true
-  },
   "files": ["hardhat.config.ts", "vitest.config.ts"],
   "exclude": ["lib"]
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.11",
     "husky": "^9.1.7",
-    "typescript": "^5.8.3"
+    "typescript": "^7.0.2"
   },
   "resolutions": {
     "esbuild": "0.25.11"

--- a/patches/rocketh@0.19.3.patch
+++ b/patches/rocketh@0.19.3.patch
@@ -61,3 +61,20 @@ index 018a31ca31616c50679b1b566c1092b67857c47d..b21ab3736f81172de7ab5402e97f1390
 +    }
 +}
  //# sourceMappingURL=index.js.map
+diff --git a/dist/environment/index.js b/dist/environment/index.js
+index 8322d74aea4cf8dc59b29690836fd7fa97163255..1ba6ef786a445f3034ca0722372a01380394e737 100644
+--- a/dist/environment/index.js
++++ b/dist/environment/index.js
+@@ -334,6 +334,12 @@ export async function createEnvironment(userConfig, resolvedExecutionParams, dep
+             // for backward compatibility
+             tags: context.tags,
+         },
++        // for backward compatibility with rocketh <0.15 deploy scripts (e.g. the
++        // ens-contracts DNS registrar scripts) that read `config.saveDeployments`;
++        // rocketh 0.19 moved this value onto `context`.
++        config: {
++            saveDeployments: context.saveDeployments,
++        },
+         extra: resolvedExecutionParams.extra || {},
+     };
+     // const signer = {


### PR DESCRIPTION
## Summary

This PR significantly expands the v1→v2 migration documentation and adds tooling to pre-migrate curated mainnet names on devnet forks. The migration guide is restructured for clarity with quick-start instructions, deployment context guidance, and detailed phase-by-phase runbooks. New utilities enable devnet operators to seed real ENS names for testing migration flows.

## Key Changes

**Documentation & Guides:**
- Restructured `migration.md` with quick-start section, deployment contexts (live/clean-testnet/fork), and expanded phase descriptions with prerequisites, commands, and expected outcomes
- Added "Re-deploying fresh" guidance for scenarios where v2 is redeployed onto an already-migrated network
- Enhanced `premigration.md` with quick-start examples and clearer script reference
- Updated `README.md` with mainnet fork mode instructions and pre-migration devnet workflow

**Pre-Migration Devnet Tooling:**
- New `preMigrateDevnetNames.ts` script to reserve curated real-mainnet names on devnet forks, with optional owner reassignment for testing migration flows
- New `preMigrationUtils.ts` shared utilities (`createCSVFile`, `buildMainArgs`, `verifyV2State`, `DEPLOYER_PRIVATE_KEY`) extracted from test helpers for reuse in production scripts
- Refactored `test/utils/mockPreMigration.ts` to re-export utilities from `script/preMigrationUtils.ts`, eliminating duplication

**Migration Metadata Persistence:**
- Enhanced `runPreMigrationCommand` to persist pre-migration checkpoint summaries (reserved/renewed/skipped counts) to `.premigration.json` sidecar in deployment namespace
- Added `metadataLabel` and `persistMetadata` options to control metadata recording
- New `recordPreMigrationMetadata` function to upsert run summaries by label
- Updated deployment artifacts documentation to include `.premigration.json`

**Devnet Enhancements:**
- Added `--preMigrate` and `--preMigrateOwner` flags to `runDevnet.ts` for automated pre-migration on startup
- New test suite `preMigrateDevnetNames.test.ts` validating devnet pre-migration flow

**Code Quality:**
- Fixed TypeScript config to include `"types": ["bun"]` for proper Bun type support
- Updated test globals from `process.env.TEST_GLOBALS` to `process.TEST_GLOBALS` for consistency
- Removed unused `ts-node` dependency; updated TypeScript to 7.0.2
- Minor formatting improvements (line wrapping, consistent spacing)
- Added `rmSync` import to preMigration.ts for checkpoint cleanup

## Notable Implementation Details

- Pre-migration metadata is only persisted on non-dry-run executions and when `persistMetadata` is true, preventing throwaway fork runs from touching committed deployment namespaces
- Curated devnet names span migration edge cases (unwrapped, wrapped-locked, wrapped-unlocked, special characters, numeric labels, CANNOT_TRANSFER fuse) for comprehensive frontend testing
- Checkpoint exports now track skip reasons separately (`skippedNeverRegisteredCount`, `skippedPastGraceCount`, `alreadyRegisteredCount`) for better visibility into pre-migration outcomes

https://claude.ai/code/session_01MFCJKXvSsFmjX1Lizpqai7