### PR TITLE
fix: preserve compiler build info for deployments

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
     "rocketh@0.19.3": "patches/rocketh@0.19.3.patch",
     "@rhinestone/sdk@1.8.0": "patches/@rhinestone%2Fsdk@1.8.0.patch",
     "@rocketh/node@0.19.3": "patches/@rocketh-node@0.19.3.patch",
+    "hardhat-deploy@2.0.3": "patches/hardhat-deploy@2.0.3.patch",
   },
   "overrides": {
     "esbuild": "0.25.11",

--- a/contracts/deployments/README.md
+++ b/contracts/deployments/README.md
@@ -18,7 +18,9 @@ deployments/
     .migrations.json      # rocketh's record of completed deploy scripts (id → unix-epoch-seconds)
     .deployment.json      # { environment, chainId, deployedAt } — when this set was first deployed
     .premigration.json    # pre-migration counts sidecar (names reserved/renewed/skipped/…), no label strings
-    <Contract>.json       # one file per deployed contract (address, abi, bytecode, receipt, …)
+    <Contract>.json       # one file per deployed contract (address, abi, bytecode, receipt, buildInfoId, …)
+    build-info/
+      <buildInfoId>.json  # exact compiler input shared by every contract from that build
   v1/
     <network>/            # local v1-reference overrides (searched before the bundled set)
       .chainId            # chain id of the referenced v1 set
@@ -31,6 +33,13 @@ dotfiles are metadata; rocketh loads only `.migrations.json` and the
 mistaken for a contract. `.deployment.json` is written once, on the first deploy
 into a namespace, so its `deployedAt` records the original deployment time and
 survives idempotent re-runs.
+
+Compiled deployment artifacts record a `buildInfoId`. The matching file under
+`build-info/` preserves the exact compiler version, settings, remappings, and
+source text used to produce the deployed bytecode. It is copied once per build,
+so contracts compiled together share one file. The much larger compiler output
+is not committed because it can be regenerated from this input. Vendored
+artifacts that were not produced by this Hardhat build may omit `buildInfoId`.
 
 `.premigration.json` is the durable record of the v1→v2 pre-migration run(s) that
 targeted this namespace. It holds counts only — never the reserved label strings

--- a/contracts/test/unit/deploymentBuildInfo.test.ts
+++ b/contracts/test/unit/deploymentBuildInfo.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { setupEnvironmentFromFiles } from "@rocketh/node";
+import type { UserConfig } from "rocketh/types";
+
+const CHAIN_ID = 31337;
+const ENVIRONMENT = "sepolia";
+const ADDRESS = "0x0000000000000000000000000000000000000001";
+const TRANSACTION_HASH = `0x${"1".repeat(64)}` as `0x${string}`;
+const BLOCK_HASH = `0x${"2".repeat(64)}` as `0x${string}`;
+const GAS_ESTIMATES = { external: { "example()": "1" } } as const;
+
+const { loadEnvironmentFromFilesWithConfig } = setupEnvironmentFromFiles({});
+
+describe("deployment build info", () => {
+  it("persists build info for direct and broadcast saves in the configured deployment root", async () => {
+    const originalCwd = process.cwd();
+    process.chdir(resolve(import.meta.dirname, "../.."));
+    const tempRoot = mkdtempSync(join(tmpdir(), "rocketh-build-info-"));
+    const deploymentsRoot = join(tempRoot, "deployments", "v1");
+    const buildInfoId = `test-${basename(tempRoot)}`;
+    const sourceBuildInfo = resolve(
+      "artifacts",
+      "build-info",
+      `${buildInfoId}.json`,
+    );
+    const savedBuildInfo = join(
+      deploymentsRoot,
+      ENVIRONMENT,
+      "build-info",
+      `${buildInfoId}.json`,
+    );
+    const buildInfo = { id: buildInfoId, input: { settings: {} } };
+
+    mkdirSync(dirname(sourceBuildInfo), { recursive: true });
+    writeFileSync(sourceBuildInfo, JSON.stringify(buildInfo));
+
+    try {
+      const provider = {
+        async request({ method }: { method: string }) {
+          switch (method) {
+            case "eth_chainId":
+              return `0x${CHAIN_ID.toString(16)}`;
+            case "eth_getBlockByNumber":
+              return { hash: BLOCK_HASH };
+            case "eth_accounts":
+              return [];
+            case "eth_sendRawTransaction":
+              return TRANSACTION_HASH;
+            case "eth_getTransactionByHash":
+              return null;
+            case "eth_getTransactionReceipt":
+              return {
+                blockHash: BLOCK_HASH,
+                blockNumber: "0x1",
+                contractAddress: ADDRESS,
+                cumulativeGasUsed: "0x1",
+                from: ADDRESS,
+                gasUsed: "0x1",
+                logs: [],
+                logsBloom: `0x${"0".repeat(512)}`,
+                status: "0x1",
+                to: null,
+                transactionHash: TRANSACTION_HASH,
+                transactionIndex: "0x0",
+                type: "0x2",
+              };
+            default:
+              throw new Error(`unexpected RPC method: ${method}`);
+          }
+        },
+      };
+      const config = {
+        deployments: deploymentsRoot,
+        chains: {
+          [CHAIN_ID]: {
+            info: {
+              id: CHAIN_ID,
+              name: "Test",
+              nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+              rpcUrls: { default: { http: ["http://localhost"] } },
+            },
+            pollingInterval: 0.001,
+          },
+        },
+        environments: {
+          [ENVIRONMENT]: { chain: CHAIN_ID },
+        },
+      } as const satisfies UserConfig;
+      const env = await loadEnvironmentFromFilesWithConfig(
+        {
+          environment: ENVIRONMENT,
+          provider: provider as never,
+          saveDeployments: true,
+        },
+        config,
+      );
+      const artifact = {
+        abi: [] as const,
+        bytecode: "0x00" as const,
+        metadata: "{}",
+        buildInfoId,
+        evm: {
+          gasEstimates: GAS_ESTIMATES,
+          bytecode: { opcodes: "PUSH0 STOP" },
+        },
+      };
+
+      await env.save("DirectSave", {
+        ...artifact,
+        address: ADDRESS,
+      } as never);
+      await waitForFile(join(deploymentsRoot, ENVIRONMENT, "DirectSave.json"));
+      expectDeploymentFile(deploymentsRoot, "DirectSave", buildInfoId);
+      expect(JSON.parse(readFileSync(savedBuildInfo, "utf8"))).toEqual(
+        buildInfo,
+      );
+
+      rmSync(savedBuildInfo);
+      await env.broadcastDeployment(
+        "BroadcastSave",
+        { type: "raw", from: ADDRESS, raw: "0x00" },
+        {
+          ...artifact,
+          argsData: "0x",
+        },
+        { expectedAddress: ADDRESS },
+      );
+      await waitForFile(
+        join(deploymentsRoot, ENVIRONMENT, "BroadcastSave.json"),
+      );
+      expectDeploymentFile(deploymentsRoot, "BroadcastSave", buildInfoId);
+      expect(existsSync(savedBuildInfo)).toBe(true);
+    } finally {
+      rmSync(sourceBuildInfo, { force: true });
+      rmSync(tempRoot, { recursive: true, force: true });
+      process.chdir(originalCwd);
+    }
+  });
+});
+
+function expectDeploymentFile(
+  deploymentsRoot: string,
+  name: string,
+  buildInfoId: string,
+) {
+  const deployment = JSON.parse(
+    readFileSync(join(deploymentsRoot, ENVIRONMENT, `${name}.json`), "utf8"),
+  );
+  expect(deployment.buildInfoId).toBe(buildInfoId);
+  expect(deployment.evm).toEqual({ gasEstimates: GAS_ESTIMATES });
+}
+
+async function waitForFile(file: string) {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (existsSync(file)) return;
+    await Bun.sleep(1);
+  }
+  throw new Error(`timed out waiting for ${file}`);
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "patchedDependencies": {
     "@rocketh/node@0.19.3": "patches/@rocketh-node@0.19.3.patch",
     "rocketh@0.19.3": "patches/rocketh@0.19.3.patch",
-    "@rhinestone/sdk@1.8.0": "patches/@rhinestone%2Fsdk@1.8.0.patch"
+    "@rhinestone/sdk@1.8.0": "patches/@rhinestone%2Fsdk@1.8.0.patch",
+    "hardhat-deploy@2.0.3": "patches/hardhat-deploy@2.0.3.patch"
   }
 }

