### PR TITLE
Allow `MigrationHelper` to unwrap `HCA`

### DIFF
--- a/contracts/deploy/05_MigrationHelper.ts
+++ b/contracts/deploy/05_MigrationHelper.ts
@@ -13,6 +13,10 @@ export default execute(
       (typeof artifacts.LockedMigrationController)["abi"]
     >("LockedMigrationController");
 
+    const standaloneHCAFactory = get<
+      (typeof artifacts.StandaloneHCAFactory)["abi"]
+    >("StandaloneHCAFactory");
+
     const contractNamer =
       get<(typeof artifacts.IContractNamer)["abi"]>("ContractNamer");
 
@@ -23,16 +27,18 @@ export default execute(
         rootRegistry.address,
         unlockedMigrationController.address,
         lockedMigrationController.address,
+        standaloneHCAFactory.address,
         contractNamer.address,
       ],
     });
   },
   {
-    tags: ["MigrationHelper", "migration:phase1:deploy-v2", "v2"],
+    tags: ["MigrationHelper", "migration:phase1:deploy-v2", "v2", "hca"],
     dependencies: [
       "RootRegistry",
       "UnlockedMigrationController",
       "LockedMigrationController",
+      "StandaloneHCAFactory",
       "ContractNamer",
     ],
   },

--- a/contracts/src/migration/MigrationHelper.sol
+++ b/contracts/src/migration/MigrationHelper.sol
@@ -5,6 +5,7 @@ import {IBaseRegistrar} from "@ens/contracts/ethregistrar/IBaseRegistrar.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
 
+import {IStandaloneHCAFactory} from "../hca/interfaces/IStandaloneHCAFactory.sol";
 import {IRegistry} from "../registry/interfaces/IRegistry.sol";
 import {IContractNamer} from "../reverse-registrar/interfaces/IContractNamer.sol";
 import {LibRegistry} from "../universalResolver/libraries/LibRegistry.sol";
@@ -42,6 +43,9 @@ contract MigrationHelper is DelegatedContractNamer {
     /// @dev The ENSv1 `BaseRegistrar` contract.
     IBaseRegistrar internal immutable _BASE_REGISTRAR;
 
+    /// @dev The factory that certifies HCA owner bindings.
+    IStandaloneHCAFactory internal immutable _STANDALONE_HCA_FACTORY;
+
     ////////////////////////////////////////////////////////////////////////
     // Errors
     ////////////////////////////////////////////////////////////////////////
@@ -65,11 +69,13 @@ contract MigrationHelper is DelegatedContractNamer {
     /// @param rootRegistry The root registry.
     /// @param unlockedController The ENSv2 `UnlockedMigrationController`.
     /// @param lockedController The ENSv2 `LockedMigrationController`.
+    /// @param standaloneHCAFactory Factory certifying immutable HCA owner bindings.
     /// @param contractNamer Delegated contract namer.
     constructor(
         IRegistry rootRegistry,
         AbstractWrapperReceiver unlockedController,
         AbstractWrapperReceiver lockedController,
+        IStandaloneHCAFactory standaloneHCAFactory,
         IContractNamer contractNamer
     )
         DelegatedContractNamer(contractNamer)
@@ -77,6 +83,7 @@ contract MigrationHelper is DelegatedContractNamer {
         ROOT_REGISTRY = rootRegistry;
         UNLOCKED_CONTROLLER = unlockedController;
         LOCKED_CONTROLLER = lockedController;
+        _STANDALONE_HCA_FACTORY = standaloneHCAFactory;
 
         NAME_WRAPPER = unlockedController.NAME_WRAPPER();
         _BASE_REGISTRAR = NAME_WRAPPER.registrar();
@@ -99,7 +106,10 @@ contract MigrationHelper is DelegatedContractNamer {
     )
         external
     {
-        address sender = msg.sender;
+        address sender = _STANDALONE_HCA_FACTORY.authorizedOwnerOf(msg.sender);
+        if (sender == address(0)) {
+            sender = msg.sender;
+        }
         for (uint256 i; i < unwrapped.length; ++i) {
             LibMigration.Data calldata md = unwrapped[i];
             uint256 tokenId = uint256(keccak256(bytes(md.label)));

--- a/contracts/test/unit/migration/MigrationHelper.t.sol
+++ b/contracts/test/unit/migration/MigrationHelper.t.sol
@@ -14,6 +14,7 @@ import {LockedMigrationController} from "~src/migration/LockedMigrationControlle
 import {WrapperRegistry} from "~src/registry/WrapperRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
 import {MigrationHelper, LockedChildren} from "~src/migration/MigrationHelper.sol";
+import {StandaloneHCAFactory} from "~src/hca/StandaloneHCAFactory.sol";
 import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixture.sol";
 
 contract MigrationHelperTest is MigrationControllerFixture {
@@ -72,6 +73,7 @@ contract MigrationHelperTest is MigrationControllerFixture {
             rootRegistry,
             unlockedController,
             lockedController,
+            new StandaloneHCAFactory(verifiableFactory, address(this)),
             contractNamer
         );
     }


### PR DESCRIPTION
- changed `MigrationHelper`
     * constructor takes `IStandaloneHCAFactory`
     * `migrate()` unwraps `HCA`