### PR TITLE
fix: authorize HCA registrars through registry roles

### DIFF
--- a/contracts/deploy/hca/01_HCAOwnerAndSessionValidator.ts
+++ b/contracts/deploy/hca/01_HCAOwnerAndSessionValidator.ts
@@ -20,8 +20,8 @@ export default execute(
     const permittedResolverImpl = get<
       (typeof artifacts.PermissionedResolver)["abi"]
     >("PermissionedResolverImpl");
-    const ethRegistrar =
-      get<(typeof artifacts.ETHRegistrar)["abi"]>("ETHRegistrar");
+    const ethRegistry =
+      get<(typeof artifacts.PermissionedRegistry)["abi"]>("ETHRegistry");
     const verifiableFactory =
       get<(typeof artifacts.VerifiableFactory)["abi"]>("VerifiableFactory");
     const localExecutor = getOrNull<
@@ -62,7 +62,7 @@ export default execute(
       args: [
         defaultReverseRegistrarAdapter.address,
         permittedResolverImpl.address,
-        ethRegistrar.address,
+        ethRegistry.address,
         verifiableFactory.address,
         paymentToken,
         secondaryPaymentToken,
@@ -82,7 +82,7 @@ export default execute(
     dependencies: [
       "DefaultReverseRegistrarAdapter",
       "PermissionedResolverImpl",
-      "ETHRegistrar",
+      "ETHRegistry",
       "VerifiableFactory",
       "MockRegistrationIntentExecutor",
     ],

--- a/contracts/script/liveHcaRhinestoneRegistration.ts
+++ b/contracts/script/liveHcaRhinestoneRegistration.ts
@@ -754,7 +754,7 @@ async function main() {
     [
       "DEFAULT_REVERSE_REGISTRAR_HCA_ADAPTER",
       "PERMITTED_RESOLVER_IMPL",
-      "ETH_REGISTRAR",
+      "ETH_REGISTRY",
       "VERIFIABLE_FACTORY",
       "PAYMENT_TOKEN",
       "SECONDARY_PAYMENT_TOKEN",
@@ -772,7 +772,7 @@ async function main() {
   const [
     boundReverseAdapter,
     boundResolverImpl,
-    boundRegistrar,
+    boundRegistry,
     boundFactory,
     boundPaymentToken,
     boundSecondaryPaymentToken,
@@ -790,10 +790,21 @@ async function main() {
     deployments.permissionedResolverImpl,
   );
   assertAddress(
-    "validator registrar",
-    boundRegistrar,
-    deployments.ethRegistrar,
+    "validator ETH registry",
+    boundRegistry,
+    deployments.ethRegistry,
   );
+  const registrarAuthorized = (await publicClient.readContract({
+    address: deployments.ethRegistry,
+    abi: PermissionedRegistry.abi,
+    functionName: "hasRootRoles",
+    args: [ROLES.REGISTRY.REGISTRAR, deployments.ethRegistrar],
+  })) as boolean;
+  if (!registrarAuthorized) {
+    throw new Error(
+      `selected registrar ${deployments.ethRegistrar} does not hold ETHRegistry ROLE_REGISTRAR`,
+    );
+  }
   assertAddress(
     "validator factory",
     boundFactory,

--- a/contracts/src/hca/HCAOwnerAndSessionValidator.sol
+++ b/contracts/src/hca/HCAOwnerAndSessionValidator.sol
@@ -13,6 +13,8 @@ import {IValidator} from "nexus/interfaces/modules/IValidator.sol";
 
 import {EACBaseRolesLib} from "../access-control/libraries/EACBaseRolesLib.sol";
 import {IETHRegistrar} from "../registrar/interfaces/IETHRegistrar.sol";
+import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
+import {RegistryRolesLib} from "../registry/libraries/RegistryRolesLib.sol";
 
 import {IStandaloneHCAOwner} from "./interfaces/IStandaloneHCAOwner.sol";
 
@@ -377,8 +379,8 @@ contract HCAOwnerAndSessionValidator is IValidator {
     /// @notice The resolver implementation permitted for resolver deployment.
     address public immutable PERMITTED_RESOLVER_IMPL;
 
-    /// @notice The ENS registrar permitted for registration actions.
-    address public immutable ETH_REGISTRAR;
+    /// @notice The ENS registry whose root registrar role authorizes registration targets.
+    address public immutable ETH_REGISTRY;
 
     /// @notice The VerifiableFactory permitted for resolver deployment.
     address public immutable VERIFIABLE_FACTORY;
@@ -489,7 +491,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
 
     /// @param defaultReverseRegistrarHcaAdapter The HCA-aware default reverse registrar adapter.
     /// @param permittedResolverImpl The resolver implementation accepted in resolver deployment actions.
-    /// @param ethRegistrar The ENS registrar accepted by the registration policy.
+    /// @param ethRegistry The ENS registry that authorizes registrars through its root roles.
     /// @param verifiableFactory The VerifiableFactory accepted by the registration policy.
     /// @param paymentToken The primary ERC20 payment token accepted by the registration policy.
     /// @param secondaryPaymentToken The secondary ERC20 payment token accepted by the registration policy.
@@ -498,7 +500,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
     constructor(
         address defaultReverseRegistrarHcaAdapter,
         address permittedResolverImpl,
-        address ethRegistrar,
+        address ethRegistry,
         address verifiableFactory,
         address paymentToken,
         address secondaryPaymentToken,
@@ -508,7 +510,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
     {
         DEFAULT_REVERSE_REGISTRAR_HCA_ADAPTER = defaultReverseRegistrarHcaAdapter;
         PERMITTED_RESOLVER_IMPL = permittedResolverImpl;
-        ETH_REGISTRAR = ethRegistrar;
+        ETH_REGISTRY = ethRegistry;
         VERIFIABLE_FACTORY = verifiableFactory;
         VERIFIABLE_PROXY_LOGIC = VerifiableFactory(verifiableFactory).proxyLogic();
         PAYMENT_TOKEN = paymentToken;
@@ -1374,15 +1376,18 @@ contract HCAOwnerAndSessionValidator is IValidator {
 
             bytes4 selector = _selector(execution.callData);
 
-            if (execution.target == ETH_REGISTRAR) {
-                if (selector != COMMIT_SELECTOR && selector != REGISTER_SELECTOR) {
+            if (selector == COMMIT_SELECTOR) {
+                if (!_isAuthorizedRegistrar(execution.target)) {
                     revert ActionNotAllowed(execution.target, selector);
                 }
-                if (selector == REGISTER_SELECTOR) {
-                    state.usesResolver = true;
-                    if (policyResolver.code.length == 0 && !state.deploysResolver) {
-                        revert PolicyRuleFailed();
-                    }
+                continue;
+            }
+
+            if (selector == REGISTER_SELECTOR) {
+                // The preceding registration scan verifies the target's live registrar role.
+                state.usesResolver = true;
+                if (policyResolver.code.length == 0 && !state.deploysResolver) {
+                    revert PolicyRuleFailed();
                 }
                 continue;
             }
@@ -1459,11 +1464,11 @@ contract HCAOwnerAndSessionValidator is IValidator {
     {
         for (uint256 i; i < executions.length; ++i) {
             Execution memory execution = executions[i];
-            if (
-                execution.target != ETH_REGISTRAR ||
-                _selector(execution.callData) != REGISTER_SELECTOR
-            ) {
+            if (_selector(execution.callData) != REGISTER_SELECTOR) {
                 continue;
+            }
+            if (!_isAuthorizedRegistrar(execution.target)) {
+                revert ActionNotAllowed(execution.target, REGISTER_SELECTOR);
             }
 
             (address registrant, address resolver) = _registerFields(execution.callData);
@@ -1568,7 +1573,8 @@ contract HCAOwnerAndSessionValidator is IValidator {
             );
     }
 
-    /// @dev Allows registrar payment approvals and exact, signed executor-refund approvals.
+    /// @dev Allows payment approvals to registry-authorized registrars and exact, signed
+    ///      executor-refund approvals.
     function _checkPaymentTokenApproval(
         address token,
         bytes memory callData,
@@ -1578,7 +1584,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
         view
     {
         address spender = _readAddress(callData, 4);
-        if (spender == ETH_REGISTRAR) {
+        if (_isAuthorizedRegistrar(spender)) {
             return;
         }
         if (
@@ -1588,6 +1594,17 @@ contract HCAOwnerAndSessionValidator is IValidator {
         ) {
             revert PolicyRuleFailed();
         }
+    }
+
+    /// @dev Returns whether the pinned registry currently authorizes an account to register names.
+    /// @param account The prospective registrar.
+    /// @return authorized Whether the account holds the root registrar role.
+    function _isAuthorizedRegistrar(address account) internal view returns (bool authorized) {
+        return
+            IPermissionedRegistry(ETH_REGISTRY).hasRootRoles(
+                RegistryRolesLib.ROLE_REGISTRAR,
+                account
+            );
     }
 
     /// @dev Finds and checks an optional EIP-2612 funding pull into the HCA.

--- a/contracts/test/mocks/MockStandaloneHCAStack.sol
+++ b/contracts/test/mocks/MockStandaloneHCAStack.sol
@@ -8,6 +8,28 @@ import {EncodedModuleTypes} from "nexus/lib/ModuleTypeLib.sol";
 
 import {HCAOwnerAndSessionValidator} from "~src/hca/HCAOwnerAndSessionValidator.sol";
 
+/// @title Mock Registrar Role Registry
+/// @notice Test-only registry stand-in that exposes mutable root-role membership.
+contract MockRegistrarRoleRegistry {
+    mapping(address account => uint256 roles) internal _rootRoles;
+
+    /// @notice Replaces an account's root-role bitmap.
+    /// @param account The account whose roles are updated.
+    /// @param roles The complete root-role bitmap to store.
+    function setRootRoles(address account, uint256 roles) external {
+        _rootRoles[account] = roles;
+    }
+
+    /// @notice Checks whether an account holds every requested root role.
+    /// @param roleBitmap The roles that must all be present.
+    /// @param account The account to inspect.
+    /// @return Whether the account holds every requested role.
+    function hasRootRoles(uint256 roleBitmap, address account) external view returns (bool) {
+        return (_rootRoles[account] & roleBitmap) == roleBitmap;
+    }
+}
+
+
 /// @title Mock Standalone HCA
 /// @notice Test-only HCA stand-in that exposes an owner and forwards validation.
 contract MockStandaloneHCA {

--- a/contracts/test/mocks/MockStandaloneHCAStack.sol
+++ b/contracts/test/mocks/MockStandaloneHCAStack.sol
@@ -8,28 +8,6 @@ import {EncodedModuleTypes} from "nexus/lib/ModuleTypeLib.sol";
 
 import {HCAOwnerAndSessionValidator} from "~src/hca/HCAOwnerAndSessionValidator.sol";
 
-/// @title Mock Registrar Role Registry
-/// @notice Test-only registry stand-in that exposes mutable root-role membership.
-contract MockRegistrarRoleRegistry {
-    mapping(address account => uint256 roles) internal _rootRoles;
-
-    /// @notice Replaces an account's root-role bitmap.
-    /// @param account The account whose roles are updated.
-    /// @param roles The complete root-role bitmap to store.
-    function setRootRoles(address account, uint256 roles) external {
-        _rootRoles[account] = roles;
-    }
-
-    /// @notice Checks whether an account holds every requested root role.
-    /// @param roleBitmap The roles that must all be present.
-    /// @param account The account to inspect.
-    /// @return Whether the account holds every requested role.
-    function hasRootRoles(uint256 roleBitmap, address account) external view returns (bool) {
-        return (_rootRoles[account] & roleBitmap) == roleBitmap;
-    }
-}
-
-
 /// @title Mock Standalone HCA
 /// @notice Test-only HCA stand-in that exposes an owner and forwards validation.
 contract MockStandaloneHCA {

--- a/contracts/test/unit/hca/HCAOwnerAndSessionValidator.t.sol
+++ b/contracts/test/unit/hca/HCAOwnerAndSessionValidator.t.sol
@@ -8,9 +8,12 @@ import {Test} from "forge-std/Test.sol";
 import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 
 import {HCAOwnerAndSessionValidator} from "~src/hca/HCAOwnerAndSessionValidator.sol";
+import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
 
-import {MockStandaloneHCA} from "../../mocks/MockStandaloneHCAStack.sol";
+import {MockRegistrarRoleRegistry, MockStandaloneHCA} from "../../mocks/MockStandaloneHCAStack.sol";
 
+/// @title HCA Owner and Session Validator Tests
+/// @notice Exercises owner signatures, session permissions, and registration policies.
 contract HCAOwnerAndSessionValidatorTest is Test {
     struct ClaimFixture {
         uint256 nonce;
@@ -83,15 +86,18 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     address gasRefundPaymaster = makeAddr("refund-paymaster");
 
     HCAOwnerAndSessionValidatorEnableHarness validator;
+    MockRegistrarRoleRegistry ethRegistry;
     MockStandaloneHCA hca;
 
     function setUp() public {
         hca = new MockStandaloneHCA(owner);
+        ethRegistry = new MockRegistrarRoleRegistry();
+        ethRegistry.setRootRoles(ethRegistrar, RegistryRolesLib.ROLE_REGISTRAR);
         VerifiableFactory factory = new VerifiableFactory();
         validator = new HCAOwnerAndSessionValidatorEnableHarness(
             makeAddr("reverse-adapter"),
             makeAddr("resolver-implementation"),
-            ethRegistrar,
+            address(ethRegistry),
             address(factory),
             paymentToken,
             makeAddr("secondary-payment-token"),
@@ -1047,11 +1053,13 @@ contract HCAOwnerAndSessionValidatorTest is Test {
 }
 
 
+/// @title HCA Owner and Session Validator Enable Harness
+/// @notice Exposes internal digest construction for session-enable unit tests.
 contract HCAOwnerAndSessionValidatorEnableHarness is HCAOwnerAndSessionValidator {
     constructor(
         address defaultReverseRegistrarHCAAdapter,
         address permittedResolverImpl,
-        address ethRegistrar,
+        address ethRegistry,
         address verifiableFactory,
         address paymentToken,
         address secondaryPaymentToken,
@@ -1061,7 +1069,7 @@ contract HCAOwnerAndSessionValidatorEnableHarness is HCAOwnerAndSessionValidator
         HCAOwnerAndSessionValidator(
             defaultReverseRegistrarHCAAdapter,
             permittedResolverImpl,
-            ethRegistrar,
+            ethRegistry,
             verifiableFactory,
             paymentToken,
             secondaryPaymentToken,

--- a/contracts/test/unit/hca/HCAOwnerAndSessionValidator.t.sol
+++ b/contracts/test/unit/hca/HCAOwnerAndSessionValidator.t.sol
@@ -8,13 +8,17 @@ import {Test} from "forge-std/Test.sol";
 import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 
 import {HCAOwnerAndSessionValidator} from "~src/hca/HCAOwnerAndSessionValidator.sol";
+import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
 
-import {MockRegistrarRoleRegistry, MockStandaloneHCA} from "../../mocks/MockStandaloneHCAStack.sol";
+import {MockStandaloneHCA} from "../../mocks/MockStandaloneHCAStack.sol";
 
 /// @title HCA Owner and Session Validator Tests
 /// @notice Exercises owner signatures, session permissions, and registration policies.
 contract HCAOwnerAndSessionValidatorTest is Test {
+    string internal constant PERMISSIONED_REGISTRY_ARTIFACT =
+        "src/registry/PermissionedRegistry.sol:PermissionedRegistry";
+
     struct ClaimFixture {
         uint256 nonce;
         uint256 deadline;
@@ -86,13 +90,18 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     address gasRefundPaymaster = makeAddr("refund-paymaster");
 
     HCAOwnerAndSessionValidatorEnableHarness validator;
-    MockRegistrarRoleRegistry ethRegistry;
+    IPermissionedRegistry ethRegistry;
     MockStandaloneHCA hca;
 
     function setUp() public {
         hca = new MockStandaloneHCA(owner);
-        ethRegistry = new MockRegistrarRoleRegistry();
-        ethRegistry.setRootRoles(ethRegistrar, RegistryRolesLib.ROLE_REGISTRAR);
+        ethRegistry = IPermissionedRegistry(
+            deployCode(
+                PERMISSIONED_REGISTRY_ARTIFACT,
+                abi.encode(address(0), address(this), RegistryRolesLib.ROLE_REGISTRAR_ADMIN)
+            )
+        );
+        ethRegistry.grantRootRoles(RegistryRolesLib.ROLE_REGISTRAR, ethRegistrar);
         VerifiableFactory factory = new VerifiableFactory();
         validator = new HCAOwnerAndSessionValidatorEnableHarness(
             makeAddr("reverse-adapter"),

--- a/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
+++ b/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
@@ -30,6 +30,7 @@ import {Test} from "forge-std/Test.sol";
 
 import {
     MockExecutorModule,
+    MockRegistrarRoleRegistry,
     MockStandaloneHCA,
     MockValidatorModule
 } from "../../mocks/MockStandaloneHCAStack.sol";
@@ -42,8 +43,11 @@ import {
 import {StandaloneHCAFactory} from "~src/hca/StandaloneHCAFactory.sol";
 import {StandaloneSingleOwnerHCA} from "~src/hca/StandaloneSingleOwnerHCA.sol";
 import {IStandaloneHCAOwner} from "~src/hca/interfaces/IStandaloneHCAOwner.sol";
+import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
 import {IAddressSet} from "~src/utils/interfaces/IAddressSet.sol";
 
+/// @title Standalone Single-Owner HCA Tests
+/// @notice Exercises account ownership, sessions, execution, and upgrade authorization.
 contract StandaloneSingleOwnerHCATest is Test {
     string internal constant PERMISSIONED_ADDRESS_SET_ARTIFACT =
         "src/utils/PermissionedAddressSet.sol:PermissionedAddressSet";
@@ -92,12 +96,15 @@ contract StandaloneSingleOwnerHCATest is Test {
 
     HCAOwnerAndSessionValidator validator;
     HCAOwnerAndSessionValidatorHarness validatorHarness;
+    MockRegistrarRoleRegistry ethRegistry;
     MockStandaloneHCA hca;
     IAddressSetApproval upgradeSet;
 
     function setUp() public {
         upgradeSet = _deployPermissionedAddressSet(upgradeSetAdmin);
         hca = new MockStandaloneHCA(owner);
+        ethRegistry = new MockRegistrarRoleRegistry();
+        ethRegistry.setRootRoles(ethRegistrar, RegistryRolesLib.ROLE_REGISTRAR);
 
         VerifiableFactory factory = new VerifiableFactory();
         verifiableFactory = address(factory);
@@ -117,7 +124,7 @@ contract StandaloneSingleOwnerHCATest is Test {
         validator = new HCAOwnerAndSessionValidator(
             defaultReverseRegistrarHCAAdapter,
             permittedResolverImpl,
-            ethRegistrar,
+            address(ethRegistry),
             verifiableFactory,
             usdc,
             dai,
@@ -127,7 +134,7 @@ contract StandaloneSingleOwnerHCATest is Test {
         validatorHarness = new HCAOwnerAndSessionValidatorHarness(
             defaultReverseRegistrarHCAAdapter,
             permittedResolverImpl,
-            ethRegistrar,
+            address(ethRegistry),
             verifiableFactory,
             usdc,
             dai,
@@ -666,7 +673,7 @@ contract StandaloneSingleOwnerHCATest is Test {
             new HCAOwnerAndSessionValidatorHarness(
                 defaultReverseRegistrarHCAAdapter,
                 permittedResolverImpl,
-                ethRegistrar,
+                address(ethRegistry),
                 verifiableFactory,
                 usdc,
                 dai,
@@ -1222,6 +1229,99 @@ contract StandaloneSingleOwnerHCATest is Test {
             resolver,
             _operationData(executions)
         );
+    }
+
+    function test_validator_acceptsMultipleRegistryAuthorizedRegistrars() public {
+        address alternateRegistrar = makeAddr("alternate-registrar");
+        ethRegistry.setRootRoles(alternateRegistrar, RegistryRolesLib.ROLE_REGISTRAR);
+
+        HCAOwnerAndSessionValidator.Execution[] memory executions =
+            new HCAOwnerAndSessionValidator.Execution[](4);
+        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: _registerCallDataForLabel(
+            "alice",
+            owner,
+            resolver
+        )});
+        executions[1] = HCAOwnerAndSessionValidator.Execution({target: alternateRegistrar, value: 0, callData: _registerCallDataForLabel(
+            "bob",
+            owner,
+            resolver
+        )});
+        executions[2] = HCAOwnerAndSessionValidator.Execution({target: usdc, value: 0, callData: abi.encodeWithSelector(
+            APPROVE_SELECTOR,
+            alternateRegistrar,
+            1 ether
+        )});
+        executions[3] = HCAOwnerAndSessionValidator.Execution({target: resolver, value: 0, callData: _resolverRoleCall(
+            hex"00",
+            EACBaseRolesLib.ALL_ROLES,
+            owner,
+            true
+        )});
+
+        validatorHarness.checkRegistrationPolicyHarness(
+            address(hca),
+            owner,
+            resolver,
+            _operationData(executions)
+        );
+    }
+
+    function test_validator_rejectsRegistrarImmediatelyAfterRoleRevocation() public {
+        ethRegistry.setRootRoles(ethRegistrar, 0);
+        bytes memory operationData =
+            _singleOperationData(
+                ethRegistrar,
+                0,
+                abi.encodeWithSelector(COMMIT_SELECTOR, bytes32("commitment"))
+            );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                HCAOwnerAndSessionValidator.ActionNotAllowed.selector,
+                ethRegistrar,
+                COMMIT_SELECTOR
+            )
+        );
+        validatorHarness.checkRegistrationPolicyHarness(
+            address(hca),
+            owner,
+            address(0),
+            operationData
+        );
+    }
+
+    function test_validator_rejectsApprovalAfterRegistrarRoleRevocation() public {
+        ethRegistry.setRootRoles(ethRegistrar, 0);
+        bytes memory operationData =
+            _singleOperationData(
+                usdc,
+                0,
+                abi.encodeWithSelector(APPROVE_SELECTOR, ethRegistrar, 1 ether)
+            );
+
+        vm.expectRevert(HCAOwnerAndSessionValidator.PolicyRuleFailed.selector);
+        validatorHarness.checkRegistrationPolicyHarness(
+            address(hca),
+            owner,
+            address(0),
+            operationData
+        );
+    }
+
+    function test_validator_rejectsUnapprovedRegistrarTarget() public {
+        address unapprovedRegistrar = makeAddr("unapproved-registrar");
+        bytes memory operationData =
+            _singleOperationData(unapprovedRegistrar, 0, _registerCallData(owner, resolver));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                HCAOwnerAndSessionValidator.ActionNotAllowed.selector,
+                unapprovedRegistrar,
+                REGISTER_SELECTOR
+            )
+        );
+        validatorHarness.checkRegistrationPolicyHarness(address(hca), owner, resolver, operationData);
     }
 
     function test_validator_rejectsPolicyViolations() public {
@@ -2214,11 +2314,13 @@ contract StandaloneSingleOwnerHCATest is Test {
 }
 
 
+/// @title HCA Owner and Session Validator Harness
+/// @notice Exposes internal validator helpers for policy-focused tests.
 contract HCAOwnerAndSessionValidatorHarness is HCAOwnerAndSessionValidator {
     constructor(
         address defaultReverseRegistrarHCAAdapter,
         address permittedResolverImpl,
-        address ethRegistrar,
+        address ethRegistry,
         address verifiableFactory,
         address paymentToken,
         address secondaryPaymentToken,
@@ -2228,7 +2330,7 @@ contract HCAOwnerAndSessionValidatorHarness is HCAOwnerAndSessionValidator {
         HCAOwnerAndSessionValidator(
             defaultReverseRegistrarHCAAdapter,
             permittedResolverImpl,
-            ethRegistrar,
+            ethRegistry,
             verifiableFactory,
             paymentToken,
             secondaryPaymentToken,

--- a/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
+++ b/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
@@ -30,7 +30,6 @@ import {Test} from "forge-std/Test.sol";
 
 import {
     MockExecutorModule,
-    MockRegistrarRoleRegistry,
     MockStandaloneHCA,
     MockValidatorModule
 } from "../../mocks/MockStandaloneHCAStack.sol";
@@ -43,6 +42,7 @@ import {
 import {StandaloneHCAFactory} from "~src/hca/StandaloneHCAFactory.sol";
 import {StandaloneSingleOwnerHCA} from "~src/hca/StandaloneSingleOwnerHCA.sol";
 import {IStandaloneHCAOwner} from "~src/hca/interfaces/IStandaloneHCAOwner.sol";
+import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
 import {IAddressSet} from "~src/utils/interfaces/IAddressSet.sol";
 
@@ -53,6 +53,8 @@ contract StandaloneSingleOwnerHCATest is Test {
         "src/utils/PermissionedAddressSet.sol:PermissionedAddressSet";
     string internal constant PERMISSIONED_RESOLVER_ARTIFACT =
         "src/resolver/PermissionedResolver.sol:PermissionedResolver";
+    string internal constant PERMISSIONED_REGISTRY_ARTIFACT =
+        "src/registry/PermissionedRegistry.sol:PermissionedRegistry";
 
     bytes4 constant ERC1271_MAGICVALUE = 0x1626ba7e;
 
@@ -96,15 +98,20 @@ contract StandaloneSingleOwnerHCATest is Test {
 
     HCAOwnerAndSessionValidator validator;
     HCAOwnerAndSessionValidatorHarness validatorHarness;
-    MockRegistrarRoleRegistry ethRegistry;
+    IPermissionedRegistry ethRegistry;
     MockStandaloneHCA hca;
     IAddressSetApproval upgradeSet;
 
     function setUp() public {
         upgradeSet = _deployPermissionedAddressSet(upgradeSetAdmin);
         hca = new MockStandaloneHCA(owner);
-        ethRegistry = new MockRegistrarRoleRegistry();
-        ethRegistry.setRootRoles(ethRegistrar, RegistryRolesLib.ROLE_REGISTRAR);
+        ethRegistry = IPermissionedRegistry(
+            deployCode(
+                PERMISSIONED_REGISTRY_ARTIFACT,
+                abi.encode(address(0), address(this), RegistryRolesLib.ROLE_REGISTRAR_ADMIN)
+            )
+        );
+        ethRegistry.grantRootRoles(RegistryRolesLib.ROLE_REGISTRAR, ethRegistrar);
 
         VerifiableFactory factory = new VerifiableFactory();
         verifiableFactory = address(factory);
@@ -1233,7 +1240,7 @@ contract StandaloneSingleOwnerHCATest is Test {
 
     function test_validator_acceptsMultipleRegistryAuthorizedRegistrars() public {
         address alternateRegistrar = makeAddr("alternate-registrar");
-        ethRegistry.setRootRoles(alternateRegistrar, RegistryRolesLib.ROLE_REGISTRAR);
+        ethRegistry.grantRootRoles(RegistryRolesLib.ROLE_REGISTRAR, alternateRegistrar);
 
         HCAOwnerAndSessionValidator.Execution[] memory executions =
             new HCAOwnerAndSessionValidator.Execution[](4);
@@ -1268,7 +1275,7 @@ contract StandaloneSingleOwnerHCATest is Test {
     }
 
     function test_validator_rejectsRegistrarImmediatelyAfterRoleRevocation() public {
-        ethRegistry.setRootRoles(ethRegistrar, 0);
+        ethRegistry.revokeRootRoles(RegistryRolesLib.ROLE_REGISTRAR, ethRegistrar);
         bytes memory operationData =
             _singleOperationData(
                 ethRegistrar,
@@ -1292,7 +1299,7 @@ contract StandaloneSingleOwnerHCATest is Test {
     }
 
     function test_validator_rejectsApprovalAfterRegistrarRoleRevocation() public {
-        ethRegistry.setRootRoles(ethRegistrar, 0);
+        ethRegistry.revokeRootRoles(RegistryRolesLib.ROLE_REGISTRAR, ethRegistrar);
         bytes memory operationData =
             _singleOperationData(
                 usdc,

--- a/contracts/test/unit/hcaDeployHelpers.test.ts
+++ b/contracts/test/unit/hcaDeployHelpers.test.ts
@@ -143,12 +143,18 @@ describe("HCA deployment script scope", () => {
     expect(deployReverseRegistrarAdapter.tags).toContain("hca");
   });
 
-  it("pins the HCA validator to the canonical default reverse adapter", () => {
+  it("pins the HCA validator to stable authorization dependencies", () => {
     expect(deployHCAOwnerAndSessionValidator.dependencies).toContain(
       "DefaultReverseRegistrarAdapter",
     );
     expect(deployHCAOwnerAndSessionValidator.dependencies).not.toContain(
       "DefaultReverseRegistrarHCAAdapter",
+    );
+    expect(deployHCAOwnerAndSessionValidator.dependencies).toContain(
+      "ETHRegistry",
+    );
+    expect(deployHCAOwnerAndSessionValidator.dependencies).not.toContain(
+      "ETHRegistrar",
     );
   });
 

--- a/docs/HCA.md
+++ b/docs/HCA.md
@@ -38,6 +38,8 @@ A registration uses an HCA on the registration chain. A cross-chain registration
 
 The HCA uses a Nexus implementation with a fixed validator and executor. The source Nexus uses the fixed funding validator. The HCA prevents module installation and removal. An approved upgrade can change the fixed modules.
 
+The destination validator pins the long-lived `ETHRegistry`, not one registrar deployment. A registration target or payment-token spender is permitted only while that registry grants it the root `ROLE_REGISTRAR`. This supports concurrent registrars and registrar replacement without an HCA implementation upgrade. Revoking the role disables the registrar for existing sessions immediately.
+
 The HCA rejects delegatecall execution and the standard ERC-721 and ERC-1155 receiver callbacks. It can hold ETH or supported tokens during an operation. Do not use it for long-term funds.
 
 ### HCA address
@@ -362,7 +364,7 @@ The fee limits specify the refund token, exchange rate, gas overhead, and maximu
 
 The session permits:
 
-- Commitment and registration calls
+- Commitment and registration calls to registry-authorized registrars
 - Deployment of the approved resolver implementation
 - Supported resolver record changes
 - Primary-name changes for the HCA owner
@@ -376,11 +378,13 @@ The validator applies these rules:
 - A new resolver must use the approved implementation and exact initializer.
 - An existing resolver must verify against the approved implementation.
 - Every registration must give root `ROLES.ALL` to the wallet.
-- A registrar approval can name only `ETHRegistrar` as spender.
+- A registrar approval can name only a current root `ROLE_REGISTRAR` holder as spender.
 - An execution-fee approval must match the signed fee and the session limits.
 - A first same-chain action can use one wallet permit followed by the same-value transfer into the HCA.
 
 The session key can select labels, records, and primary-name strings. The owner does not pre-sign one fixed registration. The session can register more than one name before expiry or revocation.
+
+Registrar-role governance is therefore part of the session trust boundary: granting the role makes that registrar available to already-enabled, short-lived sessions, while revocation removes it. The remaining selector, registrant, and resolver checks still apply to every authorized registrar.
 
 The session does not permit:
 


### PR DESCRIPTION
pins the HCA validator to `ETHRegistry` instead of one `ETHRegistrar`, and authorises registrar calls and payment approvals through the live root `ROLE_REGISTRAR`. this allows registrar replacement or multiple active registrars without upgrading every HCA, while role revocation takes effect immediately.