### PR TITLE
docs(hca): add interface selector tag to IStandaloneHCAFactory

### DIFF
--- a/contracts/src/hca/interfaces/IStandaloneHCAFactory.sol
+++ b/contracts/src/hca/interfaces/IStandaloneHCAFactory.sol
@@ -5,6 +5,7 @@ import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFact
 
 /// @title Standalone HCA Factory Interface
 /// @notice Exposes governed HCA deployment and immutable factory-certified owner bindings.
+/// @dev Interface selector: `0xb2a3ab4f`
 interface IStandaloneHCAFactory {
     /// @notice Sets whether an implementation may initialize new HCAs through this factory.
     /// @dev Approval changes affect only future deployments.


### PR DESCRIPTION
## What

Adds the missing `@dev Interface selector: \`0xb2a3ab4f\`` NatSpec tag to the new `IStandaloneHCAFactory` interface.

## Why

The **Lint and Format** CI job on #386 fails with:

```
src/hca/interfaces/IStandaloneHCAFactory.sol:8:11: error: Missing @dev Interface selector tag (expected `0xb2a3ab4f`) [docs/selector-tags]
```

The repo's `docs/selector-tags` rule requires every interface to declare its ERC-165 interfaceId in a NatSpec `@dev` tag (as `IStandaloneHCAOwner`, `IETHRegistrar`, etc. already do). The new interface added in #386 was missing it, so the job exits 1.

## Verification

The interfaceId `0xb2a3ab4f` was confirmed as the XOR of the interface's function selectors (`setImplementationApproval`, `deploy`, `VERIFIABLE_FACTORY`, `approvedImplementations`, `hcaOwners`, `authorizedOwnerOf`, `deploymentSalt`), matching the value the linter expects.

Docs-only change — no bytecode or behavior impact. Targets the #386 branch so its CI goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)