--- a/patches/@rocketh-node@0.19.3.patch
+++ b/patches/@rocketh-node@0.19.3.patch
@@ -10,3 +10,92 @@ index 00db18f8f807c3f47828e4c46aa963c525ddc2f2..6c389ef9247c35d0d006b5dc3fdd2552
  import fs from 'node:fs';
  import path from 'node:path';
  import prompts from 'prompts';
+diff --git a/dist/environment/deployment-store.js b/dist/environment/deployment-store.js
+index 2e5448f..9e311d6 100644
+--- a/dist/environment/deployment-store.js
++++ b/dist/environment/deployment-store.js
+@@ -9,0 +10,33 @@ export function createFSDeploymentStore() {
++    function prepareDeploymentFile(deploymentsFolder, environmentName, name, content) {
++        if (name.startsWith('.') || !name.endsWith('.json'))
++            return content;
++        let deployment;
++        try {
++            deployment = JSON.parse(content);
++        }
++        catch {
++            return content;
++        }
++        if (Object.hasOwn(deployment, 'evm')) {
++            const evm = deployment.evm;
++            if (evm && typeof evm === 'object' && Object.hasOwn(evm, 'gasEstimates')) {
++                deployment.evm = { gasEstimates: evm.gasEstimates };
++            }
++            else {
++                delete deployment.evm;
++            }
++            content = JSON.stringify(deployment, null, 2);
++        }
++        if (typeof deployment.buildInfoId === 'string') {
++            const buildInfoDir = path.join(getFolder(deploymentsFolder, environmentName), 'build-info');
++            fs.mkdirSync(buildInfoDir, { recursive: true });
++            try {
++                fs.copyFileSync(path.resolve('artifacts', 'build-info', `${deployment.buildInfoId}.json`), path.join(buildInfoDir, `${deployment.buildInfoId}.json`), fs.constants.COPYFILE_EXCL);
++            }
++            catch (error) {
++                if (error.code !== 'EEXIST')
++                    throw error;
++            }
++        }
++        return content;
++    }
+@@ -15,0 +49 @@ export function createFSDeploymentStore() {
++        content = prepareDeploymentFile(deploymentsFolder, environmentName, name, content);
+diff --git a/src/environment/deployment-store.ts b/src/environment/deployment-store.ts
+index 7e92e2b..99d92f7 100644
+--- a/src/environment/deployment-store.ts
++++ b/src/environment/deployment-store.ts
+@@ -12,0 +13,42 @@ export function createFSDeploymentStore(): DeploymentStore {
++	function prepareDeploymentFile(
++		deploymentsFolder: string,
++		environmentName: string,
++		name: string,
++		content: string,
++	): string {
++		if (name.startsWith('.') || !name.endsWith('.json')) return content;
++
++		let deployment: Record<string, any>;
++		try {
++			deployment = JSON.parse(content);
++		} catch {
++			return content;
++		}
++
++		if (Object.hasOwn(deployment, 'evm')) {
++			const evm = deployment.evm;
++			if (evm && typeof evm === 'object' && Object.hasOwn(evm, 'gasEstimates')) {
++				deployment.evm = {gasEstimates: evm.gasEstimates};
++			} else {
++				delete deployment.evm;
++			}
++			content = JSON.stringify(deployment, null, 2);
++		}
++
++		if (typeof deployment.buildInfoId === 'string') {
++			const buildInfoDir = path.join(getFolder(deploymentsFolder, environmentName), 'build-info');
++			fs.mkdirSync(buildInfoDir, {recursive: true});
++			try {
++				fs.copyFileSync(
++					path.resolve('artifacts', 'build-info', `${deployment.buildInfoId}.json`),
++					path.join(buildInfoDir, `${deployment.buildInfoId}.json`),
++					fs.constants.COPYFILE_EXCL,
++				);
++			} catch (error) {
++				if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
++			}
++		}
++
++		return content;
++	}
++
+@@ -30,0 +73 @@ export function createFSDeploymentStore(): DeploymentStore {
++		content = prepareDeploymentFile(deploymentsFolder, environmentName, name, content);

--- a/patches/hardhat-deploy@2.0.3.patch
+++ b/patches/hardhat-deploy@2.0.3.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/generate-types.js b/dist/generate-types.js
+index 7aa3dd8632c3da7815a528ed920e37b339e779b4..2268b181bb4500d67faaeac0df73e49eb98c7624 100644
+--- a/dist/generate-types.js
++++ b/dist/generate-types.js
+@@ -222 +222 @@ export async function generateTypes(paths, config) {
+-            const { buildInfoId, _format, ...artifactObject } = hardhatArtifactObject;
++            const { _format, ...artifactObject } = hardhatArtifactObject;
+diff --git a/src/generate-types.ts b/src/generate-types.ts
+index 9f84f9d6b1731db6b10d64b7786b7f6966a0008a..fa4959f10730c90b076f1a324391a26538c7eeb0 100644
+--- a/src/generate-types.ts
++++ b/src/generate-types.ts
+@@ -256 +256 @@ export async function generateTypes(paths: {artifacts: string[]}, config: Artifa
+-			const {buildInfoId, _format, ...artifactObject} = hardhatArtifactObject;
++			const {_format, ...artifactObject} = hardhatArtifactObject;


### PR DESCRIPTION
preserves the hardhat-deploy `buildInfoId` in generated artifacts, copies each exact compiler input once into `deployments/<network>/build-info`, and stops embedding duplicate EVM build data in every deployment file. this restores the useful part of the old hardhat-deploy behavior without committing the much larger regenerable compiler output.