### PR TITLE
fix: pin Solidity compiler profiles

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -18,6 +18,31 @@ const outputSelection = {
     "*": ["storageLayout"],
   },
 };
+// Keep exactly one general compiler so every non-overridden production root
+// remains on the protocol compiler. New compiler versions must be scoped with
+// explicit overrides and added to the compiler-policy regression.
+const protocolCompiler = {
+  version,
+  settings: {
+    optimizer: {
+      enabled: true,
+      runs: 1000,
+    },
+    evmVersion: "cancun",
+    outputSelection,
+  },
+} as const;
+const hcaCompiler = {
+  version: hcaVersion,
+  settings: {
+    optimizer: {
+      enabled: true,
+      runs: 1000,
+    },
+    evmVersion: "cancun",
+    outputSelection,
+  },
+} as const;
 const tenderlySepoliaRpcUrl =
   process.env.TENDERLY_SEPOLIA_RPC_URL ??
   configVariable("TENDERLY_SEPOLIA_RPC_URL");
@@ -35,31 +60,18 @@ const plugins = [
 ];
 const config = {
   solidity: {
-    compilers: [
-      {
-        version,
-        settings: {
-          optimizer: {
-            enabled: true,
-            runs: 1000,
-          },
-          evmVersion: "cancun",
-          outputSelection,
-        },
-      },
-      {
-        version: hcaVersion,
-        settings: {
-          optimizer: {
-            enabled: true,
-            runs: 1000,
-          },
-          evmVersion: "prague",
-          outputSelection,
-        },
-      },
-    ],
+    compilers: [protocolCompiler],
     overrides: {
+      "src/hca/HCAFundingSessionValidator.sol": hcaCompiler,
+      "src/hca/HCAOwnerAndSessionValidator.sol": hcaCompiler,
+      "src/hca/StandaloneHCAFactory.sol": hcaCompiler,
+      "src/hca/StandaloneSingleOwnerHCA.sol": hcaCompiler,
+      "test/mocks/MockRegistrationIntentExecutor.sol": hcaCompiler,
+      "test/mocks/MockStandaloneHCAStack.sol": hcaCompiler,
+      "test/unit/hca/HCAFundingSessionValidator.t.sol": hcaCompiler,
+      "test/unit/hca/HCAOwnerAndSessionValidator.t.sol": hcaCompiler,
+      "test/unit/hca/StandaloneHCAFactory.t.sol": hcaCompiler,
+      "test/unit/hca/StandaloneSingleOwnerHCA.t.sol": hcaCompiler,
       "lib/ens-contracts/contracts/wrapper/NameWrapper.sol": {
         version: "0.8.17",
         settings: {
@@ -67,6 +79,8 @@ const config = {
             enabled: true,
             runs: 1200,
           },
+          evmVersion: "london",
+          outputSelection,
         },
       },
       // 23k at 1
@@ -79,17 +93,6 @@ const config = {
             runs: 100,
           },
           evmVersion: "cancun",
-          outputSelection,
-        },
-      },
-      "src/L2/reverse-registrar/L2ReverseRegistrar.sol": {
-        version,
-        settings: {
-          optimizer: {
-            enabled: true,
-            runs: 1_000_000,
-          },
-          evmVersion: "paris",
           outputSelection,
         },
       },

--- a/contracts/src/dns/DNSAliasResolver.sol
+++ b/contracts/src/dns/DNSAliasResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {CCIPReader} from "@ens/contracts/ccipRead/CCIPReader.sol";
 import {IGatewayProvider} from "@ens/contracts/ccipRead/IGatewayProvider.sol";

--- a/contracts/src/dns/DNSTLDResolver.sol
+++ b/contracts/src/dns/DNSTLDResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.24;
+pragma solidity 0.8.25;
 
 import {CCIPReader, OffchainLookup} from "@ens/contracts/ccipRead/CCIPBatcher.sol";
 import {IGatewayProvider} from "@ens/contracts/ccipRead/IGatewayProvider.sol";

--- a/contracts/src/dns/DNSTXTResolver.sol
+++ b/contracts/src/dns/DNSTXTResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {IMulticallable} from "@ens/contracts/resolvers/IMulticallable.sol";
 import {IAddressResolver} from "@ens/contracts/resolvers/profiles/IAddressResolver.sol";

--- a/contracts/src/hca/HCAFundingSessionValidator.sol
+++ b/contracts/src/hca/HCAFundingSessionValidator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity 0.8.27;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";

--- a/contracts/src/hca/HCAOwnerAndSessionValidator.sol
+++ b/contracts/src/hca/HCAOwnerAndSessionValidator.sol
@@ -17,7 +17,7 @@ import {IETHRegistrar} from "../registrar/interfaces/IETHRegistrar.sol";
 import {IStandaloneHCAOwner} from "./interfaces/IStandaloneHCAOwner.sol";
 
 /// @notice Resolver calls encoded and validated by the HCA registration policy.
-/// @dev Interface selector: `0xcb811eec`.
+/// @dev Interface selector: `0xcb811eec`
 interface IHCARegistrationResolver {
     /// @notice Initializes a resolver proxy for an account.
     /// @param admin The initial resolver administrator.
@@ -38,7 +38,7 @@ interface IHCARegistrationResolver {
 
 
 /// @notice Reverse-registration call encoded and validated by the HCA registration policy.
-/// @dev Interface selector: `0xab863445`.
+/// @dev Interface selector: `0xab863445`
 interface IHCAReverseRegistrarAdapter {
     /// @notice Sets the primary name for an account through its HCA.
     /// @param account The account whose primary name is set.

--- a/contracts/src/hca/HCAOwnerAndSessionValidator.sol
+++ b/contracts/src/hca/HCAOwnerAndSessionValidator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity 0.8.27;
 
 import {CloneProxyBytecode} from "@ensdomains/verifiable-factory/CloneProxyBytecode.sol";
 import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
@@ -13,12 +13,39 @@ import {IValidator} from "nexus/interfaces/modules/IValidator.sol";
 
 import {EACBaseRolesLib} from "../access-control/libraries/EACBaseRolesLib.sol";
 import {IETHRegistrar} from "../registrar/interfaces/IETHRegistrar.sol";
-import {PermissionedResolver} from "../resolver/PermissionedResolver.sol";
-import {
-    DefaultReverseRegistrarAdapter
-} from "../reverse-registrar/DefaultReverseRegistrarAdapter.sol";
 
 import {IStandaloneHCAOwner} from "./interfaces/IStandaloneHCAOwner.sol";
+
+/// @notice Resolver calls encoded and validated by the HCA registration policy.
+/// @dev Interface selector: `0xcb811eec`.
+interface IHCARegistrationResolver {
+    /// @notice Initializes a resolver proxy for an account.
+    /// @param admin The initial resolver administrator.
+    /// @param roleBitmap The roles granted to the administrator.
+    /// @param setters Initial resolver calls executed during initialization.
+    function initialize(address admin, uint256 roleBitmap, bytes[] calldata setters) external;
+
+    /// @notice Updates an account's roles for an ENS name.
+    /// @param name The DNS-encoded name whose roles are updated.
+    /// @param roleBitmap The roles to update.
+    /// @param account The account receiving or losing the roles.
+    /// @param grant Whether the roles are granted or revoked.
+    /// @return success Whether the roles were updated.
+    function authorizeNameRoles(bytes calldata name, uint256 roleBitmap, address account, bool grant)
+        external
+        returns (bool success);
+}
+
+
+/// @notice Reverse-registration call encoded and validated by the HCA registration policy.
+/// @dev Interface selector: `0xab863445`.
+interface IHCAReverseRegistrarAdapter {
+    /// @notice Sets the primary name for an account through its HCA.
+    /// @param account The account whose primary name is set.
+    /// @param name The primary name to set.
+    function setNameWithHCA(address account, string calldata name) external;
+}
+
 
 /// @title HCA Owner and Session Validator
 /// @notice Fixed validator for standalone HCA owner authorization and scoped ENS sessions.
@@ -302,7 +329,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
 
     /// @notice Selector for DefaultReverseRegistrarAdapter.setNameWithHCA(address,string).
     bytes4 public constant SET_NAME_WITH_HCA_SELECTOR =
-        DefaultReverseRegistrarAdapter.setNameWithHCA.selector;
+        IHCAReverseRegistrarAdapter.setNameWithHCA.selector;
 
     /// @notice Selector for PermissionedResolver.clearRecords(bytes32).
     bytes4 public constant CLEAR_RECORDS_SELECTOR = 0x3603d758;
@@ -342,7 +369,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
 
     /// @notice Selector for PermissionedResolver.authorizeNameRoles(bytes,uint256,address,bool).
     bytes4 public constant AUTHORIZE_NAME_ROLES_SELECTOR =
-        PermissionedResolver.authorizeNameRoles.selector;
+        IHCARegistrationResolver.authorizeNameRoles.selector;
 
     /// @notice The HCA-aware default reverse registrar adapter permitted for default primary-name setup.
     address public immutable DEFAULT_REVERSE_REGISTRAR_HCA_ADAPTER;
@@ -1472,7 +1499,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
         bytes[] memory setters = new bytes[](0);
         bytes memory expectedInitData =
             abi.encodeCall(
-                PermissionedResolver.initialize,
+                IHCARegistrationResolver.initialize,
                 (account, EACBaseRolesLib.ALL_ROLES, setters)
             );
         bytes memory expectedCallData =
@@ -1826,7 +1853,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
         if (selector == AUTHORIZE_NAME_ROLES_SELECTOR) {
             bytes memory expectedCallData =
                 abi.encodeCall(
-                    PermissionedResolver.authorizeNameRoles,
+                    IHCARegistrationResolver.authorizeNameRoles,
                     (hex"00", EACBaseRolesLib.ALL_ROLES, owner, true)
                 );
             if (keccak256(callData) != keccak256(expectedCallData)) {

--- a/contracts/src/hca/StandaloneHCAFactory.sol
+++ b/contracts/src/hca/StandaloneHCAFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity 0.8.27;
 
 import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/src/hca/StandaloneSingleOwnerHCA.sol
+++ b/contracts/src/hca/StandaloneSingleOwnerHCA.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity 0.8.27;
 
 import {IProxyAuthorization} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
 import {PackedUserOperation} from "account-abstraction/interfaces/PackedUserOperation.sol";

--- a/contracts/src/hca/interfaces/IStandaloneHCAOwner.sol
+++ b/contracts/src/hca/interfaces/IStandaloneHCAOwner.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.13;
 
 /// @title Standalone HCA Owner Interface
 /// @notice Minimal owner view exposed by a standalone HCA account.

--- a/contracts/src/migration/Graveyard.sol
+++ b/contracts/src/migration/Graveyard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {
     BaseRegistrarImplementation

--- a/contracts/src/migration/LockedMigrationController.sol
+++ b/contracts/src/migration/LockedMigrationController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";

--- a/contracts/src/migration/MigrationHelper.sol
+++ b/contracts/src/migration/MigrationHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {IBaseRegistrar} from "@ens/contracts/ethregistrar/IBaseRegistrar.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";

--- a/contracts/src/migration/UnlockedMigrationController.sol
+++ b/contracts/src/migration/UnlockedMigrationController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {IBaseRegistrar} from "@ens/contracts/ethregistrar/IBaseRegistrar.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";

--- a/contracts/src/registrar/BatchRegistrar.sol
+++ b/contracts/src/registrar/BatchRegistrar.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/src/registrar/ETHRegistrar.sol
+++ b/contracts/src/registrar/ETHRegistrar.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 

--- a/contracts/src/registrar/ETHRenewerV1.sol
+++ b/contracts/src/registrar/ETHRenewerV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {
     BaseRegistrarImplementation

--- a/contracts/src/registrar/StandardRentPriceOracle.sol
+++ b/contracts/src/registrar/StandardRentPriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {StringUtils} from "@ens/contracts/utils/StringUtils.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 

--- a/contracts/src/registry/UserRegistry.sol
+++ b/contracts/src/registry/UserRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {IProxyAuthorization} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/contracts/src/registry/WrapperRegistry.sol
+++ b/contracts/src/registry/WrapperRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";

--- a/contracts/src/resolver/ENSV1Resolver.sol
+++ b/contracts/src/resolver/ENSV1Resolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {IGatewayProvider} from "@ens/contracts/ccipRead/IGatewayProvider.sol";
 import {ENS} from "@ens/contracts/registry/ENS.sol";

--- a/contracts/src/resolver/ENSV2Resolver.sol
+++ b/contracts/src/resolver/ENSV2Resolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {IGatewayProvider} from "@ens/contracts/ccipRead/IGatewayProvider.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";

--- a/contracts/src/resolver/PermissionedResolver.sol
+++ b/contracts/src/resolver/PermissionedResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.25;
 
 import {IMulticallable} from "@ens/contracts/resolvers/IMulticallable.sol";
 import {IABIResolver} from "@ens/contracts/resolvers/profiles/IABIResolver.sol";

--- a/contracts/src/resolver/PublicResolverV2.sol
+++ b/contracts/src/resolver/PublicResolverV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.25;
 
 import {Multicallable} from "@ens/contracts/resolvers/Multicallable.sol";
 import {ABIResolver} from "@ens/contracts/resolvers/profiles/ABIResolver.sol";

--- a/contracts/src/reverse-registrar/DefaultReverseRegistrarAdapter.sol
+++ b/contracts/src/reverse-registrar/DefaultReverseRegistrarAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.25;
+pragma solidity 0.8.25;
 
 import {
     IDefaultReverseRegistrar

--- a/contracts/src/reverse-registrar/L2ReverseRegistrar.sol
+++ b/contracts/src/reverse-registrar/L2ReverseRegistrar.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.25;
+pragma solidity 0.8.25;
 
 import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/contracts/src/reverse-registrar/L2ReverseRegistrarWithMigration.sol
+++ b/contracts/src/reverse-registrar/L2ReverseRegistrarWithMigration.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.13;
+pragma solidity 0.8.25;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/src/reverse-registrar/ReverseRegistrarAdapter.sol
+++ b/contracts/src/reverse-registrar/ReverseRegistrarAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.25;
+pragma solidity 0.8.25;
 
 import {IReverseRegistrar} from "@ens/contracts/reverseRegistrar/IReverseRegistrar.sol";
 

--- a/contracts/src/testnet/TestnetV1PremigrationRegistrar.sol
+++ b/contracts/src/testnet/TestnetV1PremigrationRegistrar.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.17;
+pragma solidity 0.8.25;
 
 import {
     BaseRegistrarImplementation

--- a/contracts/src/universalResolver/UniversalResolverV2.sol
+++ b/contracts/src/universalResolver/UniversalResolverV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {IGatewayProvider} from "@ens/contracts/ccipRead/IGatewayProvider.sol";
 import {

--- a/contracts/src/universalResolver/UpgradableUniversalResolverProxy.sol
+++ b/contracts/src/universalResolver/UpgradableUniversalResolverProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
+pragma solidity 0.8.25;
 
 import {EIP3668, OffchainLookup} from "@ens/contracts/ccipRead/EIP3668.sol";
 import {BytesUtils} from "@ens/contracts/utils/BytesUtils.sol";

--- a/contracts/src/utils/ContractNamer.sol
+++ b/contracts/src/utils/ContractNamer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {
     OwnableUpgradeable

--- a/contracts/src/utils/LabelStore.sol
+++ b/contracts/src/utils/LabelStore.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.25;
 
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 

--- a/contracts/src/utils/PermissionedAddressSet.sol
+++ b/contracts/src/utils/PermissionedAddressSet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.25;
 
 import {EnhancedAccessControl} from "../access-control/EnhancedAccessControl.sol";
 import {IContractNamer} from "../reverse-registrar/interfaces/IContractNamer.sol";

--- a/contracts/test/fixtures/HCAFixture.sol
+++ b/contracts/test/fixtures/HCAFixture.sol
@@ -13,7 +13,7 @@ import {IStandaloneHCAOwner} from "~src/hca/interfaces/IStandaloneHCAOwner.sol";
 /// @dev Certified HCAs are deployed through the real `StandaloneHCAFactory` so consumer tests
 ///      exercise the production certification path; the fixture acts as factory governance.
 ///      The factory is deployed from its compiled artifact so consumer tests never import its
-///      `0.8.27` source into their own compiler profile.
+///      source into their own compiler profile.
 abstract contract HCAFixture is Test {
     string internal constant STANDALONE_HCA_FACTORY_ARTIFACT =
         "src/hca/StandaloneHCAFactory.sol:StandaloneHCAFactory";

--- a/contracts/test/fixtures/HCAFixture.sol
+++ b/contracts/test/fixtures/HCAFixture.sol
@@ -5,18 +5,23 @@ import {Test} from "forge-std/Test.sol";
 
 import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 
-import {StandaloneHCAFactory} from "~src/hca/StandaloneHCAFactory.sol";
+import {IStandaloneHCAFactory} from "~src/hca/interfaces/IStandaloneHCAFactory.sol";
 import {IStandaloneHCAOwner} from "~src/hca/interfaces/IStandaloneHCAOwner.sol";
 
 /// @title HCA Test Fixture
 /// @notice Provides factory-certified and uncertified HCAs for adapter tests.
 /// @dev Certified HCAs are deployed through the real `StandaloneHCAFactory` so consumer tests
 ///      exercise the production certification path; the fixture acts as factory governance.
+///      The factory is deployed from its compiled artifact so consumer tests never import its
+///      `0.8.27` source into their own compiler profile.
 abstract contract HCAFixture is Test {
+    string internal constant STANDALONE_HCA_FACTORY_ARTIFACT =
+        "src/hca/StandaloneHCAFactory.sol:StandaloneHCAFactory";
+
     MockHCA trustedHCAImpl;
     MockHCA untrustedHCAImpl;
     VerifiableFactory verifiableFactory;
-    StandaloneHCAFactory standaloneHCAFactory;
+    IStandaloneHCAFactory standaloneHCAFactory;
 
     uint256 private nextSalt = 1;
 
@@ -24,7 +29,9 @@ abstract contract HCAFixture is Test {
         verifiableFactory = new VerifiableFactory();
         trustedHCAImpl = new MockHCA();
         untrustedHCAImpl = new MockHCA();
-        standaloneHCAFactory = new StandaloneHCAFactory(verifiableFactory, address(this));
+        standaloneHCAFactory = IStandaloneHCAFactory(
+            deployCode(STANDALONE_HCA_FACTORY_ARTIFACT, abi.encode(verifiableFactory, address(this)))
+        );
         standaloneHCAFactory.setImplementationApproval(address(trustedHCAImpl), true);
     }
 

--- a/contracts/test/integration/HardhatCompilerIsolation.test.ts
+++ b/contracts/test/integration/HardhatCompilerIsolation.test.ts
@@ -1,0 +1,267 @@
+import { readFile, readdir } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+type Artifact = {
+  buildInfoId: string;
+  contractName: string;
+  deployedBytecode: string;
+  sourceName: string;
+};
+
+type BuildInfo = {
+  solcLongVersion: string;
+  solcVersion: string;
+  input: {
+    settings: {
+      evmVersion: string;
+      optimizer: {
+        enabled: boolean;
+        runs: number;
+      };
+      viaIR?: boolean;
+    };
+  };
+};
+
+type CompilerProfile = {
+  evmVersion: string;
+  optimizerRuns: number;
+  solcLongVersion: string;
+  solcVersion: string;
+};
+
+const contractsDir = resolve(import.meta.dirname, "../..");
+const protocolProfile: CompilerProfile = {
+  solcVersion: "0.8.25",
+  solcLongVersion: "0.8.25+commit.b61c2a91",
+  evmVersion: "cancun",
+  optimizerRuns: 1000,
+};
+const hcaProfile: CompilerProfile = {
+  solcVersion: "0.8.27",
+  solcLongVersion: "0.8.27+commit.40a35a09",
+  evmVersion: "cancun",
+  optimizerRuns: 1000,
+};
+const wrapperRegistryProfile: CompilerProfile = {
+  solcVersion: "0.8.25",
+  solcLongVersion: "0.8.25+commit.b61c2a91",
+  evmVersion: "cancun",
+  optimizerRuns: 100,
+};
+const nameWrapperProfile: CompilerProfile = {
+  solcVersion: "0.8.17",
+  solcLongVersion: "0.8.17+commit.8df45f5f",
+  evmVersion: "london",
+  optimizerRuns: 1200,
+};
+const hcaSources = new Set([
+  "src/hca/HCAFundingSessionValidator.sol",
+  "src/hca/HCAOwnerAndSessionValidator.sol",
+  "src/hca/StandaloneHCAFactory.sol",
+  "src/hca/StandaloneSingleOwnerHCA.sol",
+]);
+const externalDeploymentSources = [
+  "lib/ens-contracts/contracts/ccipRead/GatewayProvider.sol",
+  "lib/ens-contracts/contracts/dnsregistrar/OffchainDNSResolver.sol",
+  "lib/ens-contracts/contracts/dnsregistrar/SimplePublicSuffixList.sol",
+  "lib/ens-contracts/contracts/dnssec-oracle/DNSSECImpl.sol",
+  "lib/ens-contracts/contracts/ethregistrar/BaseRegistrarImplementation.sol",
+  "lib/ens-contracts/contracts/ethregistrar/RegistrarSecurityController.sol",
+  "lib/ens-contracts/contracts/registry/ENSRegistry.sol",
+  "lib/ens-contracts/contracts/resolvers/OwnedResolver.sol",
+  "lib/ens-contracts/contracts/resolvers/PublicResolver.sol",
+  "lib/ens-contracts/contracts/reverseRegistrar/DefaultReverseRegistrar.sol",
+  "lib/ens-contracts/contracts/reverseRegistrar/ReverseRegistrar.sol",
+  "lib/ens-contracts/contracts/reverseResolver/DefaultReverseResolver.sol",
+  "lib/ens-contracts/contracts/root/Root.sol",
+  "lib/ens-contracts/contracts/universalResolver/UniversalResolver.sol",
+  "lib/ens-contracts/contracts/wrapper/NameWrapper.sol",
+  "lib/verifiable-factory/src/VerifiableFactory.sol",
+] as const;
+const auxiliaryDeploymentSources = [
+  ["test/mocks/MockERC20.sol", "MockERC20", protocolProfile],
+  ["test/mocks/MockPremigrator.sol", "MockPremigrator", protocolProfile],
+  [
+    "test/mocks/MockRegistrationIntentExecutor.sol",
+    "MockRegistrationIntentExecutor",
+    hcaProfile,
+  ],
+] as const;
+
+const buildInfoCache = new Map<string, BuildInfo>();
+
+async function readArtifact(
+  sourcePath: string,
+  contractName: string,
+): Promise<Artifact> {
+  const path = resolve(
+    contractsDir,
+    "artifacts",
+    sourcePath,
+    `${contractName}.json`,
+  );
+  return JSON.parse(await readFile(path, "utf8")) as Artifact;
+}
+
+async function readBuildInfo(artifact: Artifact): Promise<BuildInfo> {
+  const cached = buildInfoCache.get(artifact.buildInfoId);
+  if (cached) return cached;
+
+  const path = resolve(
+    contractsDir,
+    "artifacts",
+    "build-info",
+    `${artifact.buildInfoId}.json`,
+  );
+  const buildInfo = JSON.parse(await readFile(path, "utf8")) as BuildInfo;
+  buildInfoCache.set(artifact.buildInfoId, buildInfo);
+  return buildInfo;
+}
+
+async function readArtifactsRecursively(
+  directory: string,
+): Promise<Artifact[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const artifacts = await Promise.all(
+    entries.map(async (entry): Promise<Artifact[]> => {
+      const path = resolve(directory, entry.name);
+      if (entry.isDirectory()) return readArtifactsRecursively(path);
+      if (!entry.name.endsWith(".json") || entry.name.endsWith(".dbg.json")) {
+        return [];
+      }
+      return [JSON.parse(await readFile(path, "utf8")) as Artifact];
+    }),
+  );
+  return artifacts.flat();
+}
+
+async function expectExactSourcePragma(
+  sourceName: string,
+  expectedVersion: string,
+): Promise<void> {
+  const source = await readFile(resolve(contractsDir, sourceName), "utf8");
+  const pragma = source.match(/^pragma solidity ([^;]+);$/m)?.[1];
+  expect(pragma, sourceName).toBe(expectedVersion);
+}
+
+function expectedFirstPartyProfile(sourceName: string): CompilerProfile {
+  if (hcaSources.has(sourceName)) return hcaProfile;
+  if (sourceName === "src/registry/WrapperRegistry.sol") {
+    return wrapperRegistryProfile;
+  }
+  return protocolProfile;
+}
+
+async function expectCompilerProfile(
+  artifact: Artifact,
+  expected: CompilerProfile,
+): Promise<void> {
+  const buildInfo = await readBuildInfo(artifact);
+  const label = `${artifact.sourceName}:${artifact.contractName}`;
+
+  expect(buildInfo.solcVersion, label).toBe(expected.solcVersion);
+  expect(buildInfo.solcLongVersion, label).toBe(expected.solcLongVersion);
+  expect(buildInfo.input.settings.evmVersion, label).toBe(expected.evmVersion);
+  expect(buildInfo.input.settings.optimizer.enabled, label).toBe(true);
+  expect(buildInfo.input.settings.optimizer.runs, label).toBe(
+    expected.optimizerRuns,
+  );
+  expect(buildInfo.input.settings.viaIR ?? false, label).toBe(false);
+}
+
+describe("Hardhat compiler isolation", () => {
+  it("exact-pins every deployable first-party source to its compiler", async () => {
+    const artifacts = await readArtifactsRecursively(
+      resolve(contractsDir, "artifacts", "src"),
+    );
+    const deployableSources = new Set<string>();
+    for (const artifact of artifacts) {
+      if (artifact.deployedBytecode === "0x") continue;
+      const source = await readFile(
+        resolve(contractsDir, artifact.sourceName),
+        "utf8",
+      );
+      if (
+        new RegExp(`^contract\\s+${artifact.contractName}\\b`, "m").test(source)
+      ) {
+        deployableSources.add(artifact.sourceName);
+      }
+    }
+    expect(deployableSources.size).toBeGreaterThan(0);
+
+    for (const sourceName of deployableSources) {
+      await expectExactSourcePragma(
+        sourceName,
+        expectedFirstPartyProfile(sourceName).solcVersion,
+      );
+    }
+
+    for (const [sourceName, , profile] of auxiliaryDeploymentSources) {
+      await expectExactSourcePragma(sourceName, profile.solcVersion);
+    }
+  });
+
+  it("pins every first-party production artifact to its compiler profile", async () => {
+    const artifacts = await readArtifactsRecursively(
+      resolve(contractsDir, "artifacts", "src"),
+    );
+    expect(artifacts.length).toBeGreaterThan(0);
+
+    for (const artifact of artifacts) {
+      await expectCompilerProfile(
+        artifact,
+        expectedFirstPartyProfile(artifact.sourceName),
+      );
+    }
+  });
+
+  it("pins externally sourced deployment roots to their compiler profiles", async () => {
+    for (const sourcePath of externalDeploymentSources) {
+      const contractName = sourcePath.slice(
+        sourcePath.lastIndexOf("/") + 1,
+        -".sol".length,
+      );
+      const artifact = await readArtifact(sourcePath, contractName);
+      await expectCompilerProfile(
+        artifact,
+        sourcePath === "lib/ens-contracts/contracts/wrapper/NameWrapper.sol"
+          ? nameWrapperProfile
+          : protocolProfile,
+      );
+    }
+  });
+
+  it("pins auxiliary deployment roots to their compiler profiles", async () => {
+    for (const [
+      sourcePath,
+      contractName,
+      profile,
+    ] of auxiliaryDeploymentSources) {
+      await expectCompilerProfile(
+        await readArtifact(sourcePath, contractName),
+        profile,
+      );
+    }
+  });
+
+  it("uses the HCA compiler without exceeding the deployment size limit", async () => {
+    const hcaContracts = [
+      ["src/hca/HCAFundingSessionValidator.sol", "HCAFundingSessionValidator"],
+      [
+        "src/hca/HCAOwnerAndSessionValidator.sol",
+        "HCAOwnerAndSessionValidator",
+      ],
+      ["src/hca/StandaloneHCAFactory.sol", "StandaloneHCAFactory"],
+      ["src/hca/StandaloneSingleOwnerHCA.sol", "StandaloneSingleOwnerHCA"],
+    ] as const;
+
+    for (const [sourcePath, contractName] of hcaContracts) {
+      const artifact = await readArtifact(sourcePath, contractName);
+      const deployedSize = (artifact.deployedBytecode.length - 2) / 2;
+
+      expect(deployedSize, contractName).toBeLessThanOrEqual(24_576);
+    }
+  });
+});

--- a/contracts/test/integration/HardhatCompilerIsolation.test.ts
+++ b/contracts/test/integration/HardhatCompilerIsolation.test.ts
@@ -246,22 +246,28 @@ describe("Hardhat compiler isolation", () => {
     }
   });
 
-  it("uses the HCA compiler without exceeding the deployment size limit", async () => {
-    const hcaContracts = [
-      ["src/hca/HCAFundingSessionValidator.sol", "HCAFundingSessionValidator"],
-      [
-        "src/hca/HCAOwnerAndSessionValidator.sol",
-        "HCAOwnerAndSessionValidator",
-      ],
-      ["src/hca/StandaloneHCAFactory.sol", "StandaloneHCAFactory"],
-      ["src/hca/StandaloneSingleOwnerHCA.sol", "StandaloneSingleOwnerHCA"],
-    ] as const;
+  it.skipIf(Boolean(process.env.COVERAGE))(
+    "uses the HCA compiler without exceeding the deployment size limit",
+    async () => {
+      const hcaContracts = [
+        [
+          "src/hca/HCAFundingSessionValidator.sol",
+          "HCAFundingSessionValidator",
+        ],
+        [
+          "src/hca/HCAOwnerAndSessionValidator.sol",
+          "HCAOwnerAndSessionValidator",
+        ],
+        ["src/hca/StandaloneHCAFactory.sol", "StandaloneHCAFactory"],
+        ["src/hca/StandaloneSingleOwnerHCA.sol", "StandaloneSingleOwnerHCA"],
+      ] as const;
 
-    for (const [sourcePath, contractName] of hcaContracts) {
-      const artifact = await readArtifact(sourcePath, contractName);
-      const deployedSize = (artifact.deployedBytecode.length - 2) / 2;
+      for (const [sourcePath, contractName] of hcaContracts) {
+        const artifact = await readArtifact(sourcePath, contractName);
+        const deployedSize = (artifact.deployedBytecode.length - 2) / 2;
 
-      expect(deployedSize, contractName).toBeLessThanOrEqual(24_576);
-    }
-  });
+        expect(deployedSize, contractName).toBeLessThanOrEqual(24_576);
+      }
+    },
+  );
 });

--- a/contracts/test/mocks/MockERC20.sol
+++ b/contracts/test/mocks/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.25;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {ERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";

--- a/contracts/test/mocks/MockPremigrator.sol
+++ b/contracts/test/mocks/MockPremigrator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.13;
+pragma solidity 0.8.25;
 
 import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
 import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";

--- a/contracts/test/mocks/MockRegistrationIntentExecutor.sol
+++ b/contracts/test/mocks/MockRegistrationIntentExecutor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity 0.8.27;
 
 import {INexus} from "nexus/interfaces/INexus.sol";
 import {IExecutor} from "nexus/interfaces/modules/IExecutor.sol";

--- a/contracts/test/mocks/MockStandaloneHCAStack.sol
+++ b/contracts/test/mocks/MockStandaloneHCAStack.sol
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
+import {IProxyAuthorization} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {PackedUserOperation} from "account-abstraction/interfaces/PackedUserOperation.sol";
 import {IExecutor} from "nexus/interfaces/modules/IExecutor.sol";
 import {IValidator} from "nexus/interfaces/modules/IValidator.sol";
 import {EncodedModuleTypes} from "nexus/lib/ModuleTypeLib.sol";
 
-import {HCAOwnerAndSessionValidator} from "~src/hca/HCAOwnerAndSessionValidator.sol";
+import {
+    HCAOwnerAndSessionValidator,
+    IHCARegistrationResolver
+} from "~src/hca/HCAOwnerAndSessionValidator.sol";
+import {IAddressSet} from "~src/utils/interfaces/IAddressSet.sol";
 
 /// @title Mock Standalone HCA
 /// @notice Test-only HCA stand-in that exposes an owner and forwards validation.
@@ -56,6 +62,78 @@ contract MockStandaloneHCA {
                 signature
             );
     }
+}
+
+
+/// @title Mock Address Set
+/// @notice Test-only administrator-controlled address set for HCA upgrade authorization.
+contract MockAddressSet is IAddressSet {
+    /// @notice The only account allowed to update the set.
+    address public immutable ADMIN;
+
+    mapping(address member => bool approved) private _approved;
+
+    /// @notice Thrown when an account other than the administrator updates the set.
+    /// @param caller The unauthorized caller.
+    error UnauthorizedAddressSetAdmin(address caller);
+
+    /// @param admin The account allowed to update the set.
+    constructor(address admin) {
+        ADMIN = admin;
+    }
+
+    /// @notice Adds or removes an address from the set.
+    /// @param member The address whose membership changes.
+    /// @param approved Whether the address is included.
+    function approve(address member, bool approved) external {
+        if (msg.sender != ADMIN) {
+            revert UnauthorizedAddressSetAdmin(msg.sender);
+        }
+        _approved[member] = approved;
+    }
+
+    /// @inheritdoc IAddressSet
+    function includes(address member) external view returns (bool) {
+        return _approved[member];
+    }
+}
+
+
+/// @title Mock HCA Registration Resolver
+/// @notice Test-only upgradeable resolver target implementing the HCA policy call surface.
+contract MockHCARegistrationResolver is
+    IHCARegistrationResolver,
+    IProxyAuthorization,
+    UUPSUpgradeable
+{
+    /// @notice Accepts the production resolver's constructor shape.
+    /// @dev The constructor argument is unused by this test implementation.
+    constructor(
+        address /* contractNamer */
+    )
+    {}
+
+    /// @inheritdoc IHCARegistrationResolver
+    function initialize(address, uint256, bytes[] calldata) external initializer {
+        __UUPSUpgradeable_init();
+    }
+
+    /// @inheritdoc IHCARegistrationResolver
+    function authorizeNameRoles(bytes calldata, uint256, address, bool)
+        external
+        pure
+        returns (bool success)
+    {
+        return true;
+    }
+
+    /// @inheritdoc IProxyAuthorization
+    function canUpgradeFrom(address) external pure returns (bool allowed) {
+        return true;
+    }
+
+    /// @dev Allows every upgrade because authorization behavior is outside this mock's scope.
+    function _authorizeUpgrade(address) internal override {}
 }
 
 

--- a/contracts/test/mocks/MockStandaloneHCAStack.sol
+++ b/contracts/test/mocks/MockStandaloneHCAStack.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity 0.8.27;
 
 import {PackedUserOperation} from "account-abstraction/interfaces/PackedUserOperation.sol";
 import {IExecutor} from "nexus/interfaces/modules/IExecutor.sol";

--- a/contracts/test/mocks/MockStandaloneHCAStack.sol
+++ b/contracts/test/mocks/MockStandaloneHCAStack.sol
@@ -1,18 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import {IProxyAuthorization} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {PackedUserOperation} from "account-abstraction/interfaces/PackedUserOperation.sol";
 import {IExecutor} from "nexus/interfaces/modules/IExecutor.sol";
 import {IValidator} from "nexus/interfaces/modules/IValidator.sol";
 import {EncodedModuleTypes} from "nexus/lib/ModuleTypeLib.sol";
 
-import {
-    HCAOwnerAndSessionValidator,
-    IHCARegistrationResolver
-} from "~src/hca/HCAOwnerAndSessionValidator.sol";
-import {IAddressSet} from "~src/utils/interfaces/IAddressSet.sol";
+import {HCAOwnerAndSessionValidator} from "~src/hca/HCAOwnerAndSessionValidator.sol";
 
 /// @title Mock Standalone HCA
 /// @notice Test-only HCA stand-in that exposes an owner and forwards validation.
@@ -62,78 +56,6 @@ contract MockStandaloneHCA {
                 signature
             );
     }
-}
-
-
-/// @title Mock Address Set
-/// @notice Test-only administrator-controlled address set for HCA upgrade authorization.
-contract MockAddressSet is IAddressSet {
-    /// @notice The only account allowed to update the set.
-    address public immutable ADMIN;
-
-    mapping(address member => bool approved) private _approved;
-
-    /// @notice Thrown when an account other than the administrator updates the set.
-    /// @param caller The unauthorized caller.
-    error UnauthorizedAddressSetAdmin(address caller);
-
-    /// @param admin The account allowed to update the set.
-    constructor(address admin) {
-        ADMIN = admin;
-    }
-
-    /// @notice Adds or removes an address from the set.
-    /// @param member The address whose membership changes.
-    /// @param approved Whether the address is included.
-    function approve(address member, bool approved) external {
-        if (msg.sender != ADMIN) {
-            revert UnauthorizedAddressSetAdmin(msg.sender);
-        }
-        _approved[member] = approved;
-    }
-
-    /// @inheritdoc IAddressSet
-    function includes(address member) external view returns (bool) {
-        return _approved[member];
-    }
-}
-
-
-/// @title Mock HCA Registration Resolver
-/// @notice Test-only upgradeable resolver target implementing the HCA policy call surface.
-contract MockHCARegistrationResolver is
-    IHCARegistrationResolver,
-    IProxyAuthorization,
-    UUPSUpgradeable
-{
-    /// @notice Accepts the production resolver's constructor shape.
-    /// @dev The constructor argument is unused by this test implementation.
-    constructor(
-        address /* contractNamer */
-    )
-    {}
-
-    /// @inheritdoc IHCARegistrationResolver
-    function initialize(address, uint256, bytes[] calldata) external initializer {
-        __UUPSUpgradeable_init();
-    }
-
-    /// @inheritdoc IHCARegistrationResolver
-    function authorizeNameRoles(bytes calldata, uint256, address, bool)
-        external
-        pure
-        returns (bool success)
-    {
-        return true;
-    }
-
-    /// @inheritdoc IProxyAuthorization
-    function canUpgradeFrom(address) external pure returns (bool allowed) {
-        return true;
-    }
-
-    /// @dev Allows every upgrade because authorization behavior is outside this mock's scope.
-    function _authorizeUpgrade(address) internal override {}
 }
 
 

--- a/contracts/test/unit/hca/StandaloneHCAFactory.t.sol
+++ b/contracts/test/unit/hca/StandaloneHCAFactory.t.sol
@@ -9,11 +9,7 @@ import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
 import {Test} from "forge-std/Test.sol";
 
-import {
-    MockAddressSet,
-    MockExecutorModule,
-    MockValidatorModule
-} from "../../mocks/MockStandaloneHCAStack.sol";
+import {MockExecutorModule, MockValidatorModule} from "../../mocks/MockStandaloneHCAStack.sol";
 
 import {StandaloneHCAFactory} from "~src/hca/StandaloneHCAFactory.sol";
 import {StandaloneSingleOwnerHCA} from "~src/hca/StandaloneSingleOwnerHCA.sol";
@@ -22,6 +18,9 @@ import {IAddressSet} from "~src/utils/interfaces/IAddressSet.sol";
 /// @title Standalone HCA Factory Tests
 /// @notice Exercises governed deployment and immutable HCA owner certification.
 contract StandaloneHCAFactoryTest is Test {
+    string internal constant PERMISSIONED_ADDRESS_SET_ARTIFACT =
+        "src/utils/PermissionedAddressSet.sol:PermissionedAddressSet";
+
     uint256 internal constant USER_SALT = 7;
 
     address internal owner = makeAddr("owner");
@@ -247,9 +246,13 @@ contract StandaloneHCAFactoryTest is Test {
                 address(new MockValidatorModule()),
                 address(new MockExecutorModule()),
                 "",
-                new MockAddressSet(address(this)),
+                _deployPermissionedAddressSet(address(this)),
                 IAddressSet(address(0))
             );
+    }
+
+    function _deployPermissionedAddressSet(address rootAccount) internal returns (IAddressSet) {
+        return IAddressSet(deployCode(PERMISSIONED_ADDRESS_SET_ARTIFACT, abi.encode(rootAccount)));
     }
 
     function _expectedAddress(address owner_, address implementation_, uint256 userSalt)

--- a/contracts/test/unit/hca/StandaloneHCAFactory.t.sol
+++ b/contracts/test/unit/hca/StandaloneHCAFactory.t.sol
@@ -9,11 +9,14 @@ import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
 import {Test} from "forge-std/Test.sol";
 
-import {MockExecutorModule, MockValidatorModule} from "../../mocks/MockStandaloneHCAStack.sol";
+import {
+    MockAddressSet,
+    MockExecutorModule,
+    MockValidatorModule
+} from "../../mocks/MockStandaloneHCAStack.sol";
 
 import {StandaloneHCAFactory} from "~src/hca/StandaloneHCAFactory.sol";
 import {StandaloneSingleOwnerHCA} from "~src/hca/StandaloneSingleOwnerHCA.sol";
-import {PermissionedAddressSet} from "~src/utils/PermissionedAddressSet.sol";
 import {IAddressSet} from "~src/utils/interfaces/IAddressSet.sol";
 
 /// @title Standalone HCA Factory Tests
@@ -244,7 +247,7 @@ contract StandaloneHCAFactoryTest is Test {
                 address(new MockValidatorModule()),
                 address(new MockExecutorModule()),
                 "",
-                new PermissionedAddressSet(address(this)),
+                new MockAddressSet(address(this)),
                 IAddressSet(address(0))
             );
     }

--- a/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
+++ b/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
@@ -29,9 +29,7 @@ import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 import {Test} from "forge-std/Test.sol";
 
 import {
-    MockAddressSet,
     MockExecutorModule,
-    MockHCARegistrationResolver,
     MockStandaloneHCA,
     MockValidatorModule
 } from "../../mocks/MockStandaloneHCAStack.sol";
@@ -47,6 +45,11 @@ import {IStandaloneHCAOwner} from "~src/hca/interfaces/IStandaloneHCAOwner.sol";
 import {IAddressSet} from "~src/utils/interfaces/IAddressSet.sol";
 
 contract StandaloneSingleOwnerHCATest is Test {
+    string internal constant PERMISSIONED_ADDRESS_SET_ARTIFACT =
+        "src/utils/PermissionedAddressSet.sol:PermissionedAddressSet";
+    string internal constant PERMISSIONED_RESOLVER_ARTIFACT =
+        "src/resolver/PermissionedResolver.sol:PermissionedResolver";
+
     bytes4 constant ERC1271_MAGICVALUE = 0x1626ba7e;
 
     bytes4 constant COMMIT_SELECTOR = 0xf14fcbc8;
@@ -90,15 +93,15 @@ contract StandaloneSingleOwnerHCATest is Test {
     HCAOwnerAndSessionValidator validator;
     HCAOwnerAndSessionValidatorHarness validatorHarness;
     MockStandaloneHCA hca;
-    MockAddressSet upgradeSet;
+    IAddressSetApproval upgradeSet;
 
     function setUp() public {
-        upgradeSet = new MockAddressSet(upgradeSetAdmin);
+        upgradeSet = _deployPermissionedAddressSet(upgradeSetAdmin);
         hca = new MockStandaloneHCA(owner);
 
         VerifiableFactory factory = new VerifiableFactory();
         verifiableFactory = address(factory);
-        permittedResolverImpl = address(new MockHCARegistrationResolver(makeAddr("resolver-namer")));
+        permittedResolverImpl = _deployPermissionedResolver(makeAddr("resolver-namer"));
         bytes[] memory setters = new bytes[](0);
         vm.prank(address(hca));
         resolver = factory.deployProxy(
@@ -187,7 +190,7 @@ contract StandaloneSingleOwnerHCATest is Test {
     function test_standaloneSingleOwnerHCA_upgradesThroughVerifiableFactoryProxy() public {
         VerifiableFactory factory = new VerifiableFactory();
         StandaloneSingleOwnerHCA implementation = _newAccount();
-        MockAddressSet predecessorUpgradeSet = new MockAddressSet(upgradeSetAdmin);
+        IAddressSetApproval predecessorUpgradeSet = _deployPermissionedAddressSet(upgradeSetAdmin);
         StandaloneSingleOwnerHCA nextImplementation = _newAccount(predecessorUpgradeSet);
 
         address proxy =
@@ -1172,10 +1175,9 @@ contract StandaloneSingleOwnerHCATest is Test {
     }
 
     function test_validator_rejectsChangedResolverImplementation() public {
-        MockHCARegistrationResolver otherImplementation =
-            new MockHCARegistrationResolver(makeAddr("other-resolver-namer"));
+        address otherImplementation = _deployPermissionedResolver(makeAddr("other-resolver-namer"));
         vm.prank(address(hca));
-        IUUPSProxyUpgrade(resolver).upgradeToAndCall(address(otherImplementation), "");
+        IUUPSProxyUpgrade(resolver).upgradeToAndCall(otherImplementation, "");
 
         _expectValidationRevert(
             _singleOperationData(
@@ -1724,7 +1726,7 @@ contract StandaloneSingleOwnerHCATest is Test {
         LegacyDelegatecallHCA implementation =
             new LegacyDelegatecallHCA(address(userOpEntryPoint), address(validator));
         VerifiableFactory factory = new VerifiableFactory();
-        MockAddressSet trustedHCASet = new MockAddressSet(address(this));
+        IAddressSetApproval trustedHCASet = _deployPermissionedAddressSet(address(this));
         trustedHCASet.approve(address(implementation), true);
         StandaloneHCAFactory deployer = new StandaloneHCAFactory(factory, address(this));
         deployer.setImplementationApproval(address(implementation), true);
@@ -1854,6 +1856,20 @@ contract StandaloneSingleOwnerHCATest is Test {
                 upgradeSet,
                 IAddressSet(address(0))
             );
+    }
+
+    function _deployPermissionedAddressSet(address rootAccount)
+        internal
+        returns (IAddressSetApproval)
+    {
+        return
+            IAddressSetApproval(
+                deployCode(PERMISSIONED_ADDRESS_SET_ARTIFACT, abi.encode(rootAccount))
+            );
+    }
+
+    function _deployPermissionedResolver(address namer) internal returns (address) {
+        return deployCode(PERMISSIONED_RESOLVER_ARTIFACT, abi.encode(namer));
     }
 
     function _resolverAddress(VerifiableFactory factory, address deployer, uint256 salt)
@@ -2446,7 +2462,7 @@ contract OwnerSpoofingPayload {
 contract ImplementationTrustOnlyDefaultAdapter {
     DefaultReverseRegistrar internal immutable REGISTRAR;
     VerifiableFactory internal immutable VERIFIABLE_FACTORY;
-    MockAddressSet internal immutable TRUSTED_HCA_SET;
+    IAddressSet internal immutable TRUSTED_HCA_SET;
 
     /// @param registrar The reverse registrar updated by the adapter.
     /// @param verifiableFactory The factory queried for the caller's current implementation.
@@ -2454,7 +2470,7 @@ contract ImplementationTrustOnlyDefaultAdapter {
     constructor(
         DefaultReverseRegistrar registrar,
         VerifiableFactory verifiableFactory,
-        MockAddressSet trustedHCASet
+        IAddressSet trustedHCASet
     )
     {
         REGISTRAR = registrar;
@@ -2471,6 +2487,16 @@ contract ImplementationTrustOnlyDefaultAdapter {
         require(IStandaloneHCAOwner(msg.sender).owner() == account);
         REGISTRAR.setNameForAddr(account, name);
     }
+}
+
+
+/// @title Address Set Approval Interface
+/// @notice Exposes the mutation used with production address-set deployments in these tests.
+interface IAddressSetApproval is IAddressSet {
+    /// @notice Adds or removes an address from the set.
+    /// @param addr The address whose membership changes.
+    /// @param approved Whether the address is included.
+    function approve(address addr, bool approved) external;
 }
 
 

--- a/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
+++ b/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
@@ -29,18 +29,21 @@ import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 import {Test} from "forge-std/Test.sol";
 
 import {
+    MockAddressSet,
     MockExecutorModule,
+    MockHCARegistrationResolver,
     MockStandaloneHCA,
     MockValidatorModule
 } from "../../mocks/MockStandaloneHCAStack.sol";
 
 import {EACBaseRolesLib} from "~src/access-control/libraries/EACBaseRolesLib.sol";
-import {HCAOwnerAndSessionValidator} from "~src/hca/HCAOwnerAndSessionValidator.sol";
+import {
+    HCAOwnerAndSessionValidator,
+    IHCARegistrationResolver
+} from "~src/hca/HCAOwnerAndSessionValidator.sol";
 import {StandaloneHCAFactory} from "~src/hca/StandaloneHCAFactory.sol";
 import {StandaloneSingleOwnerHCA} from "~src/hca/StandaloneSingleOwnerHCA.sol";
 import {IStandaloneHCAOwner} from "~src/hca/interfaces/IStandaloneHCAOwner.sol";
-import {PermissionedResolver} from "~src/resolver/PermissionedResolver.sol";
-import {PermissionedAddressSet} from "~src/utils/PermissionedAddressSet.sol";
 import {IAddressSet} from "~src/utils/interfaces/IAddressSet.sol";
 
 contract StandaloneSingleOwnerHCATest is Test {
@@ -87,22 +90,22 @@ contract StandaloneSingleOwnerHCATest is Test {
     HCAOwnerAndSessionValidator validator;
     HCAOwnerAndSessionValidatorHarness validatorHarness;
     MockStandaloneHCA hca;
-    PermissionedAddressSet upgradeSet;
+    MockAddressSet upgradeSet;
 
     function setUp() public {
-        upgradeSet = new PermissionedAddressSet(upgradeSetAdmin);
+        upgradeSet = new MockAddressSet(upgradeSetAdmin);
         hca = new MockStandaloneHCA(owner);
 
         VerifiableFactory factory = new VerifiableFactory();
         verifiableFactory = address(factory);
-        permittedResolverImpl = address(new PermissionedResolver(makeAddr("resolver-namer")));
+        permittedResolverImpl = address(new MockHCARegistrationResolver(makeAddr("resolver-namer")));
         bytes[] memory setters = new bytes[](0);
         vm.prank(address(hca));
         resolver = factory.deployProxy(
             permittedResolverImpl,
             resolverSalt,
             abi.encodeCall(
-                PermissionedResolver.initialize,
+                IHCARegistrationResolver.initialize,
                 (address(hca), EACBaseRolesLib.ALL_ROLES, setters)
             )
         );
@@ -184,7 +187,7 @@ contract StandaloneSingleOwnerHCATest is Test {
     function test_standaloneSingleOwnerHCA_upgradesThroughVerifiableFactoryProxy() public {
         VerifiableFactory factory = new VerifiableFactory();
         StandaloneSingleOwnerHCA implementation = _newAccount();
-        PermissionedAddressSet predecessorUpgradeSet = new PermissionedAddressSet(upgradeSetAdmin);
+        MockAddressSet predecessorUpgradeSet = new MockAddressSet(upgradeSetAdmin);
         StandaloneSingleOwnerHCA nextImplementation = _newAccount(predecessorUpgradeSet);
 
         address proxy =
@@ -1169,8 +1172,8 @@ contract StandaloneSingleOwnerHCATest is Test {
     }
 
     function test_validator_rejectsChangedResolverImplementation() public {
-        PermissionedResolver otherImplementation =
-            new PermissionedResolver(makeAddr("other-resolver-namer"));
+        MockHCARegistrationResolver otherImplementation =
+            new MockHCARegistrationResolver(makeAddr("other-resolver-namer"));
         vm.prank(address(hca));
         IUUPSProxyUpgrade(resolver).upgradeToAndCall(address(otherImplementation), "");
 
@@ -1721,7 +1724,7 @@ contract StandaloneSingleOwnerHCATest is Test {
         LegacyDelegatecallHCA implementation =
             new LegacyDelegatecallHCA(address(userOpEntryPoint), address(validator));
         VerifiableFactory factory = new VerifiableFactory();
-        PermissionedAddressSet trustedHCASet = new PermissionedAddressSet(address(this));
+        MockAddressSet trustedHCASet = new MockAddressSet(address(this));
         trustedHCASet.approve(address(implementation), true);
         StandaloneHCAFactory deployer = new StandaloneHCAFactory(factory, address(this));
         deployer.setImplementationApproval(address(implementation), true);
@@ -1925,7 +1928,7 @@ contract StandaloneSingleOwnerHCATest is Test {
         pure
         returns (bytes memory)
     {
-        return abi.encodeCall(PermissionedResolver.initialize, (admin, roleBitmap, setters));
+        return abi.encodeCall(IHCARegistrationResolver.initialize, (admin, roleBitmap, setters));
     }
 
     function _registrationOperationDataWithDefaultReverseName(
@@ -2443,7 +2446,7 @@ contract OwnerSpoofingPayload {
 contract ImplementationTrustOnlyDefaultAdapter {
     DefaultReverseRegistrar internal immutable REGISTRAR;
     VerifiableFactory internal immutable VERIFIABLE_FACTORY;
-    PermissionedAddressSet internal immutable TRUSTED_HCA_SET;
+    MockAddressSet internal immutable TRUSTED_HCA_SET;
 
     /// @param registrar The reverse registrar updated by the adapter.
     /// @param verifiableFactory The factory queried for the caller's current implementation.
@@ -2451,7 +2454,7 @@ contract ImplementationTrustOnlyDefaultAdapter {
     constructor(
         DefaultReverseRegistrar registrar,
         VerifiableFactory verifiableFactory,
-        PermissionedAddressSet trustedHCASet
+        MockAddressSet trustedHCASet
     )
     {
         REGISTRAR = registrar;


### PR DESCRIPTION
pins deployable contracts to their intended compiler versions and adds regression coverage for compiler settings. without this, adding the HCA compiler allowed hardhat to silently rebuild compatible protocol contracts with it.