### PR TITLE
fix(migration): revoke superseded deployments' v1 authorizations

### DIFF
--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -157,15 +157,24 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   | Surface | Candidates considered | Revoked via |
   | --- | --- | --- |
   | `BaseRegistrar` | the four v1 registration controllers, the handoff contracts (`ETHRenewerV1`, `Graveyard`, `TestnetV1PremigrationRegistrar`) of **every** namespace on this chain, and any address in the registrar's `ControllerAdded` history that no local artifact accounts for | `RegistrarSecurityController.removeRegistrarController` while it still owns the registrar, else `removeController` |
-  | `ReverseRegistrar` | this tooling's handoff contracts granted there (`TestnetV1PremigrationRegistrar`, `ReverseRegistrarAdapter`) of **every** namespace on this chain | `setController(addr, false)` |
-  | `DefaultReverseRegistrar` | this tooling's handoff contracts granted there (`TestnetV1PremigrationRegistrar`, `DefaultReverseRegistrarAdapter`) of **every** namespace on this chain | `setController(addr, false)` |
+  | `ReverseRegistrar` | this tooling's handoff contracts granted there (`TestnetV1PremigrationRegistrar`, `ReverseRegistrarAdapter`) of **every** namespace on this chain, plus any address in the registrar's `ControllerChanged` history that reports forwarding to it | `setController(addr, false)` |
+  | `DefaultReverseRegistrar` | this tooling's handoff contracts granted there (`TestnetV1PremigrationRegistrar`, `DefaultReverseRegistrarAdapter`) of **every** namespace on this chain, plus any address in the registrar's `ControllerChanged` history that reports forwarding to it | `setController(addr, false)` |
 
   Only the **active** namespace's handoff contracts are left authorized.
   `verify-v1-registrars-disabled` asserts that complete set and fails on anything else.
 
+  Namespaces are matched against both the network and the active `--deployment-network`, so a custom
+  namespace and the archives named after it are scanned too. The active namespace's artifacts are
+  read directly rather than through that scan: its grants are the ones that must survive, so they can
+  never depend on a directory listing.
+
   > v1-side controllers on the reverse registrars (the official registrar controllers, which set
   > reverse records during registration) are deliberately **not** touched — revoking them is outside
-  > the migration's remit and would break unrelated v1 behaviour.
+  > the migration's remit and would break unrelated v1 behaviour. A discovered address counts as this
+  > tooling's own only when it answers `REVERSE_REGISTRAR()` / `DEFAULT_REVERSE_REGISTRAR()` with the
+  > registrar holding the grant; everything else is listed as `v1-owned, outside migration remit` and
+  > left enabled. That back-reference is what lets a superseded adapter be revoked when its deployment
+  > namespace is no longer on disk.
 - **Re-deploying fresh:** **must be run — not a no-op.** The v1 registration controllers stay frozen
   from the prior deployment, but that deployment's own handoff contracts are still authorized, and
   `TestnetV1PremigrationRegistrar` among them is a permissionless free registrar: leaving it enabled
@@ -173,10 +182,17 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   registry rather than the live one (they are also invisible to the TheGraph-based CSV export, so a
   later pre-migration will not pick them up). Run the phase, then `verify-v1-registrars-disabled`.
 
-> **Controller discovery.** The registrar's controller history is read from its events. When the RPC
-> cannot serve that range (a fork whose history predates its fork block, or a provider range limit)
-> both commands print a warning and fall back to controllers backed by a local deployment artifact —
-> treat a warned run as an incomplete audit and re-check against an archival RPC.
+> **Controller discovery.** Each surface's controller history is read from its events across the whole
+> chain. Providers cap `eth_getLogs` by block span or result count (free tiers commonly at 1k–10k
+> blocks), and a load-balanced endpoint may apply a cap to only some requests, so a refused span is
+> bisected and each half requested in turn until the provider accepts — the blocks covered are the
+> same either way. Anything else — a fork whose history predates its fork block, a refusal that
+> persists at the smallest span — fails both commands rather than reverting to the locally-described
+> controllers: that reduced set says nothing about grants no artifact accounts for, and a partial
+> audit must never pass for a complete one.
+>
+> An uncapped archival RPC reads each surface in a single request. Against a capped one the scan still
+> completes and returns the same controllers, but costs hundreds of requests and several minutes.
 
 ### Phase 4: authorize ETHRenewerV1
 

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -65,8 +65,9 @@ Phase numbering matches the console output of the `fork full` orchestrator in
 > is where the fresh deploy happens; the later phases re-seed and re-wire v1 to the **new** contract
 > addresses rather than the archived ones. Phases below carry a **Re-deploying fresh** note wherever
 > that changes what you run — most importantly, phase 1 needs a `reclaim-v1-registrar-ownership` prep
-> step and phase 3 becomes a no-op. The one-command shortcut is [`fork full`](#fork-full), which
-> detects an already-migrated chain and adjusts automatically.
+> step, and phase 3 must still be run: it is what removes the archived deployment's v1 controllers.
+> The one-command shortcut is [`fork full`](#fork-full), which detects an already-migrated chain and
+> adjusts automatically.
 
 ### Phase 0: deploy fresh v1 (clean-testnet only)
 
@@ -150,14 +151,32 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   when it is run through `phase execute-owner-txs --role v1Owner`.
 - **Env / args:** v1 owner key via `--private-key` (or `SEPOLIA_V1_OWNER_KEY` / `V1_OWNER_KEY` through
   execute-owner-txs). `--calldata-only` emits calldata for a multisig instead of broadcasting.
-- **Expected outcome:** `LegacyETHRegistrarController`, `ETHRegistrarController`,
-  `WrappedETHRegistrarController`, and `NameWrapper` removed as v1 `BaseRegistrar` controllers (via
-  `RegistrarSecurityController` when deployed); new v1 registrations frozen.
-  `verify-v1-registrars-disabled` confirms.
-- **Re-deploying fresh:** normally a **no-op you can skip** — the v1 registrars were removed by the
-  prior deployment and stay frozen (reclaiming v1 `BaseRegistrar` ownership in phase 1 does not
-  re-enable them). Re-running is harmless (each controller logs "already disabled"); prefer just
-  `verify-v1-registrars-disabled` to confirm the freeze is still in place.
+- **Expected outcome:** every v1 authorization the active deployment did not itself grant is revoked;
+  new v1 registrations frozen. The phase audits three v1 surfaces:
+
+  | Surface | Candidates considered | Revoked via |
+  | --- | --- | --- |
+  | `BaseRegistrar` | the four v1 registration controllers, the handoff contracts (`ETHRenewerV1`, `Graveyard`, `TestnetV1PremigrationRegistrar`) of **every** namespace on this chain, and any address in the registrar's `ControllerAdded` history that no local artifact accounts for | `RegistrarSecurityController.removeRegistrarController` when deployed, else `removeController` |
+  | `ReverseRegistrar` | this tooling's handoff contracts only | `setController(addr, false)` |
+  | `DefaultReverseRegistrar` | this tooling's handoff contracts only | `setController(addr, false)` |
+
+  Only the **active** namespace's handoff contracts are left authorized.
+  `verify-v1-registrars-disabled` asserts that complete set and fails on anything else.
+
+  > v1-side controllers on the reverse registrars (the official registrar controllers, which set
+  > reverse records during registration) are deliberately **not** touched — revoking them is outside
+  > the migration's remit and would break unrelated v1 behaviour.
+- **Re-deploying fresh:** **must be run — not a no-op.** The v1 registration controllers stay frozen
+  from the prior deployment, but that deployment's own handoff contracts are still authorized, and
+  `TestnetV1PremigrationRegistrar` among them is a permissionless free registrar: leaving it enabled
+  silently reopens `.eth` registration on v1, and the names it mints reserve into the **archived** v2
+  registry rather than the live one (they are also invisible to the TheGraph-based CSV export, so a
+  later pre-migration will not pick them up). Run the phase, then `verify-v1-registrars-disabled`.
+
+> **Controller discovery.** The registrar's controller history is read from its events. When the RPC
+> cannot serve that range (a fork whose history predates its fork block, or a provider range limit)
+> both commands print a warning and fall back to controllers backed by a local deployment artifact —
+> treat a warned run as an incomplete audit and re-check against an archival RPC.
 
 ### Phase 4: authorize ETHRenewerV1
 
@@ -176,9 +195,8 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   transfers v1 `BaseRegistrar` ownership to `ETHRenewerV1` is deferred to
   [phase 6](#phase-6-enable-the-v2-controller).
 - **Re-deploying fresh:** authorizes the **newly-deployed** `ETHRenewerV1` (a new address) as a v1
-  controller — must be re-run. The prior deployment's `ETHRenewerV1` remains an authorized controller
-  (orphaned but harmless); the tooling does not deauthorize it, so remove it manually only if you want
-  a clean controller set.
+  controller — must be re-run. The prior deployment's `ETHRenewerV1` is removed by
+  [phase 3](#phase-3-disable-v1-registrars), so run the phases in order rather than skipping ahead.
 
 > **Mainnet renewal continuity.** Renewals are paused between phase 3 (freeze) and phase 4
 > (authorize), and the phase 5 sync can run for days. When the v1 owner is a DAO/multisig, execute
@@ -213,6 +231,7 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   bun run migration -- phase activate-v1-renewer              --network sepolia
   bun run migration -- phase enable-v2-registrar              --network sepolia
   bun run migration -- phase verify-v2-registrar              --network sepolia
+  bun run migration -- phase verify-v1-registrars-disabled    --network sepolia
   ```
 - **Prerequisites:** phase 5 complete. Order matters — the handoff controllers must be authorized
   **before** `activate-v1-renewer` transfers v1 `BaseRegistrar` ownership away from the v1 owner
@@ -228,11 +247,18 @@ Phase numbering matches the console output of the `fork full` orchestrator in
   `ETHRenewerV1` (final lock-down); `ETHRegistrar` granted `REGISTRAR | RENEW` on the v2 `ETHRegistry`
   — live v2 registrations open. `verify-v2-registrar` confirms the grant. This bundle replaces the
   all-at-once role swap done by [prepareMigration.md](./prepareMigration.md).
+
+  These handoff grants are the last step to touch v1 authorizations, so
+  `verify-v1-registrars-disabled` is re-run here to assert the final set: only the active deployment's
+  contracts may hold a v1 grant. `fork full` runs this assertion automatically. It is the check that
+  catches a superseded deployment's controller surviving the freeze — the phase 3 registration smoke
+  test cannot see one, because it only exercises the official registrar controller's path.
 - **Re-deploying fresh:** re-points v1 at the new set and must be re-run —
   `activate-v1-handoff-controllers` authorizes the new `Graveyard`, `activate-v1-renewer` transfers v1
   `BaseRegistrar` ownership to the new `ETHRenewerV1` (the ownership you reclaimed in phase 1), and
-  `enable-v2-registrar` grants the new `ETHRegistrar`. The prior deployment's `Graveyard`/`ETHRenewerV1`
-  remain authorized as orphaned v1 controllers.
+  `enable-v2-registrar` grants the new `ETHRegistrar`. The prior deployment's
+  `Graveyard`/`ETHRenewerV1`/`TestnetV1PremigrationRegistrar` are revoked by
+  [phase 3](#phase-3-disable-v1-registrars) in the same run.
 
 ### Phase 7: switch the Universal Resolver to v2
 
@@ -323,8 +349,9 @@ prerequisites, and expected outcome:
 
 > **Re-deploying onto an already-migrated Sepolia?** This runbook assumes a first migration. On a
 > repeat deploy the order is unchanged, but read each phase's **Re-deploying fresh** note first: run
-> [`phase reclaim-v1-registrar-ownership`](#cli-commands) before phase 1, skip phase 3 (v1 is already
-> frozen), and expect phases 2, 4, 5, 6, and 7 to re-seed and re-wire v1 to the new contract set.
+> [`phase reclaim-v1-registrar-ownership`](#cli-commands) before phase 1, run phase 3 (it removes the
+> archived deployment's controllers — do not skip it), and expect phases 2, 4, 5, 6, and 7 to re-seed
+> and re-wire v1 to the new contract set.
 
 ### After
 
@@ -510,9 +537,9 @@ Two commands are **not** on-chain and intentionally omit the network options:
 | `premigration verify` | Verify eligible CSV names were reserved or registered on v2 |
 | `phase deploy-v2` | Phase 1: deploy the v2 migration contracts with the registrar deferred; archives any existing namespace and deploys fresh by default (`--resume` continues an interrupted deploy) |
 | `phase reclaim-v1-registrar-ownership` | Re-migration only: reclaim v1 `BaseRegistrar` ownership from a prior deployment's `ETHRenewerV1` back to the v1 owner (run before the Phase 1 deferred-tx replay on an already-migrated chain) |
-| `phase disable-v1-registrars` | Phase 3: disable v1 registrar controllers |
+| `phase disable-v1-registrars` | Phase 3: revoke every v1 authorization (BaseRegistrar + reverse registrars) the active deployment did not grant |
 | `phase set-v1-reverse-default-resolver` | Point the v1 `ReverseRegistrar` default resolver at the v1 `PublicResolver` (v1-owner write) |
-| `phase verify-v1-registrars-disabled` | Verify v1 registrar controllers are disabled |
+| `phase verify-v1-registrars-disabled` | Verify no v1 authorization outside the active deployment is enabled |
 | `phase authorize-v1-renewer` | Phase 4: authorize `ETHRenewerV1` as a v1 controller so unmigrated names stay renewable |
 | `phase execute-owner-txs` | Execute prepared owner transactions from a JSONL file (optionally filtered by `--role`) |
 | `phase disable-batch-registrar` | Phase 6: revoke registrar/renew roles from `BatchRegistrar` |

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -156,9 +156,9 @@ Phase numbering matches the console output of the `fork full` orchestrator in
 
   | Surface | Candidates considered | Revoked via |
   | --- | --- | --- |
-  | `BaseRegistrar` | the four v1 registration controllers, the handoff contracts (`ETHRenewerV1`, `Graveyard`, `TestnetV1PremigrationRegistrar`) of **every** namespace on this chain, and any address in the registrar's `ControllerAdded` history that no local artifact accounts for | `RegistrarSecurityController.removeRegistrarController` when deployed, else `removeController` |
-  | `ReverseRegistrar` | this tooling's handoff contracts only | `setController(addr, false)` |
-  | `DefaultReverseRegistrar` | this tooling's handoff contracts only | `setController(addr, false)` |
+  | `BaseRegistrar` | the four v1 registration controllers, the handoff contracts (`ETHRenewerV1`, `Graveyard`, `TestnetV1PremigrationRegistrar`) of **every** namespace on this chain, and any address in the registrar's `ControllerAdded` history that no local artifact accounts for | `RegistrarSecurityController.removeRegistrarController` while it still owns the registrar, else `removeController` |
+  | `ReverseRegistrar` | this tooling's handoff contracts granted there (`TestnetV1PremigrationRegistrar`, `ReverseRegistrarAdapter`) of **every** namespace on this chain | `setController(addr, false)` |
+  | `DefaultReverseRegistrar` | this tooling's handoff contracts granted there (`TestnetV1PremigrationRegistrar`, `DefaultReverseRegistrarAdapter`) of **every** namespace on this chain | `setController(addr, false)` |
 
   Only the **active** namespace's handoff contracts are left authorized.
   `verify-v1-registrars-disabled` asserts that complete set and fails on anything else.

--- a/contracts/script/migration.ts
+++ b/contracts/script/migration.ts
@@ -23,6 +23,7 @@ import {
   http,
   keccak256,
   namehash,
+  parseAbiItem,
   parseEther,
   stringToHex,
   zeroAddress,
@@ -1561,20 +1562,187 @@ async function sendAdminWrite(opts: {
   await waitForSuccessfulReceipt(opts.client, hash, opts.receiptLabel);
 }
 
-async function disableV1Registrars(opts: {
+// v1-side controllers able to mint `.eth` registrations, removed by the freeze.
+const V1_REGISTRATION_CONTROLLER_NAMES = [
+  "LegacyETHRegistrarController",
+  "ETHRegistrarController",
+  "WrappedETHRegistrarController",
+  "NameWrapper",
+] as const;
+
+// v2-side contracts a migration authorizes against v1. Every deployment namespace
+// holds its own instances, so re-deploying leaves the previous namespace's copies
+// authorized until they are explicitly revoked — including the testnet premigration
+// registrar, which registers names permissionlessly.
+const V1_HANDOFF_CONTROLLER_NAMES = [
+  "ETHRenewerV1",
+  "Graveyard",
+  "TestnetV1PremigrationRegistrar",
+] as const;
+
+// v1 reverse registrars the testnet premigration registrar is granted control of so
+// it can write reverse records on a registrant's behalf. These are shared v1
+// contracts, so a superseded deployment's grant stays live across re-deploys.
+const V1_REVERSE_REGISTRAR_NAMES = [
+  "ReverseRegistrar",
+  "DefaultReverseRegistrar",
+] as const;
+
+const V1_CONTROLLER_ADDED_EVENT = parseAbiItem(
+  "event ControllerAdded(address indexed controller)",
+);
+const V1_CONTROLLER_REMOVED_EVENT = parseAbiItem(
+  "event ControllerRemoved(address indexed controller)",
+);
+
+type V1ControllerState = {
+  // The v1 contract holding the authorization, e.g. "v1 BaseRegistrar".
+  surface: string;
+  name: string;
+  address: Address;
+  enabled: boolean;
+  // Authorized by the active deployment and expected to stay enabled.
+  keep: boolean;
+  // Contract the revoke transaction targets, and the contract whose owner() gates it.
+  target: JsonDeployment;
+  gate: JsonDeployment;
+  revokeFunctionName: string;
+  revokeArgs: readonly unknown[];
+};
+
+type V1ControllerAudit = {
+  controllers: V1ControllerState[];
+  // True when the registrar's controller history could not be read, so only
+  // controllers backed by a local deployment artifact were considered.
+  discoveryIncomplete: boolean;
+};
+
+function v1ControllersToRemove(audit: V1ControllerAudit): V1ControllerState[] {
+  return audit.controllers.filter(
+    (controller) => controller.enabled && !controller.keep,
+  );
+}
+
+function describeV1Controller(controller: V1ControllerState): string {
+  return `${controller.surface}: ${controller.name} ${controller.address}`;
+}
+
+// Reads `controllers(address)` for a batch of candidates on one v1 contract.
+async function readControllerFlags(
+  client: ReturnType<typeof publicClient>,
+  contract: JsonDeployment,
+  addresses: Address[],
+): Promise<boolean[]> {
+  return Promise.all(
+    addresses.map(
+      (address) =>
+        client.readContract({
+          address: contract.address,
+          abi: contract.abi,
+          functionName: "controllers",
+          args: [address],
+        }) as Promise<boolean>,
+    ),
+  );
+}
+
+// Reads a namespace's recorded chain id, absent when the namespace predates the
+// metadata or the file cannot be parsed.
+function readDeploymentChainId(path: string): number | undefined {
+  const chainPath = join(path, ".chain");
+  if (!existsSync(chainPath)) return undefined;
+  try {
+    const { chainId } = JSON.parse(readFileSync(chainPath, "utf-8"));
+    const parsed = Number(chainId);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Deployment namespaces that target the same chain: every namespace named for this
+// network — the canonical one, the dated archives a fresh deploy renamed aside, and
+// the `-fork` / `-clean-` runtime sets. Keyed off the network rather than the active
+// namespace so a fork run (`sepolia-fork`) still recognises the canonical `sepolia`
+// set as superseded, whose contracts hold live grants on the forked v1. A namespace
+// whose recorded chain id matches none of the expected ids is excluded so unrelated
+// deployment sets are never treated as this chain's orphans.
+function siblingDeploymentNamespaces(opts: {
+  deploymentsDir: string;
+  network: string;
+  chainIds: number[];
+}): string[] {
+  const root = resolve(opts.deploymentsDir);
+  if (!existsSync(root)) return [];
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter(
+      (name) => name === opts.network || name.startsWith(`${opts.network}-`),
+    )
+    .filter((name) => {
+      const chainId = readDeploymentChainId(join(root, name));
+      return chainId === undefined || opts.chainIds.includes(chainId);
+    })
+    .sort();
+}
+
+// Every address the registrar has ever had as a controller, recovered from its
+// controller events. Returns null when the log range cannot be served (a fork
+// whose history predates its fork block, or a provider range limit) so an empty
+// result is never mistaken for a clean controller set.
+async function discoverV1ControllerAddresses(
+  client: ReturnType<typeof publicClient>,
+  address: Address,
+): Promise<Address[] | null> {
+  try {
+    const toBlock = await client.getBlockNumber();
+    const logs = await Promise.all(
+      [V1_CONTROLLER_ADDED_EVENT, V1_CONTROLLER_REMOVED_EVENT].map((event) =>
+        client.getLogs({ address, event, fromBlock: 0n, toBlock }),
+      ),
+    );
+    return logs
+      .flat()
+      .map((log) =>
+        getAddress((log.args as { controller: Address }).controller),
+      );
+  } catch {
+    return null;
+  }
+}
+
+type V1ControllerAuditOptions = {
   network: MigrationNetwork;
   rpcUrl: string;
   chainId?: string;
   provider?: RpcProvider;
+  deploymentsDir?: string;
+  deploymentNetwork?: string;
   v1DeploymentsDir?: string;
   v1DeploymentNetwork?: string;
   extraControllers?: Array<{ name: string; address: Address }>;
-  privateKey?: `0x${string}`;
-  impersonateOwner?: boolean;
-  calldataOnly?: boolean;
-}) {
-  const chain = migrationChain(opts);
-  const client = publicClient(opts.rpcUrl, chain, opts.provider);
+};
+
+// Builds the full picture of the v1 authorizations a migration hands out, across
+// every v1 contract it grants against.
+//
+// On the BaseRegistrar, candidates are drawn from the named v1 registration
+// controllers, the handoff controllers of every deployment namespace on this chain
+// (so a superseded deployment's instances are not left authorized), and a
+// best-effort scan of the registrar's controller events that catches addresses no
+// local artifact describes.
+//
+// On the reverse registrars, candidates are restricted to this tooling's own handoff
+// contracts. v1-side controllers there (the official registrar controllers, which set
+// reverse records on registration) are deliberately left alone: revoking them is
+// outside the migration's remit and would break unrelated v1 behaviour.
+//
+// In both cases only the active namespace's handoff contracts are expected to stay
+// authorized.
+async function auditV1Controllers(
+  opts: V1ControllerAuditOptions & { client: ReturnType<typeof publicClient> },
+): Promise<V1ControllerAudit> {
   const baseRegistrar = requireV1Deployment(
     opts.network,
     "BaseRegistrarImplementation",
@@ -1585,70 +1753,194 @@ async function disableV1Registrars(opts: {
     "RegistrarSecurityController",
     opts,
   );
-  const controllerNames = [
-    "LegacyETHRegistrarController",
-    "ETHRegistrarController",
-    "WrappedETHRegistrarController",
-    "NameWrapper",
-  ];
+  const deploymentNetwork = opts.deploymentNetwork ?? opts.network;
+  const deploymentsDir = opts.deploymentsDir ?? DEFAULT_DEPLOYMENTS_DIR;
+  const canonicalChainId = NETWORKS[opts.network].chain.id;
 
-  const target = registrarSecurityController ?? baseRegistrar;
-  const wallet = opts.calldataOnly
-    ? null
-    : (
-        await resolveOwnerGatedWallet({
-          client,
-          chain,
-          rpcUrl: opts.rpcUrl,
-          provider: opts.provider,
-          gate: target,
-          ownerLabel: "v1 registrar owner",
-          privateKey: opts.privateKey,
-          impersonateOwner: opts.impersonateOwner,
-        })
-      ).wallet;
+  const registrarCandidates = new Map<Address, string>();
+  const handoffCandidates = new Map<Address, string>();
+  const keepAddresses = new Set<Address>();
+  const addCandidate = (
+    map: Map<Address, string>,
+    address: Address,
+    name: string,
+  ) => {
+    const key = getAddress(address);
+    if (!map.has(key)) map.set(key, name);
+  };
 
-  const controllers = [
-    ...controllerNames.flatMap((name) => {
-      const controller = loadV1Deployment(opts.network, name, opts);
-      return controller ? [{ name, address: controller.address }] : [];
-    }),
-    ...(opts.extraControllers ?? []),
-  ];
+  for (const name of V1_REGISTRATION_CONTROLLER_NAMES) {
+    const controller = loadV1Deployment(opts.network, name, opts);
+    if (controller) addCandidate(registrarCandidates, controller.address, name);
+  }
 
-  for (const { name, address } of controllers) {
-    const enabled = await client.readContract({
-      address: baseRegistrar.address,
-      abi: baseRegistrar.abi,
-      functionName: "controllers",
-      args: [address],
-    });
-    if (!enabled) {
-      console.log(`already disabled: ${name} ${address}`);
-      continue;
+  for (const namespace of siblingDeploymentNamespaces({
+    deploymentsDir,
+    network: opts.network,
+    chainIds: [parseNumber(opts.chainId, canonicalChainId), canonicalChainId],
+  })) {
+    const isActiveNamespace = namespace === deploymentNetwork;
+    for (const name of V1_HANDOFF_CONTROLLER_NAMES) {
+      const controller = maybeLoadV2Deployment(deploymentsDir, namespace, name);
+      if (!controller) continue;
+      if (isActiveNamespace) keepAddresses.add(getAddress(controller.address));
+      const label = `${name} (${namespace})`;
+      addCandidate(registrarCandidates, controller.address, label);
+      addCandidate(handoffCandidates, controller.address, label);
     }
+  }
 
-    const functionName = registrarSecurityController
-      ? "removeRegistrarController"
-      : "removeController";
+  for (const { name, address } of opts.extraControllers ?? []) {
+    addCandidate(registrarCandidates, address, name);
+  }
+
+  const discovered = await discoverV1ControllerAddresses(
+    opts.client,
+    baseRegistrar.address,
+  );
+  for (const address of discovered ?? []) {
+    addCandidate(registrarCandidates, address, "unrecognized controller");
+  }
+
+  const registrarTarget = registrarSecurityController ?? baseRegistrar;
+  const surfaces: Array<{
+    surface: string;
+    authority: JsonDeployment;
+    target: JsonDeployment;
+    gate: JsonDeployment;
+    revokeFunctionName: string;
+    revokeArgs: (address: Address) => readonly unknown[];
+    candidates: Map<Address, string>;
+  }> = [
+    {
+      surface: "v1 BaseRegistrar",
+      authority: baseRegistrar,
+      target: registrarTarget,
+      gate: registrarTarget,
+      revokeFunctionName: registrarSecurityController
+        ? "removeRegistrarController"
+        : "removeController",
+      revokeArgs: (address) => [address],
+      candidates: registrarCandidates,
+    },
+  ];
+
+  for (const name of V1_REVERSE_REGISTRAR_NAMES) {
+    const reverseRegistrar = loadV1Deployment(opts.network, name, opts);
+    if (!reverseRegistrar) continue;
+    surfaces.push({
+      surface: `v1 ${name}`,
+      authority: reverseRegistrar,
+      target: reverseRegistrar,
+      gate: reverseRegistrar,
+      revokeFunctionName: "setController",
+      revokeArgs: (address) => [address, false],
+      candidates: handoffCandidates,
+    });
+  }
+
+  const controllers: V1ControllerState[] = [];
+  for (const surface of surfaces) {
+    const entries = [...surface.candidates.entries()];
+    if (entries.length === 0) continue;
+    const flags = await readControllerFlags(
+      opts.client,
+      surface.authority,
+      entries.map(([address]) => address),
+    );
+    entries.forEach(([address, name], index) => {
+      controllers.push({
+        surface: surface.surface,
+        name,
+        address,
+        enabled: flags[index],
+        keep: keepAddresses.has(address),
+        target: surface.target,
+        gate: surface.gate,
+        revokeFunctionName: surface.revokeFunctionName,
+        revokeArgs: surface.revokeArgs(address),
+      });
+    });
+  }
+
+  return { controllers, discoveryIncomplete: discovered === null };
+}
+
+async function disableV1Registrars(
+  opts: V1ControllerAuditOptions & {
+    privateKey?: `0x${string}`;
+    impersonateOwner?: boolean;
+    calldataOnly?: boolean;
+  },
+) {
+  const chain = migrationChain(opts);
+  const client = publicClient(opts.rpcUrl, chain, opts.provider);
+  const audit = await auditV1Controllers({ ...opts, client });
+
+  if (audit.discoveryIncomplete) {
+    console.warn(
+      "warning: the registrar's controller history could not be read; only controllers with a local deployment artifact were checked",
+    );
+  }
+  for (const controller of audit.controllers) {
+    const { enabled, keep } = controller;
+    if (enabled && keep) {
+      console.log(
+        `keeping active deployment grant: ${describeV1Controller(controller)}`,
+      );
+    } else if (!enabled) {
+      console.log(`already revoked: ${describeV1Controller(controller)}`);
+    }
+  }
+
+  const toRemove = v1ControllersToRemove(audit);
+  if (toRemove.length === 0) {
+    console.log("no superseded v1 authorizations left to revoke");
+    return;
+  }
+
+  // Surfaces are gated by different owners, so resolve one signing wallet per gate.
+  const wallets = new Map<Address, ReturnType<typeof walletClient>>();
+  const walletForGate = async (gate: JsonDeployment, ownerLabel: string) => {
+    const key = getAddress(gate.address);
+    const existing = wallets.get(key);
+    if (existing) return existing;
+    const { wallet } = await resolveOwnerGatedWallet({
+      client,
+      chain,
+      rpcUrl: opts.rpcUrl,
+      provider: opts.provider,
+      gate,
+      ownerLabel,
+      privateKey: opts.privateKey,
+      impersonateOwner: opts.impersonateOwner,
+    });
+    wallets.set(key, wallet);
+    return wallet;
+  };
+
+  for (const controller of toRemove) {
+    const { target, revokeFunctionName, revokeArgs, surface } = controller;
+    const label = describeV1Controller(controller);
     const data = encodeFunctionData({
       abi: target.abi,
-      functionName,
-      args: [address],
+      functionName: revokeFunctionName,
+      args: revokeArgs,
     });
     if (opts.calldataOnly) {
-      printPreparedCall(`disable ${name}`, target.address, data);
+      printPreparedCall(`revoke ${label}`, target.address, data);
       continue;
     }
 
-    const hash = await wallet!.writeContract({
+    const wallet = await walletForGate(controller.gate, `${surface} owner`);
+    const hash = await wallet.writeContract({
       address: target.address,
       abi: target.abi,
-      functionName,
-      args: [address],
+      functionName: revokeFunctionName,
+      args: revokeArgs,
     });
-    await client.waitForTransactionReceipt({ hash });
-    console.log(`disabled v1 registrar controller ${name}: ${address}`);
+    await waitForSuccessfulReceipt(client, hash, `revoke ${label}`);
+    console.log(`revoked ${label}`);
   }
 }
 
@@ -2045,46 +2337,35 @@ async function activateV1RenewerAndTransferOwnership(opts: {
   }
 }
 
-async function verifyV1RegistrarsDisabled(opts: {
-  network: MigrationNetwork;
-  rpcUrl: string;
-  chainId?: string;
-  v1DeploymentsDir?: string;
-  v1DeploymentNetwork?: string;
-}) {
+// Asserts the *complete* set of v1 authorizations the migration hands out — across
+// the BaseRegistrar and the reverse registrars — not just the named registration
+// controllers. Anything enabled that the active deployment did not authorize can mint
+// or mutate v1 names and so fails the check.
+async function verifyV1RegistrarsDisabled(opts: V1ControllerAuditOptions) {
   const chain = migrationChain(opts);
-  const client = publicClient(opts.rpcUrl, chain);
-  const baseRegistrar = requireV1Deployment(
-    opts.network,
-    "BaseRegistrarImplementation",
-    opts,
-  );
-  const controllerNames = [
-    "LegacyETHRegistrarController",
-    "ETHRegistrarController",
-    "WrappedETHRegistrarController",
-    "NameWrapper",
-  ];
-  const enabledControllers: string[] = [];
+  const client = publicClient(opts.rpcUrl, chain, opts.provider);
+  const audit = await auditV1Controllers({ ...opts, client });
 
-  for (const name of controllerNames) {
-    const controller = loadV1Deployment(opts.network, name, opts);
-    if (!controller) continue;
-    const enabled = await client.readContract({
-      address: baseRegistrar.address,
-      abi: baseRegistrar.abi,
-      functionName: "controllers",
-      args: [controller.address],
-    });
-    console.log(
-      `${name}: ${enabled ? "enabled" : "disabled"} (${controller.address})`,
+  for (const controller of audit.controllers) {
+    const state = controller.enabled
+      ? controller.keep
+        ? "enabled (authorized by active deployment)"
+        : "ENABLED"
+      : "disabled";
+    console.log(`${describeV1Controller(controller)}: ${state}`);
+  }
+  if (audit.discoveryIncomplete) {
+    console.warn(
+      "warning: the registrar's controller history could not be read; only controllers with a local deployment artifact were checked",
     );
-    if (enabled) enabledControllers.push(name);
   }
 
-  if (enabledControllers.length > 0) {
+  const unexpected = v1ControllersToRemove(audit);
+  if (unexpected.length > 0) {
     throw new Error(
-      `v1 registrar controllers still enabled: ${enabledControllers.join(", ")}`,
+      `superseded v1 authorizations still enabled: ${unexpected
+        .map(describeV1Controller)
+        .join(", ")}`,
     );
   }
 }
@@ -4277,12 +4558,31 @@ export async function runForkFull(opts: RunForkFullOptions) {
       console.log(`smoke pre-migration reserved ${smokeLabels.migrate}.eth`);
     }
 
+    // Re-running against an already-migrated chain leaves the v1 BaseRegistrar
+    // owned by the prior deployment's ETHRenewerV1; reclaim it to the v1 owner
+    // before any owner-signed controller change below, the earliest of which is
+    // the phase 3 freeze. (No-op on a pristine chain. Live re-migrations use the
+    // standalone `phase reclaim-v1-registrar-ownership` command beforehand.)
+    if (useRpcStateControls) {
+      await reclaimV1RegistrarOwnership({
+        network: opts.network,
+        rpcUrl,
+        chainId: String(chainId),
+        provider,
+        ...v1Deployments,
+        v1Owner,
+        impersonateOwner: true,
+      });
+    }
+
     console.log("phase 3: disable v1 registrars");
     await disableV1Registrars({
       network: opts.network,
       rpcUrl,
       chainId: String(chainId),
       provider,
+      deploymentsDir,
+      deploymentNetwork,
       ...v1Deployments,
       ...v1OwnerSigner,
     });
@@ -4294,23 +4594,6 @@ export async function runForkFull(opts: RunForkFullOptions) {
         // registration must fail with a revert (at simulation or in the receipt).
         /revert/i,
       );
-    }
-
-    // Re-running against an already-migrated chain leaves the v1 BaseRegistrar
-    // owned by the prior deployment's ETHRenewerV1; reclaim it to the v1 owner
-    // before any owner-signed controller change below. (No-op on a pristine
-    // chain. Live re-migrations use the standalone
-    // `phase reclaim-v1-registrar-ownership` command beforehand.)
-    if (useRpcStateControls) {
-      await reclaimV1RegistrarOwnership({
-        network: opts.network,
-        rpcUrl,
-        chainId: String(chainId),
-        provider,
-        ...v1Deployments,
-        v1Owner,
-        impersonateOwner: true,
-      });
     }
 
     console.log(
@@ -4456,6 +4739,21 @@ export async function runForkFull(opts: RunForkFullOptions) {
       ethRenewerV1: ethRenewerV1.address,
       ...v1OwnerSigner,
     });
+
+    // The handoff grants above are the last thing to touch v1 authorizations, so
+    // assert the resulting set here: only the active deployment's contracts may hold
+    // a v1 grant. Catches a superseded deployment's controller surviving the freeze,
+    // which the phase 3 registration smoke test cannot see.
+    await verifyV1RegistrarsDisabled({
+      network: opts.network,
+      rpcUrl,
+      chainId: String(chainId),
+      provider,
+      ...v1Deployments,
+      deploymentsDir,
+      deploymentNetwork,
+    });
+
     const beforeEnabled = await client.readContract({
       address: ethRegistry.address,
       abi: ethRegistry.abi,
@@ -5405,15 +5703,18 @@ export async function main(argv = process.argv): Promise<void> {
   phase.addCommand(
     addV1OwnerWriteOptions(
       addV1DeploymentOptions(
-        addNetworkOptions(
-          new Command("disable-v1-registrars").description(
-            "Disable v1 registrar controllers",
+        addDeploymentOptions(
+          addNetworkOptions(
+            new Command("disable-v1-registrars").description(
+              "Disable every v1 registrar controller the active deployment did not authorize",
+            ),
           ),
         ),
       ),
     ).action(
       async (
         opts: NetworkCliOptions &
+          DeploymentCliOptions &
           V1DeploymentCliOptions &
           V1OwnerWriteCliOptions,
       ) => {
@@ -5449,17 +5750,23 @@ export async function main(argv = process.argv): Promise<void> {
   );
   phase.addCommand(
     addV1DeploymentOptions(
-      addNetworkOptions(
-        new Command("verify-v1-registrars-disabled").description(
-          "Verify v1 registrar controllers are disabled",
+      addDeploymentOptions(
+        addNetworkOptions(
+          new Command("verify-v1-registrars-disabled").description(
+            "Verify no v1 registrar controller outside the active deployment is enabled",
+          ),
         ),
       ),
-    ).action(async (opts: NetworkCliOptions & V1DeploymentCliOptions) => {
-      const networkOpts = withNetworkRpc(opts);
-      await verifyV1RegistrarsDisabled({
-        ...networkOpts,
-      });
-    }),
+    ).action(
+      async (
+        opts: NetworkCliOptions & DeploymentCliOptions & V1DeploymentCliOptions,
+      ) => {
+        const networkOpts = withNetworkRpc(opts);
+        await verifyV1RegistrarsDisabled({
+          ...networkOpts,
+        });
+      },
+    ),
   );
   phase.addCommand(
     addNetworkOptions(

--- a/contracts/script/migration.ts
+++ b/contracts/script/migration.ts
@@ -1138,7 +1138,7 @@ export async function runPreMigrationCommand(
   );
   const v1BaseRegistrar =
     opts.v1BaseRegistrar ??
-    requireV1Deployment(network, "BaseRegistrarImplementation", opts).address;
+    requireV1Deployment(network, V1_BASE_REGISTRAR_NAME, opts).address;
   const envFallbackKey = envPrivateKey(
     "PREMIGRATION_PRIVATE_KEY",
     "BATCH_REGISTRAR_OWNER_KEY",
@@ -1264,8 +1264,7 @@ async function verifyPreMigration(opts: {
       ?.address;
   const baseRegistrar =
     opts.v1BaseRegistrar ??
-    requireV1Deployment(opts.network, "BaseRegistrarImplementation", opts)
-      .address;
+    requireV1Deployment(opts.network, V1_BASE_REGISTRAR_NAME, opts).address;
   const expectedStatus = opts.expectedStatus ?? "reserved-or-registered";
   const labels = readLabelsFromCsv(
     opts.csvFile,
@@ -1570,23 +1569,49 @@ const V1_REGISTRATION_CONTROLLER_NAMES = [
   "NameWrapper",
 ] as const;
 
-// v2-side contracts a migration authorizes against v1. Every deployment namespace
-// holds its own instances, so re-deploying leaves the previous namespace's copies
-// authorized until they are explicitly revoked — including the testnet premigration
-// registrar, which registers names permissionlessly.
-const V1_HANDOFF_CONTROLLER_NAMES = [
-  "ETHRenewerV1",
-  "Graveyard",
-  "TestnetV1PremigrationRegistrar",
-] as const;
+const V1_BASE_REGISTRAR_NAME = "BaseRegistrarImplementation";
 
-// v1 reverse registrars the testnet premigration registrar is granted control of so
-// it can write reverse records on a registrant's behalf. These are shared v1
-// contracts, so a superseded deployment's grant stays live across re-deploys.
+// v1 reverse registrars a migration is granted control of: the premigration
+// registrar writes reverse records on a registrant's behalf, and the adapters
+// forward reverse updates for the accounts they are allowed to name. These are
+// shared v1 contracts, so a superseded deployment's grant stays live across
+// re-deploys.
 const V1_REVERSE_REGISTRAR_NAMES = [
   "ReverseRegistrar",
   "DefaultReverseRegistrar",
 ] as const;
+
+// v2-side contracts a migration authorizes against v1, keyed by the v1 contract
+// holding the grant. Every deployment namespace holds its own instances, so
+// re-deploying leaves the previous namespace's copies authorized until they are
+// explicitly revoked — including the testnet premigration registrar, which
+// registers names permissionlessly.
+const V1_HANDOFF_CONTROLLERS: Record<
+  typeof V1_BASE_REGISTRAR_NAME | (typeof V1_REVERSE_REGISTRAR_NAMES)[number],
+  readonly string[]
+> = {
+  BaseRegistrarImplementation: [
+    "ETHRenewerV1",
+    "Graveyard",
+    "TestnetV1PremigrationRegistrar",
+  ],
+  ReverseRegistrar: [
+    "TestnetV1PremigrationRegistrar",
+    "ReverseRegistrarAdapter",
+  ],
+  DefaultReverseRegistrar: [
+    "TestnetV1PremigrationRegistrar",
+    "DefaultReverseRegistrarAdapter",
+  ],
+};
+
+const V1_HANDOFF_CONTROLLER_ENTRIES = Object.entries(V1_HANDOFF_CONTROLLERS);
+
+// Every handoff contract name once, so each namespace's artifact is read a single
+// time regardless of how many v1 surfaces it is authorized on.
+const V1_HANDOFF_CONTROLLER_NAMES = [
+  ...new Set(Object.values(V1_HANDOFF_CONTROLLERS).flat()),
+];
 
 const V1_CONTROLLER_ADDED_EVENT = parseAbiItem(
   "event ControllerAdded(address indexed controller)",
@@ -1603,9 +1628,8 @@ type V1ControllerState = {
   enabled: boolean;
   // Authorized by the active deployment and expected to stay enabled.
   keep: boolean;
-  // Contract the revoke transaction targets, and the contract whose owner() gates it.
+  // Contract the revoke transaction targets, and whose owner() gates it.
   target: JsonDeployment;
-  gate: JsonDeployment;
   revokeFunctionName: string;
   revokeArgs: readonly unknown[];
 };
@@ -1712,6 +1736,52 @@ async function discoverV1ControllerAddresses(
   }
 }
 
+type RegistrarControlRoute = {
+  // Contract the owner-gated write targets, and whose owner() gates it.
+  target: JsonDeployment;
+  addFunctionName: string;
+  removeFunctionName: string;
+  transferFunctionName: string;
+};
+
+// The contract that currently drives the v1 BaseRegistrar's owner-gated entrypoints.
+// The security controller is a pass-through that forwards to the registrar as its
+// owner, so it only works while it still holds that ownership: once a migration has
+// handed the registrar to a renewer, or a reclaim has returned it to the v1 owner,
+// its calls revert. The route is therefore chosen from the registrar's live owner
+// rather than from the presence of a security controller artifact.
+async function resolveRegistrarControlRoute(opts: {
+  client: ReturnType<typeof publicClient>;
+  baseRegistrar: JsonDeployment;
+  registrarSecurityController: JsonDeployment | null;
+  owner?: Address;
+}): Promise<RegistrarControlRoute> {
+  const { baseRegistrar, registrarSecurityController } = opts;
+  if (registrarSecurityController) {
+    const owner =
+      opts.owner ??
+      ((await opts.client.readContract({
+        address: baseRegistrar.address,
+        abi: baseRegistrar.abi,
+        functionName: "owner",
+      })) as Address);
+    if (getAddress(owner) === getAddress(registrarSecurityController.address)) {
+      return {
+        target: registrarSecurityController,
+        addFunctionName: "addRegistrarController",
+        removeFunctionName: "removeRegistrarController",
+        transferFunctionName: "transferRegistrarOwnership",
+      };
+    }
+  }
+  return {
+    target: baseRegistrar,
+    addFunctionName: "addController",
+    removeFunctionName: "removeController",
+    transferFunctionName: "transferOwnership",
+  };
+}
+
 type V1ControllerAuditOptions = {
   network: MigrationNetwork;
   rpcUrl: string;
@@ -1734,9 +1804,10 @@ type V1ControllerAuditOptions = {
 // local artifact describes.
 //
 // On the reverse registrars, candidates are restricted to this tooling's own handoff
-// contracts. v1-side controllers there (the official registrar controllers, which set
-// reverse records on registration) are deliberately left alone: revoking them is
-// outside the migration's remit and would break unrelated v1 behaviour.
+// contracts for that registrar. v1-side controllers there (the official registrar
+// controllers, which set reverse records on registration) are deliberately left
+// alone: revoking them is outside the migration's remit and would break unrelated v1
+// behaviour.
 //
 // In both cases only the active namespace's handoff contracts are expected to stay
 // authorized.
@@ -1745,7 +1816,7 @@ async function auditV1Controllers(
 ): Promise<V1ControllerAudit> {
   const baseRegistrar = requireV1Deployment(
     opts.network,
-    "BaseRegistrarImplementation",
+    V1_BASE_REGISTRAR_NAME,
     opts,
   );
   const registrarSecurityController = loadV1Deployment(
@@ -1757,8 +1828,17 @@ async function auditV1Controllers(
   const deploymentsDir = opts.deploymentsDir ?? DEFAULT_DEPLOYMENTS_DIR;
   const canonicalChainId = NETWORKS[opts.network].chain.id;
 
-  const registrarCandidates = new Map<Address, string>();
-  const handoffCandidates = new Map<Address, string>();
+  // Candidates are tracked per v1 surface, since a handoff contract authorized on
+  // one reverse registrar has no grant to answer for on the other.
+  const surfaceCandidates = new Map<string, Map<Address, string>>();
+  const candidatesFor = (surface: string) => {
+    let candidates = surfaceCandidates.get(surface);
+    if (!candidates) {
+      candidates = new Map<Address, string>();
+      surfaceCandidates.set(surface, candidates);
+    }
+    return candidates;
+  };
   const keepAddresses = new Set<Address>();
   const addCandidate = (
     map: Map<Address, string>,
@@ -1769,6 +1849,7 @@ async function auditV1Controllers(
     if (!map.has(key)) map.set(key, name);
   };
 
+  const registrarCandidates = candidatesFor(V1_BASE_REGISTRAR_NAME);
   for (const name of V1_REGISTRATION_CONTROLLER_NAMES) {
     const controller = loadV1Deployment(opts.network, name, opts);
     if (controller) addCandidate(registrarCandidates, controller.address, name);
@@ -1785,8 +1866,11 @@ async function auditV1Controllers(
       if (!controller) continue;
       if (isActiveNamespace) keepAddresses.add(getAddress(controller.address));
       const label = `${name} (${namespace})`;
-      addCandidate(registrarCandidates, controller.address, label);
-      addCandidate(handoffCandidates, controller.address, label);
+      for (const [surface, handoffNames] of V1_HANDOFF_CONTROLLER_ENTRIES) {
+        if (handoffNames.includes(name)) {
+          addCandidate(candidatesFor(surface), controller.address, label);
+        }
+      }
     }
   }
 
@@ -1802,12 +1886,15 @@ async function auditV1Controllers(
     addCandidate(registrarCandidates, address, "unrecognized controller");
   }
 
-  const registrarTarget = registrarSecurityController ?? baseRegistrar;
+  const registrarRoute = await resolveRegistrarControlRoute({
+    client: opts.client,
+    baseRegistrar,
+    registrarSecurityController,
+  });
   const surfaces: Array<{
     surface: string;
     authority: JsonDeployment;
     target: JsonDeployment;
-    gate: JsonDeployment;
     revokeFunctionName: string;
     revokeArgs: (address: Address) => readonly unknown[];
     candidates: Map<Address, string>;
@@ -1815,11 +1902,8 @@ async function auditV1Controllers(
     {
       surface: "v1 BaseRegistrar",
       authority: baseRegistrar,
-      target: registrarTarget,
-      gate: registrarTarget,
-      revokeFunctionName: registrarSecurityController
-        ? "removeRegistrarController"
-        : "removeController",
+      target: registrarRoute.target,
+      revokeFunctionName: registrarRoute.removeFunctionName,
       revokeArgs: (address) => [address],
       candidates: registrarCandidates,
     },
@@ -1832,10 +1916,9 @@ async function auditV1Controllers(
       surface: `v1 ${name}`,
       authority: reverseRegistrar,
       target: reverseRegistrar,
-      gate: reverseRegistrar,
       revokeFunctionName: "setController",
       revokeArgs: (address) => [address, false],
-      candidates: handoffCandidates,
+      candidates: candidatesFor(name),
     });
   }
 
@@ -1856,7 +1939,6 @@ async function auditV1Controllers(
         enabled: flags[index],
         keep: keepAddresses.has(address),
         target: surface.target,
-        gate: surface.gate,
         revokeFunctionName: surface.revokeFunctionName,
         revokeArgs: surface.revokeArgs(address),
       });
@@ -1866,7 +1948,7 @@ async function auditV1Controllers(
   return { controllers, discoveryIncomplete: discovered === null };
 }
 
-async function disableV1Registrars(
+export async function disableV1Registrars(
   opts: V1ControllerAuditOptions & {
     privateKey?: `0x${string}`;
     impersonateOwner?: boolean;
@@ -1932,7 +2014,7 @@ async function disableV1Registrars(
       continue;
     }
 
-    const wallet = await walletForGate(controller.gate, `${surface} owner`);
+    const wallet = await walletForGate(target, `${surface} owner`);
     const hash = await wallet.writeContract({
       address: target.address,
       abi: target.abi,
@@ -1992,7 +2074,7 @@ async function setV1RegistrarController(opts: {
   const client = publicClient(opts.rpcUrl, chain, opts.provider);
   const baseRegistrar = requireV1Deployment(
     opts.network,
-    "BaseRegistrarImplementation",
+    V1_BASE_REGISTRAR_NAME,
     opts,
   );
   const registrarSecurityController = loadV1Deployment(
@@ -2009,20 +2091,20 @@ async function setV1RegistrarController(opts: {
   console.log(`${opts.label} v1 registrar controller enabled: ${current}`);
   if (current === opts.enabled) return;
 
-  const target = registrarSecurityController ?? baseRegistrar;
-  const functionName = registrarSecurityController
-    ? opts.enabled
-      ? "addRegistrarController"
-      : "removeRegistrarController"
-    : opts.enabled
-      ? "addController"
-      : "removeController";
+  const route = await resolveRegistrarControlRoute({
+    client,
+    baseRegistrar,
+    registrarSecurityController,
+  });
+  const functionName = opts.enabled
+    ? route.addFunctionName
+    : route.removeFunctionName;
   await sendOwnerGatedWrite({
     client,
     chain,
     rpcUrl: opts.rpcUrl,
     provider: opts.provider,
-    target,
+    target: route.target,
     functionName,
     args: [opts.controller],
     ownerLabel: "v1 registrar owner",
@@ -2161,7 +2243,7 @@ async function reclaimV1RegistrarOwnership(opts: {
   const client = publicClient(opts.rpcUrl, chain, opts.provider);
   const baseRegistrar = requireV1Deployment(
     opts.network,
-    "BaseRegistrarImplementation",
+    V1_BASE_REGISTRAR_NAME,
     opts,
   );
   const currentOwner = (await client.readContract({
@@ -2289,7 +2371,7 @@ async function activateV1RenewerAndTransferOwnership(opts: {
   const client = publicClient(opts.rpcUrl, chain, opts.provider);
   const baseRegistrar = requireV1Deployment(
     opts.network,
-    "BaseRegistrarImplementation",
+    V1_BASE_REGISTRAR_NAME,
     opts,
   );
   const registrarSecurityController = loadV1Deployment(
@@ -2305,17 +2387,19 @@ async function activateV1RenewerAndTransferOwnership(opts: {
   console.log(`v1 BaseRegistrar owner: ${currentOwner}`);
   if (getAddress(currentOwner) === getAddress(ethRenewerV1)) return;
 
-  const target = registrarSecurityController ?? baseRegistrar;
-  const functionName = registrarSecurityController
-    ? "transferRegistrarOwnership"
-    : "transferOwnership";
+  const route = await resolveRegistrarControlRoute({
+    client,
+    baseRegistrar,
+    registrarSecurityController,
+    owner: currentOwner,
+  });
   await sendOwnerGatedWrite({
     client,
     chain,
     rpcUrl: opts.rpcUrl,
     provider: opts.provider,
-    target,
-    functionName,
+    target: route.target,
+    functionName: route.transferFunctionName,
     args: [ethRenewerV1],
     ownerLabel: "v1 registrar owner",
     calldataLabel: "transfer v1 BaseRegistrar ownership to ETHRenewerV1",
@@ -2341,7 +2425,9 @@ async function activateV1RenewerAndTransferOwnership(opts: {
 // the BaseRegistrar and the reverse registrars — not just the named registration
 // controllers. Anything enabled that the active deployment did not authorize can mint
 // or mutate v1 names and so fails the check.
-async function verifyV1RegistrarsDisabled(opts: V1ControllerAuditOptions) {
+export async function verifyV1RegistrarsDisabled(
+  opts: V1ControllerAuditOptions,
+) {
   const chain = migrationChain(opts);
   const client = publicClient(opts.rpcUrl, chain, opts.provider);
   const audit = await auditV1Controllers({ ...opts, client });
@@ -3426,7 +3512,7 @@ async function deployV1(opts: DeployV1Options) {
     [
       "ENSRegistry",
       "Root",
-      "BaseRegistrarImplementation",
+      V1_BASE_REGISTRAR_NAME,
       "RegistrarSecurityController",
       "ReverseRegistrar",
       "DefaultReverseRegistrar",
@@ -3661,14 +3747,10 @@ async function readV1Owner({
   label: string;
 }) {
   const client = publicClient(rpcUrl, chain, provider);
-  const baseRegistrar = requireV1Deployment(
-    network,
-    "BaseRegistrarImplementation",
-    {
-      v1DeploymentsDir,
-      v1DeploymentNetwork,
-    },
-  );
+  const baseRegistrar = requireV1Deployment(network, V1_BASE_REGISTRAR_NAME, {
+    v1DeploymentsDir,
+    v1DeploymentNetwork,
+  });
   return (await client.readContract({
     address: baseRegistrar.address,
     abi: baseRegistrar.abi,
@@ -3798,7 +3880,7 @@ async function migrateUnwrappedV1Name({
   const registry = requireV1Deployment(network, "ENSRegistry", v1Deployments);
   const baseRegistrar = requireV1Deployment(
     network,
-    "BaseRegistrarImplementation",
+    V1_BASE_REGISTRAR_NAME,
     v1Deployments,
   );
   const resolver = (await client.readContract({
@@ -4284,7 +4366,7 @@ export async function runForkFull(opts: RunForkFullOptions) {
 
     const v1BaseRegistrar = requireV1Deployment(
       opts.network,
-      "BaseRegistrarImplementation",
+      V1_BASE_REGISTRAR_NAME,
       v1Deployments,
     );
     const v1RegistrarOwner = (await client.readContract({

--- a/contracts/script/migration.ts
+++ b/contracts/script/migration.ts
@@ -12,6 +12,10 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import {
+  AbiDecodingZeroDataError,
+  BaseError,
+  ContractFunctionRevertedError,
+  ContractFunctionZeroDataError,
   createPublicClient,
   createWalletClient,
   custom,
@@ -28,6 +32,7 @@ import {
   stringToHex,
   zeroAddress,
   zeroHash,
+  type AbiEvent,
   type Address,
   type Chain,
 } from "viem";
@@ -804,7 +809,10 @@ function installRpcCompatibility(debugRpc: boolean): void {
     const response = await originalFetch(input, init);
     try {
       const payload = await response.clone().json();
-      if (payload?.error && request?.method === "eth_feeHistory") {
+      if (
+        request?.method === "eth_feeHistory" &&
+        isMissingFeeHistory(payload?.error)
+      ) {
         return new Response(JSON.stringify(buildFeeHistoryResponse(request)), {
           headers: { "content-type": "application/json" },
           status: 200,
@@ -1613,12 +1621,29 @@ const V1_HANDOFF_CONTROLLER_NAMES = [
   ...new Set(Object.values(V1_HANDOFF_CONTROLLERS).flat()),
 ];
 
+// Controller-history events, differing per v1 surface: the BaseRegistrar records
+// grants and revocations separately, the reverse registrars carry both in one event.
 const V1_CONTROLLER_ADDED_EVENT = parseAbiItem(
   "event ControllerAdded(address indexed controller)",
 );
 const V1_CONTROLLER_REMOVED_EVENT = parseAbiItem(
   "event ControllerRemoved(address indexed controller)",
 );
+const V1_CONTROLLER_CHANGED_EVENT = parseAbiItem(
+  "event ControllerChanged(address indexed controller, bool enabled)",
+);
+
+// Getter each handoff contract exposes for the reverse registrar it forwards to,
+// so an instance no local artifact describes can still be recognised from chain
+// state. v1's own reverse controllers hold the registrar under a different name
+// and so do not answer these calls.
+const V1_REVERSE_REGISTRAR_BACK_REFERENCES: Record<
+  (typeof V1_REVERSE_REGISTRAR_NAMES)[number],
+  string
+> = {
+  ReverseRegistrar: "REVERSE_REGISTRAR",
+  DefaultReverseRegistrar: "DEFAULT_REVERSE_REGISTRAR",
+};
 
 type V1ControllerState = {
   // The v1 contract holding the authorization, e.g. "v1 BaseRegistrar".
@@ -1628,6 +1653,10 @@ type V1ControllerState = {
   enabled: boolean;
   // Authorized by the active deployment and expected to stay enabled.
   keep: boolean;
+  // A v1-side controller this tooling never granted. Reported but never revoked:
+  // the reverse registrars' own controllers set reverse records during
+  // registration, so revoking them would break unrelated v1 behaviour.
+  foreign: boolean;
   // Contract the revoke transaction targets, and whose owner() gates it.
   target: JsonDeployment;
   revokeFunctionName: string;
@@ -1636,14 +1665,12 @@ type V1ControllerState = {
 
 type V1ControllerAudit = {
   controllers: V1ControllerState[];
-  // True when the registrar's controller history could not be read, so only
-  // controllers backed by a local deployment artifact were considered.
-  discoveryIncomplete: boolean;
 };
 
 function v1ControllersToRemove(audit: V1ControllerAudit): V1ControllerState[] {
   return audit.controllers.filter(
-    (controller) => controller.enabled && !controller.keep,
+    (controller) =>
+      controller.enabled && !controller.keep && !controller.foreign,
   );
 }
 
@@ -1671,38 +1698,47 @@ async function readControllerFlags(
 }
 
 // Reads a namespace's recorded chain id, absent when the namespace predates the
-// metadata or the file cannot be parsed.
+// metadata. A metadata file that exists but cannot be parsed raises.
 function readDeploymentChainId(path: string): number | undefined {
   const chainPath = join(path, ".chain");
   if (!existsSync(chainPath)) return undefined;
+  let chainId: unknown;
   try {
-    const { chainId } = JSON.parse(readFileSync(chainPath, "utf-8"));
-    const parsed = Number(chainId);
-    return Number.isFinite(parsed) ? parsed : undefined;
-  } catch {
-    return undefined;
+    ({ chainId } = JSON.parse(readFileSync(chainPath, "utf-8")));
+  } catch (error) {
+    throw new Error(`unreadable deployment metadata: ${chainPath}`, {
+      cause: error,
+    });
   }
+  const parsed = Number(chainId);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`invalid chainId in ${chainPath}: ${String(chainId)}`);
+  }
+  return parsed;
 }
 
-// Deployment namespaces that target the same chain: every namespace named for this
-// network — the canonical one, the dated archives a fresh deploy renamed aside, and
-// the `-fork` / `-clean-` runtime sets. Keyed off the network rather than the active
-// namespace so a fork run (`sepolia-fork`) still recognises the canonical `sepolia`
-// set as superseded, whose contracts hold live grants on the forked v1. A namespace
-// whose recorded chain id matches none of the expected ids is excluded so unrelated
-// deployment sets are never treated as this chain's orphans.
+// Deployment namespaces that target the same chain: every namespace named for one
+// of the given base names — the canonical one, the dated archives a fresh deploy
+// renamed aside, and the `-fork` / `-clean-` runtime sets. The network is included
+// alongside the active namespace so a fork run (`sepolia-fork`) still recognises the
+// canonical `sepolia` set as superseded, whose contracts hold live grants on the
+// forked v1, and so a custom namespace (`--deployment-network staging`) still finds
+// its own archives. A namespace whose recorded chain id matches none of the expected
+// ids is excluded so unrelated deployment sets are never treated as this chain's
+// orphans.
 function siblingDeploymentNamespaces(opts: {
   deploymentsDir: string;
-  network: string;
+  networks: string[];
   chainIds: number[];
 }): string[] {
   const root = resolve(opts.deploymentsDir);
   if (!existsSync(root)) return [];
+  const bases = [...new Set(opts.networks)];
   return readdirSync(root, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name)
-    .filter(
-      (name) => name === opts.network || name.startsWith(`${opts.network}-`),
+    .filter((name) =>
+      bases.some((base) => name === base || name.startsWith(`${base}-`)),
     )
     .filter((name) => {
       const chainId = readDeploymentChainId(join(root, name));
@@ -1711,29 +1747,141 @@ function siblingDeploymentNamespaces(opts: {
     .sort();
 }
 
-// Every address the registrar has ever had as a controller, recovered from its
-// controller events. Returns null when the log range cannot be served (a fork
-// whose history predates its fork block, or a provider range limit) so an empty
-// result is never mistaken for a clean controller set.
+// Smallest block span worth requesting before a provider's refusal is taken at face
+// value rather than as a demand for a narrower one.
+const LOG_SCAN_MIN_SPAN = 1_000n;
+
+// Refusals of the span rather than of the query: the block range or the result count
+// exceeded a server-side cap. Both are answered by requesting a narrower span.
+const LOG_SCAN_SPAN_REFUSALS = [
+  "block range",
+  "range exceeds",
+  "narrow your filter",
+  "query returned more than",
+  "more than 10000 results",
+  "log response size",
+  "response size exceeded",
+  "query timeout exceeded",
+];
+
+function isLogSpanRefusal(error: unknown): boolean {
+  const message = errorMessageChain(error).join(" ").toLowerCase();
+  return LOG_SCAN_SPAN_REFUSALS.some((refusal) => message.includes(refusal));
+}
+
+// Every `controller` address one event has ever carried on a contract. Providers cap
+// `eth_getLogs` by block span or by result count, and a load-balanced endpoint may
+// apply a cap to only some requests, so a refused span is bisected and each half
+// requested in turn. The widest span the provider has accepted is carried across the
+// scan, so the cap is discovered once rather than rediscovered per subrange. The
+// blocks covered are the same either way; a refusal at the smallest span, or any
+// error that is not about the span, raises.
+async function readControllerEventAddresses(
+  client: ReturnType<typeof publicClient>,
+  args: { address: Address; event: AbiEvent; toBlock: bigint },
+): Promise<Address[]> {
+  let acceptedSpan: bigint | undefined;
+
+  const readSpan = async (
+    fromBlock: bigint,
+    toBlock: bigint,
+  ): Promise<Address[]> => {
+    const span = toBlock - fromBlock + 1n;
+    const bisect = () => {
+      const mid = fromBlock + span / 2n;
+      return readSpan(fromBlock, mid - 1n).then(async (left) => [
+        ...left,
+        ...(await readSpan(mid, toBlock)),
+      ]);
+    };
+    if (acceptedSpan !== undefined && span > acceptedSpan) return bisect();
+    try {
+      const logs = await client.getLogs({
+        address: args.address,
+        event: args.event,
+        fromBlock,
+        toBlock,
+      });
+      if (acceptedSpan === undefined || span > acceptedSpan) acceptedSpan = span;
+      return logs.map((log) =>
+        getAddress((log.args as { controller: Address }).controller),
+      );
+    } catch (error) {
+      if (!isLogSpanRefusal(error) || span <= LOG_SCAN_MIN_SPAN) throw error;
+      return bisect();
+    }
+  };
+  return readSpan(0n, args.toBlock);
+}
+
+// Every address a v1 surface has ever had as a controller, across the whole chain.
 async function discoverV1ControllerAddresses(
   client: ReturnType<typeof publicClient>,
   address: Address,
-): Promise<Address[] | null> {
-  try {
-    const toBlock = await client.getBlockNumber();
-    const logs = await Promise.all(
-      [V1_CONTROLLER_ADDED_EVENT, V1_CONTROLLER_REMOVED_EVENT].map((event) =>
-        client.getLogs({ address, event, fromBlock: 0n, toBlock }),
-      ),
-    );
-    return logs
-      .flat()
-      .map((log) =>
-        getAddress((log.args as { controller: Address }).controller),
-      );
-  } catch {
-    return null;
+  events: readonly AbiEvent[],
+): Promise<Address[]> {
+  const toBlock = await client.getBlockNumber();
+  const discovered = await Promise.all(
+    events.map((event) =>
+      readControllerEventAddresses(client, { address, event, toBlock }),
+    ),
+  );
+  return discovered.flat();
+}
+
+// True when the call reached the chain and the contract declined to answer: it
+// reverted, or the address returned no data because it holds no such function. The
+// message is checked alongside the error type because a provider that flattens
+// JSON-RPC errors loses the type viem would otherwise attach.
+function isContractProbeRejection(error: unknown): boolean {
+  if (
+    error instanceof BaseError &&
+    error.walk(
+      (cause) =>
+        cause instanceof ContractFunctionRevertedError ||
+        cause instanceof ContractFunctionZeroDataError ||
+        cause instanceof AbiDecodingZeroDataError,
+    ) !== null
+  ) {
+    return true;
   }
+  const message = errorMessageChain(error).join(" ").toLowerCase();
+  return (
+    message.includes("execution reverted") ||
+    message.includes("reverted for an unknown reason") ||
+    message.includes("returned no data")
+  );
+}
+
+// Filters discovered addresses down to this tooling's own handoff contracts, by
+// asking each one which reverse registrar it forwards to. An address that declines
+// the call, or answers with a different registrar, belongs to v1. Any other failure
+// means the answer is unknown and is raised.
+async function filterHandoffControllersByBackReference(
+  client: ReturnType<typeof publicClient>,
+  surface: JsonDeployment,
+  getterName: string,
+  addresses: Address[],
+): Promise<Address[]> {
+  const abi = [
+    parseAbiItem(`function ${getterName}() view returns (address)`),
+  ] as const;
+  const matches = await Promise.all(
+    addresses.map(async (address) => {
+      try {
+        const backReference = (await client.readContract({
+          address,
+          abi,
+          functionName: getterName,
+        })) as Address;
+        return getAddress(backReference) === getAddress(surface.address);
+      } catch (error) {
+        if (!isContractProbeRejection(error)) throw error;
+        return false;
+      }
+    }),
+  );
+  return addresses.filter((_, index) => matches[index]);
 }
 
 type RegistrarControlRoute = {
@@ -1791,26 +1939,27 @@ type V1ControllerAuditOptions = {
   deploymentNetwork?: string;
   v1DeploymentsDir?: string;
   v1DeploymentNetwork?: string;
-  extraControllers?: Array<{ name: string; address: Address }>;
 };
 
 // Builds the full picture of the v1 authorizations a migration hands out, across
 // every v1 contract it grants against.
 //
-// On the BaseRegistrar, candidates are drawn from the named v1 registration
-// controllers, the handoff controllers of every deployment namespace on this chain
-// (so a superseded deployment's instances are not left authorized), and a
-// best-effort scan of the registrar's controller events that catches addresses no
-// local artifact describes.
+// Candidates come from three places: the named v1 registration controllers, the
+// handoff contracts recorded in each deployment namespace on this chain (so a
+// superseded deployment's instances are not left authorized), and a scan of each
+// surface's controller events that catches addresses no local artifact describes.
 //
-// On the reverse registrars, candidates are restricted to this tooling's own handoff
-// contracts for that registrar. v1-side controllers there (the official registrar
-// controllers, which set reverse records on registration) are deliberately left
-// alone: revoking them is outside the migration's remit and would break unrelated v1
-// behaviour.
+// What a discovered address means differs by surface. On the BaseRegistrar the
+// freeze bans all v1 minting, so every controller the active deployment did not
+// authorize is revoked. On the reverse registrars only this tooling's own forwarders
+// are in remit: a discovered address is claimed only when it reports forwarding to
+// that registrar, and everything else — the official registrar controllers, which set
+// reverse records during registration — is reported and left alone, since revoking
+// them would break unrelated v1 behaviour.
 //
-// In both cases only the active namespace's handoff contracts are expected to stay
-// authorized.
+// The active namespace's handoff contracts are read directly rather than through the
+// namespace scan, so a namespace naming or chain-id mismatch can only ever cause an
+// under-revoke, never revoke the live deployment's own grants.
 async function auditV1Controllers(
   opts: V1ControllerAuditOptions & { client: ReturnType<typeof publicClient> },
 ): Promise<V1ControllerAudit> {
@@ -1855,15 +2004,17 @@ async function auditV1Controllers(
     if (controller) addCandidate(registrarCandidates, controller.address, name);
   }
 
-  for (const namespace of siblingDeploymentNamespaces({
-    deploymentsDir,
-    network: opts.network,
-    chainIds: [parseNumber(opts.chainId, canonicalChainId), canonicalChainId],
-  })) {
-    const isActiveNamespace = namespace === deploymentNetwork;
+  // Registers a namespace's handoff contracts against every surface they hold a
+  // grant on, and reports how many the namespace actually describes.
+  const addNamespaceHandoffControllers = (
+    namespace: string,
+    isActiveNamespace: boolean,
+  ) => {
+    let found = 0;
     for (const name of V1_HANDOFF_CONTROLLER_NAMES) {
       const controller = maybeLoadV2Deployment(deploymentsDir, namespace, name);
       if (!controller) continue;
+      found += 1;
       if (isActiveNamespace) keepAddresses.add(getAddress(controller.address));
       const label = `${name} (${namespace})`;
       for (const [surface, handoffNames] of V1_HANDOFF_CONTROLLER_ENTRIES) {
@@ -1872,18 +2023,25 @@ async function auditV1Controllers(
         }
       }
     }
+    return found;
+  };
+
+  // The active namespace is read directly, and first so its label wins, rather than
+  // waiting for the scan below to surface it: an empty keep set would mark the live
+  // deployment's own grants superseded and revoke them.
+  if (addNamespaceHandoffControllers(deploymentNetwork, true) === 0) {
+    throw new Error(
+      `no handoff contract artifacts under ${join(resolve(deploymentsDir), deploymentNetwork)}: cannot tell the active deployment's v1 authorizations from a superseded deployment's`,
+    );
   }
 
-  for (const { name, address } of opts.extraControllers ?? []) {
-    addCandidate(registrarCandidates, address, name);
-  }
-
-  const discovered = await discoverV1ControllerAddresses(
-    opts.client,
-    baseRegistrar.address,
-  );
-  for (const address of discovered ?? []) {
-    addCandidate(registrarCandidates, address, "unrecognized controller");
+  for (const namespace of siblingDeploymentNamespaces({
+    deploymentsDir,
+    networks: [opts.network, deploymentNetwork],
+    chainIds: [parseNumber(opts.chainId, canonicalChainId), canonicalChainId],
+  })) {
+    if (namespace === deploymentNetwork) continue;
+    addNamespaceHandoffControllers(namespace, false);
   }
 
   const registrarRoute = await resolveRegistrarControlRoute({
@@ -1898,6 +2056,11 @@ async function auditV1Controllers(
     revokeFunctionName: string;
     revokeArgs: (address: Address) => readonly unknown[];
     candidates: Map<Address, string>;
+    events: readonly AbiEvent[];
+    // Getter a discovered address must answer with this surface to be claimed as
+    // this tooling's own. Absent on the BaseRegistrar, where the freeze revokes
+    // every controller the active deployment did not authorize.
+    backReferenceGetter?: string;
   }> = [
     {
       surface: "v1 BaseRegistrar",
@@ -1906,12 +2069,12 @@ async function auditV1Controllers(
       revokeFunctionName: registrarRoute.removeFunctionName,
       revokeArgs: (address) => [address],
       candidates: registrarCandidates,
+      events: [V1_CONTROLLER_ADDED_EVENT, V1_CONTROLLER_REMOVED_EVENT],
     },
   ];
 
   for (const name of V1_REVERSE_REGISTRAR_NAMES) {
-    const reverseRegistrar = loadV1Deployment(opts.network, name, opts);
-    if (!reverseRegistrar) continue;
+    const reverseRegistrar = requireV1Deployment(opts.network, name, opts);
     surfaces.push({
       surface: `v1 ${name}`,
       authority: reverseRegistrar,
@@ -1919,11 +2082,50 @@ async function auditV1Controllers(
       revokeFunctionName: "setController",
       revokeArgs: (address) => [address, false],
       candidates: candidatesFor(name),
+      events: [V1_CONTROLLER_CHANGED_EVENT],
+      backReferenceGetter: V1_REVERSE_REGISTRAR_BACK_REFERENCES[name],
     });
   }
 
   const controllers: V1ControllerState[] = [];
   for (const surface of surfaces) {
+    const discovered = await discoverV1ControllerAddresses(
+      opts.client,
+      surface.authority.address,
+      surface.events,
+    );
+
+    // Addresses the history turned up that no artifact accounts for. Each is
+    // claimed or disowned before it joins the candidate set, so the revoke pass
+    // never has to guess whose grant it is.
+    const unknown = [
+      ...new Set(discovered.map((address) => getAddress(address))),
+    ].filter((address) => !surface.candidates.has(address));
+    const claimed = new Set(
+      surface.backReferenceGetter
+        ? await filterHandoffControllersByBackReference(
+            opts.client,
+            surface.authority,
+            surface.backReferenceGetter,
+            unknown,
+          )
+        : unknown,
+    );
+    const foreignAddresses = new Set(
+      unknown.filter((address) => !claimed.has(address)),
+    );
+    for (const address of unknown) {
+      addCandidate(
+        surface.candidates,
+        address,
+        !surface.backReferenceGetter
+          ? "unrecognized controller"
+          : claimed.has(address)
+            ? "handoff contract (no local artifact)"
+            : "v1 controller",
+      );
+    }
+
     const entries = [...surface.candidates.entries()];
     if (entries.length === 0) continue;
     const flags = await readControllerFlags(
@@ -1938,6 +2140,7 @@ async function auditV1Controllers(
         address,
         enabled: flags[index],
         keep: keepAddresses.has(address),
+        foreign: foreignAddresses.has(address),
         target: surface.target,
         revokeFunctionName: surface.revokeFunctionName,
         revokeArgs: surface.revokeArgs(address),
@@ -1945,7 +2148,7 @@ async function auditV1Controllers(
     });
   }
 
-  return { controllers, discoveryIncomplete: discovered === null };
+  return { controllers };
 }
 
 export async function disableV1Registrars(
@@ -1959,14 +2162,13 @@ export async function disableV1Registrars(
   const client = publicClient(opts.rpcUrl, chain, opts.provider);
   const audit = await auditV1Controllers({ ...opts, client });
 
-  if (audit.discoveryIncomplete) {
-    console.warn(
-      "warning: the registrar's controller history could not be read; only controllers with a local deployment artifact were checked",
-    );
-  }
   for (const controller of audit.controllers) {
-    const { enabled, keep } = controller;
-    if (enabled && keep) {
+    const { enabled, keep, foreign } = controller;
+    if (enabled && foreign) {
+      console.log(
+        `leaving v1-owned controller: ${describeV1Controller(controller)}`,
+      );
+    } else if (enabled && keep) {
       console.log(
         `keeping active deployment grant: ${describeV1Controller(controller)}`,
       );
@@ -2434,16 +2636,13 @@ export async function verifyV1RegistrarsDisabled(
 
   for (const controller of audit.controllers) {
     const state = controller.enabled
-      ? controller.keep
-        ? "enabled (authorized by active deployment)"
-        : "ENABLED"
+      ? controller.foreign
+        ? "enabled (v1-owned, outside migration remit)"
+        : controller.keep
+          ? "enabled (authorized by active deployment)"
+          : "ENABLED"
       : "disabled";
     console.log(`${describeV1Controller(controller)}: ${state}`);
-  }
-  if (audit.discoveryIncomplete) {
-    console.warn(
-      "warning: the registrar's controller history could not be read; only controllers with a local deployment artifact were checked",
-    );
   }
 
   const unexpected = v1ControllersToRemove(audit);

--- a/contracts/test/e2e/v1RegistrarFreeze.test.ts
+++ b/contracts/test/e2e/v1RegistrarFreeze.test.ts
@@ -25,6 +25,10 @@ const ARCHIVED_NAMESPACE = "mainnet-archived-20260101";
 const CUSTOM_NAMESPACE = "staging";
 const CUSTOM_ARCHIVED_NAMESPACE = "staging-20260101-r1";
 
+// Height past which a whole-chain log request is wider than the smallest span the
+// scan will narrow to, so a capped provider forces it to split the range.
+const MIN_SCAN_NARROWING_BLOCK = 1_100n;
+
 // Stand-ins for a superseded deployment's handoff contracts: the freeze only reads
 // their controller flags, so any address that is not an active deployment's works.
 const ARCHIVED_REVERSE_ADAPTER = getAddress(
@@ -464,8 +468,11 @@ describe("v1 registrar freeze", () => {
       const { adapter, defaultAdapter } = await deployUntrackedReverseAdapters();
 
       // The scan only narrows above its minimum span, so the chain has to be
-      // longer than one request's worth.
-      await env.client.mine({ blocks: 4096 });
+      // longer than one request's worth. Mined in small batches, since a single
+      // large batch outruns the RPC request timeout on a slow machine.
+      while ((await env.client.getBlockNumber()) < MIN_SCAN_NARROWING_BLOCK) {
+        await env.client.mine({ blocks: 256 });
+      }
 
       const { provider, state } = providerCappingLogSpan(1_000n);
       await disableV1Registrars({ ...freezeOptions(), provider });

--- a/contracts/test/e2e/v1RegistrarFreeze.test.ts
+++ b/contracts/test/e2e/v1RegistrarFreeze.test.ts
@@ -1,0 +1,255 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getAddress, type Address } from "viem";
+import {
+  disableV1Registrars,
+  verifyV1RegistrarsDisabled,
+} from "../../script/migration.js";
+
+// Each revoke waits a full receipt poll, so the freeze needs more than the default
+// per-test budget.
+const TEST_TIMEOUT_MS = 120_000;
+
+// The devnet runs on chain id 1, so the freeze's mainnet config applies and the
+// locally deployed RegistrarSecurityController is discovered the same way the
+// bundled mainnet artifact is.
+const NETWORK = "mainnet";
+const ACTIVE_NAMESPACE = "mainnet";
+const ARCHIVED_NAMESPACE = "mainnet-archived-20260101";
+
+// Stand-ins for a superseded deployment's handoff contracts: the freeze only reads
+// their controller flags, so any address that is not an active deployment's works.
+const ARCHIVED_REVERSE_ADAPTER = getAddress(
+  "0x00000000000000000000000000000000000ada01",
+);
+const ARCHIVED_DEFAULT_REVERSE_ADAPTER = getAddress(
+  "0x00000000000000000000000000000000000ada02",
+);
+const ARCHIVED_ETH_RENEWER = getAddress(
+  "0x00000000000000000000000000000000000ada03",
+);
+
+describe("v1 registrar freeze", () => {
+  const { env, setupEnv } = process.TEST_GLOBALS!;
+  const workDir = mkdtempSync(join(tmpdir(), "v1-registrar-freeze-"));
+  const v1DeploymentsDir = join(workDir, "v1");
+  const deploymentsDir = join(workDir, "v2");
+
+  setupEnv({ resetOnEach: true });
+
+  afterAll(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function writeDeployment(
+    root: string,
+    namespace: string,
+    name: string,
+    deployment: { address: Address; abi: readonly unknown[] },
+  ) {
+    const dir = join(root, namespace);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `${name}.json`),
+      JSON.stringify({ address: deployment.address, abi: deployment.abi }),
+    );
+  }
+
+  function writeNamespaceMetadata(root: string, namespace: string) {
+    writeFileSync(
+      join(root, namespace, ".chain"),
+      JSON.stringify({ environment: namespace, chainId: 1 }),
+    );
+  }
+
+  // Mirrors the artifact layout the freeze reads: the shared v1 contracts under the
+  // v1 deployments root, and one v2 namespace per deployment — the active one plus a
+  // superseded one whose handoff contracts must be revoked.
+  function writeDeploymentArtifacts() {
+    rmSync(workDir, { recursive: true, force: true });
+    for (const [name, contract] of [
+      ["BaseRegistrarImplementation", env.v1.BaseRegistrar],
+      ["RegistrarSecurityController", env.v1.RegistrarSecurityController],
+      ["ReverseRegistrar", env.v1.ReverseRegistrar],
+      ["DefaultReverseRegistrar", env.shared.DefaultReverseRegistrar],
+    ] as const) {
+      writeDeployment(v1DeploymentsDir, NETWORK, name, contract);
+    }
+
+    for (const [name, contract] of [
+      ["ReverseRegistrarAdapter", env.shared.ReverseRegistrarAdapter],
+      [
+        "DefaultReverseRegistrarAdapter",
+        env.shared.DefaultReverseRegistrarAdapter,
+      ],
+    ] as const) {
+      writeDeployment(deploymentsDir, ACTIVE_NAMESPACE, name, contract);
+    }
+    writeNamespaceMetadata(deploymentsDir, ACTIVE_NAMESPACE);
+
+    for (const [name, address] of [
+      ["ReverseRegistrarAdapter", ARCHIVED_REVERSE_ADAPTER],
+      ["DefaultReverseRegistrarAdapter", ARCHIVED_DEFAULT_REVERSE_ADAPTER],
+      ["ETHRenewerV1", ARCHIVED_ETH_RENEWER],
+    ] as const) {
+      writeDeployment(deploymentsDir, ARCHIVED_NAMESPACE, name, {
+        address,
+        abi: [],
+      });
+    }
+    writeNamespaceMetadata(deploymentsDir, ARCHIVED_NAMESPACE);
+  }
+
+  function freezeOptions() {
+    return {
+      network: NETWORK,
+      rpcUrl: `http://${env.hostPort}`,
+      chainId: "1",
+      deploymentsDir,
+      deploymentNetwork: ACTIVE_NAMESPACE,
+      v1DeploymentsDir,
+      v1DeploymentNetwork: NETWORK,
+      impersonateOwner: true,
+    } as const;
+  }
+
+  async function ownerAccountOf(contract: {
+    read: { owner: () => Promise<Address> };
+  }) {
+    const owner = await contract.read.owner();
+    const account = env.accounts.find(
+      (candidate) => getAddress(candidate.address) === getAddress(owner),
+    );
+    if (!account) throw new Error(`no local account for owner ${owner}`);
+    return account;
+  }
+
+  // Grants a superseded deployment's handoff contracts the same v1 authorizations a
+  // prior migration would have left behind.
+  async function authorizeArchivedHandoffContracts() {
+    const reverseOwner = await ownerAccountOf(env.v1.ReverseRegistrar);
+    await env.v1.ReverseRegistrar.write.setController(
+      [ARCHIVED_REVERSE_ADAPTER, true],
+      { account: reverseOwner },
+    );
+    const defaultReverseOwner = await ownerAccountOf(
+      env.shared.DefaultReverseRegistrar,
+    );
+    await env.shared.DefaultReverseRegistrar.write.setController(
+      [ARCHIVED_DEFAULT_REVERSE_ADAPTER, true],
+      { account: defaultReverseOwner },
+    );
+    const securityOwner = await ownerAccountOf(
+      env.v1.RegistrarSecurityController,
+    );
+    await env.v1.RegistrarSecurityController.write.addRegistrarController(
+      [ARCHIVED_ETH_RENEWER],
+      { account: securityOwner },
+    );
+  }
+
+  // Moves the BaseRegistrar out from under the security controller, the state a
+  // re-migration leaves behind once ownership has been reclaimed to the v1 owner.
+  async function reclaimRegistrarOwnershipToEoa() {
+    const securityOwner = await ownerAccountOf(
+      env.v1.RegistrarSecurityController,
+    );
+    await env.v1.RegistrarSecurityController.write.transferRegistrarOwnership(
+      [securityOwner.address],
+      { account: securityOwner },
+    );
+    return securityOwner;
+  }
+
+  it(
+    "revokes a superseded deployment's reverse registrar adapters",
+    async () => {
+      writeDeploymentArtifacts();
+      await authorizeArchivedHandoffContracts();
+
+      // The audit must see the archived adapters, so the pre-freeze state fails.
+      await expect(verifyV1RegistrarsDisabled(freezeOptions())).rejects.toThrow(
+        /superseded v1 authorizations still enabled/,
+      );
+
+      await disableV1Registrars(freezeOptions());
+
+      await expect(
+        env.v1.ReverseRegistrar.read.controllers([ARCHIVED_REVERSE_ADAPTER]),
+      ).resolves.toBe(false);
+      await expect(
+        env.shared.DefaultReverseRegistrar.read.controllers([
+          ARCHIVED_DEFAULT_REVERSE_ADAPTER,
+        ]),
+      ).resolves.toBe(false);
+      await expect(
+        env.v1.BaseRegistrar.read.controllers([ARCHIVED_ETH_RENEWER]),
+      ).resolves.toBe(false);
+
+      // The active deployment's adapters keep writing reverse records.
+      await expect(
+        env.v1.ReverseRegistrar.read.controllers([
+          env.shared.ReverseRegistrarAdapter.address,
+        ]),
+      ).resolves.toBe(true);
+      await expect(
+        env.shared.DefaultReverseRegistrar.read.controllers([
+          env.shared.DefaultReverseRegistrarAdapter.address,
+        ]),
+      ).resolves.toBe(true);
+
+      await verifyV1RegistrarsDisabled(freezeOptions());
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "revokes registrar controllers while the security controller owns the registrar",
+    async () => {
+      writeDeploymentArtifacts();
+      await authorizeArchivedHandoffContracts();
+
+      await disableV1Registrars(freezeOptions());
+
+      await expect(
+        env.v1.BaseRegistrar.read.controllers([ARCHIVED_ETH_RENEWER]),
+      ).resolves.toBe(false);
+      await expect(
+        env.v1.BaseRegistrar.read.controllers([env.v1.NameWrapper.address]),
+      ).resolves.toBe(false);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "revokes registrar controllers after ownership is reclaimed from the security controller",
+    async () => {
+      writeDeploymentArtifacts();
+      await authorizeArchivedHandoffContracts();
+      const registrarOwner = await reclaimRegistrarOwnershipToEoa();
+
+      // Routing through the security controller would revert here: it is a
+      // pass-through that only works while it owns the registrar.
+      expect(getAddress(await env.v1.BaseRegistrar.read.owner())).toBe(
+        getAddress(registrarOwner.address),
+      );
+
+      await disableV1Registrars(freezeOptions());
+
+      await expect(
+        env.v1.BaseRegistrar.read.controllers([ARCHIVED_ETH_RENEWER]),
+      ).resolves.toBe(false);
+      await expect(
+        env.v1.BaseRegistrar.read.controllers([env.v1.NameWrapper.address]),
+      ).resolves.toBe(false);
+      await expect(
+        env.v1.ReverseRegistrar.read.controllers([ARCHIVED_REVERSE_ADAPTER]),
+      ).resolves.toBe(false);
+
+      await verifyV1RegistrarsDisabled(freezeOptions());
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/contracts/test/e2e/v1RegistrarFreeze.test.ts
+++ b/contracts/test/e2e/v1RegistrarFreeze.test.ts
@@ -7,6 +7,7 @@ import {
   disableV1Registrars,
   verifyV1RegistrarsDisabled,
 } from "../../script/migration.js";
+import { deployArtifact } from "../integration/fixtures/deployArtifact.js";
 
 // Each revoke waits a full receipt poll, so the freeze needs more than the default
 // per-test budget.
@@ -18,6 +19,11 @@ const TEST_TIMEOUT_MS = 120_000;
 const NETWORK = "mainnet";
 const ACTIVE_NAMESPACE = "mainnet";
 const ARCHIVED_NAMESPACE = "mainnet-archived-20260101";
+
+// A `--deployment-network` that shares no prefix with the network it targets, whose
+// archives are therefore named after the namespace rather than the network.
+const CUSTOM_NAMESPACE = "staging";
+const CUSTOM_ARCHIVED_NAMESPACE = "staging-20260101-r1";
 
 // Stand-ins for a superseded deployment's handoff contracts: the freeze only reads
 // their controller flags, so any address that is not an active deployment's works.
@@ -67,7 +73,10 @@ describe("v1 registrar freeze", () => {
   // Mirrors the artifact layout the freeze reads: the shared v1 contracts under the
   // v1 deployments root, and one v2 namespace per deployment — the active one plus a
   // superseded one whose handoff contracts must be revoked.
-  function writeDeploymentArtifacts() {
+  function writeDeploymentArtifacts({
+    activeNamespace = ACTIVE_NAMESPACE,
+    archivedNamespace = ARCHIVED_NAMESPACE,
+  }: { activeNamespace?: string; archivedNamespace?: string } = {}) {
     rmSync(workDir, { recursive: true, force: true });
     for (const [name, contract] of [
       ["BaseRegistrarImplementation", env.v1.BaseRegistrar],
@@ -85,24 +94,57 @@ describe("v1 registrar freeze", () => {
         env.shared.DefaultReverseRegistrarAdapter,
       ],
     ] as const) {
-      writeDeployment(deploymentsDir, ACTIVE_NAMESPACE, name, contract);
+      writeDeployment(deploymentsDir, activeNamespace, name, contract);
     }
-    writeNamespaceMetadata(deploymentsDir, ACTIVE_NAMESPACE);
+    writeNamespaceMetadata(deploymentsDir, activeNamespace);
 
     for (const [name, address] of [
       ["ReverseRegistrarAdapter", ARCHIVED_REVERSE_ADAPTER],
       ["DefaultReverseRegistrarAdapter", ARCHIVED_DEFAULT_REVERSE_ADAPTER],
       ["ETHRenewerV1", ARCHIVED_ETH_RENEWER],
     ] as const) {
-      writeDeployment(deploymentsDir, ARCHIVED_NAMESPACE, name, {
+      writeDeployment(deploymentsDir, archivedNamespace, name, {
         address,
         abi: [],
       });
     }
-    writeNamespaceMetadata(deploymentsDir, ARCHIVED_NAMESPACE);
+    writeNamespaceMetadata(deploymentsDir, archivedNamespace);
   }
 
-  function freezeOptions() {
+  // Wraps the devnet RPC so `eth_getLogs` is answered only for spans up to `cap`,
+  // the way a provider with a block-range limit does. A cap of zero refuses every
+  // span with a message that is not about the span at all.
+  function providerCappingLogSpan(cap: bigint | null) {
+    const transport = env.createClient(env.accounts[0]);
+    const state = { refusals: 0 };
+    return {
+      state,
+      provider: {
+        request(args: { method: string; params?: readonly unknown[] | object }) {
+          if (args.method === "eth_getLogs") {
+            const [filter] = args.params as [
+              { fromBlock: `0x${string}`; toBlock: `0x${string}` },
+            ];
+            const span = BigInt(filter.toBlock) - BigInt(filter.fromBlock) + 1n;
+            if (cap === null) {
+              return Promise.reject(new Error("log reads are unavailable"));
+            }
+            if (span > cap) {
+              state.refusals += 1;
+              return Promise.reject(
+                new Error(
+                  "query block range exceeds server limit, narrow your filter",
+                ),
+              );
+            }
+          }
+          return transport.request(args as never);
+        },
+      },
+    };
+  }
+
+  function freezeOptions(overrides: { deploymentNetwork?: string } = {}) {
     return {
       network: NETWORK,
       rpcUrl: `http://${env.hostPort}`,
@@ -112,6 +154,7 @@ describe("v1 registrar freeze", () => {
       v1DeploymentsDir,
       v1DeploymentNetwork: NETWORK,
       impersonateOwner: true,
+      ...overrides,
     } as const;
   }
 
@@ -148,6 +191,45 @@ describe("v1 registrar freeze", () => {
       [ARCHIVED_ETH_RENEWER],
       { account: securityOwner },
     );
+  }
+
+  // Stands up a superseded deployment's reverse adapters the way a pruned or
+  // never-committed namespace leaves them: real contracts holding real grants, with
+  // no artifact on disk pointing at them. Only their on-chain back-reference to the
+  // registrar they forward to identifies them as this tooling's.
+  async function deployUntrackedReverseAdapters() {
+    const wallet = env.createClient(env.accounts[0]);
+    const contractNamer =
+      await env.shared.ReverseRegistrarAdapter.read.CONTRACT_NAMER();
+    // Sequential: both deployments sign from the same account, and the address is
+    // derived from the nonce read before sending.
+    const adapter = await deployArtifact(wallet, {
+      file: new URL(
+        "../../out/ReverseRegistrarAdapter.sol/ReverseRegistrarAdapter.json",
+        import.meta.url,
+      ),
+      args: [env.v1.ReverseRegistrar.address, contractNamer],
+    });
+    const defaultAdapter = await deployArtifact(wallet, {
+      file: new URL(
+        "../../out/DefaultReverseRegistrarAdapter.sol/DefaultReverseRegistrarAdapter.json",
+        import.meta.url,
+      ),
+      args: [env.shared.DefaultReverseRegistrar.address, contractNamer],
+    });
+
+    const reverseOwner = await ownerAccountOf(env.v1.ReverseRegistrar);
+    await env.v1.ReverseRegistrar.write.setController([adapter, true], {
+      account: reverseOwner,
+    });
+    const defaultReverseOwner = await ownerAccountOf(
+      env.shared.DefaultReverseRegistrar,
+    );
+    await env.shared.DefaultReverseRegistrar.write.setController(
+      [defaultAdapter, true],
+      { account: defaultReverseOwner },
+    );
+    return { adapter, defaultAdapter };
   }
 
   // Moves the BaseRegistrar out from under the security controller, the state a
@@ -249,6 +331,159 @@ describe("v1 registrar freeze", () => {
       ).resolves.toBe(false);
 
       await verifyV1RegistrarsDisabled(freezeOptions());
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "revokes superseded reverse adapters that no local artifact describes",
+    async () => {
+      writeDeploymentArtifacts();
+      const { adapter, defaultAdapter } = await deployUntrackedReverseAdapters();
+
+      // Artifact-only discovery cannot see these, so the audit has to recover them
+      // from the registrars' controller history.
+      await expect(verifyV1RegistrarsDisabled(freezeOptions())).rejects.toThrow(
+        /superseded v1 authorizations still enabled/,
+      );
+
+      await disableV1Registrars(freezeOptions());
+
+      await expect(
+        env.v1.ReverseRegistrar.read.controllers([adapter]),
+      ).resolves.toBe(false);
+      await expect(
+        env.shared.DefaultReverseRegistrar.read.controllers([defaultAdapter]),
+      ).resolves.toBe(false);
+
+      await expect(
+        env.v1.ReverseRegistrar.read.controllers([
+          env.shared.ReverseRegistrarAdapter.address,
+        ]),
+      ).resolves.toBe(true);
+      await expect(
+        env.shared.DefaultReverseRegistrar.read.controllers([
+          env.shared.DefaultReverseRegistrarAdapter.address,
+        ]),
+      ).resolves.toBe(true);
+
+      await verifyV1RegistrarsDisabled(freezeOptions());
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "leaves v1-owned reverse registrar controllers alone",
+    async () => {
+      writeDeploymentArtifacts();
+
+      // A contract that forwards to no reverse registrar: it answers no
+      // back-reference, so the audit must read it as v1's own rather than as a
+      // superseded handoff contract.
+      const v1Controller = env.v1.BaseRegistrar.address;
+      const reverseOwner = await ownerAccountOf(env.v1.ReverseRegistrar);
+      await env.v1.ReverseRegistrar.write.setController([v1Controller, true], {
+        account: reverseOwner,
+      });
+
+      await disableV1Registrars(freezeOptions());
+
+      await expect(
+        env.v1.ReverseRegistrar.read.controllers([v1Controller]),
+      ).resolves.toBe(true);
+      await verifyV1RegistrarsDisabled(freezeOptions());
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "resolves archives of a deployment namespace not named for the network",
+    async () => {
+      writeDeploymentArtifacts({
+        activeNamespace: CUSTOM_NAMESPACE,
+        archivedNamespace: CUSTOM_ARCHIVED_NAMESPACE,
+      });
+      await authorizeArchivedHandoffContracts();
+
+      const customOptions = freezeOptions({
+        deploymentNetwork: CUSTOM_NAMESPACE,
+      });
+      await disableV1Registrars(customOptions);
+
+      await expect(
+        env.v1.ReverseRegistrar.read.controllers([ARCHIVED_REVERSE_ADAPTER]),
+      ).resolves.toBe(false);
+      await expect(
+        env.v1.BaseRegistrar.read.controllers([ARCHIVED_ETH_RENEWER]),
+      ).resolves.toBe(false);
+
+      // The active namespace shares no prefix with the network, so a network-keyed
+      // scan would leave its grants unaccounted for and revoke them.
+      await expect(
+        env.v1.ReverseRegistrar.read.controllers([
+          env.shared.ReverseRegistrarAdapter.address,
+        ]),
+      ).resolves.toBe(true);
+      await expect(
+        env.shared.DefaultReverseRegistrar.read.controllers([
+          env.shared.DefaultReverseRegistrarAdapter.address,
+        ]),
+      ).resolves.toBe(true);
+
+      await verifyV1RegistrarsDisabled(customOptions);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "fails rather than auditing partially when controller history cannot be read",
+    async () => {
+      writeDeploymentArtifacts();
+      await authorizeArchivedHandoffContracts();
+      const { provider } = providerCappingLogSpan(null);
+
+      await expect(
+        verifyV1RegistrarsDisabled({ ...freezeOptions(), provider }),
+      ).rejects.toThrow(/log reads are unavailable/);
+      await expect(
+        disableV1Registrars({ ...freezeOptions(), provider }),
+      ).rejects.toThrow(/log reads are unavailable/);
+
+      // Nothing was revoked on the way to the failure.
+      await expect(
+        env.v1.ReverseRegistrar.read.controllers([ARCHIVED_REVERSE_ADAPTER]),
+      ).resolves.toBe(true);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "narrows the controller history scan to the span the provider serves",
+    async () => {
+      writeDeploymentArtifacts();
+      const { adapter, defaultAdapter } = await deployUntrackedReverseAdapters();
+
+      // The scan only narrows above its minimum span, so the chain has to be
+      // longer than one request's worth.
+      await env.client.mine({ blocks: 4096 });
+
+      const { provider, state } = providerCappingLogSpan(1_000n);
+      await disableV1Registrars({ ...freezeOptions(), provider });
+
+      expect(state.refusals).toBeGreaterThan(0);
+      await expect(
+        env.v1.ReverseRegistrar.read.controllers([adapter]),
+      ).resolves.toBe(false);
+      await expect(
+        env.shared.DefaultReverseRegistrar.read.controllers([defaultAdapter]),
+      ).resolves.toBe(false);
+      await expect(
+        env.v1.ReverseRegistrar.read.controllers([
+          env.shared.ReverseRegistrarAdapter.address,
+        ]),
+      ).resolves.toBe(true);
+
+      await verifyV1RegistrarsDisabled({ ...freezeOptions(), provider });
     },
     TEST_TIMEOUT_MS,
   );


### PR DESCRIPTION
Phase 3 previously only checked the four named v1 registration controllers on the BaseRegistrar. A re-deploy left the prior deployment's handoff contracts authorized, including the permissionless TestnetV1PremigrationRegistrar, silently reopening v1 .eth registration into an archived v2 registry.

The freeze now audits the BaseRegistrar and both reverse registrars, drawing candidates from the registration controllers, the handoff contracts of every deployment namespace on the chain, and the registrar's ControllerAdded history, and revokes everything the active deployment did not itself grant. verify-v1-registrars-disabled asserts that same complete set and fails on anything outside it. When the controller history cannot be read both commands warn and fall back to artifact-backed candidates.

fork full reclaims registrar ownership before the freeze rather than after it, and re-runs the verification once the phase 6 handoff grants land.