### PR TITLE
Add `calls[]` to `UserRegistry.initialize()`

### DIFF
--- a/contracts/script/setup.ts
+++ b/contracts/script/setup.ts
@@ -703,13 +703,13 @@ export async function setupDevnet({
       account, // deployer
       admin = account.address,
       roles = ROLES.ALL,
-      setters = [],
+      calls = [],
       salt,
     }: {
       account: Account;
       admin?: Address;
       roles?: bigint;
-      setters?: Hex[];
+      calls?: Hex[];
       salt?: bigint | { ownedVersion: bigint };
     }) {
       if (typeof salt === "object") {
@@ -722,7 +722,7 @@ export async function setupDevnet({
           implAddress: v2.PermissionedResolverImpl.address,
           abi: v2.PermissionedResolverImpl.abi,
           functionName: "initialize",
-          args: [admin, roles, setters],
+          args: [admin, roles, calls],
           salt,
         }),
       );
@@ -732,11 +732,13 @@ export async function setupDevnet({
       account,
       admin = account.address,
       roles = ROLES.ALL,
+      calls = [],
       salt,
     }: {
       account: Account;
       admin?: Address;
       roles?: bigint;
+      calls?: Hex[];
       salt?: bigint | { name: string; version?: bigint };
     }) {
       const implAddress = v2.UserRegistryImpl.address;
@@ -750,7 +752,7 @@ export async function setupDevnet({
           implAddress,
           abi: v2.UserRegistryImpl.abi,
           functionName: "initialize",
-          args: [admin, roles],
+          args: [admin, roles, calls],
           salt,
         }),
       );

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -247,6 +247,24 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
         return super.revokeRoles(getResource(anyId), roleBitmap, account);
     }
 
+    /// @notice Perform multiple operations.
+    /// @dev Reverts with first error.
+    /// @param calls The calls to make.
+    /// @return results The results of the calls.
+    function multicall(bytes[] calldata calls) public returns (bytes[] memory results) {
+        results = new bytes[](calls.length);
+        for (uint256 i; i < calls.length; ++i) {
+            (bool ok, bytes memory v) = address(this).delegatecall(calls[i]);
+            if (!ok) {
+                assembly {
+                    revert(add(v, 32), mload(v)) // propagate the first error
+                }
+            }
+            results[i] = v;
+        }
+        return results;
+    }
+
     /// @inheritdoc IRegistry
     function getSubregistry(string calldata label) public view virtual returns (IRegistry) {
         Entry storage entry = _entry(LibLabel.id(label));

--- a/contracts/src/registry/UserRegistry.sol
+++ b/contracts/src/registry/UserRegistry.sol
@@ -6,7 +6,6 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
-import {InvalidOwner} from "../CommonErrors.sol";
 import {ILabelStore} from "../utils/interfaces/ILabelStore.sol";
 
 import {RegistryRolesLib} from "./libraries/RegistryRolesLib.sol";
@@ -35,17 +34,18 @@ contract UserRegistry is Initializable, PermissionedRegistry, UUPSUpgradeable, I
         _disableInitializers();
     }
 
-    /// @notice Initializes a proxy instance of `UserRegistry`.
-    /// @dev Grants the supplied role bitmap to `rootAccount` on the root resource.
-    ///      Reverts if the zero address.
+    /// @notice Initialize the contract.
     /// @param rootAccount Account granted root roles.
-    /// @param roleBitmap The role bitmap granted to `rootAccount`.
-    function initialize(address rootAccount, uint256 roleBitmap) public initializer {
-        if (rootAccount == address(0)) {
-            revert InvalidOwner();
-        }
+    /// @param roleBitmap The roles granted to `rootAccount`.
+    /// @param calls The calldata that avoids permission checks.
+    function initialize(address rootAccount, uint256 roleBitmap, bytes[] calldata calls)
+        public
+        initializer
+    {
+        __UUPSUpgradeable_init();
         emit RegistryCreated();
         _grantRoles(ROOT_RESOURCE, roleBitmap, rootAccount, false);
+        multicall(calls);
     }
 
     /// @inheritdoc IERC165
@@ -84,4 +84,37 @@ contract UserRegistry is Initializable, PermissionedRegistry, UUPSUpgradeable, I
         override
         onlyRootRoles(RegistryRolesLib.ROLE_UPGRADE)
     {}
+
+    /// @dev Avoid permission checks during initialization.
+    function _checkRoles(uint256 resource, uint256 roleBitmap, address account)
+        internal
+        view
+        override
+    {
+        if (!_isInitializing()) {
+            super._checkRoles(resource, roleBitmap, account);
+        }
+    }
+
+    /// @dev Avoid permission checks during initialization.
+    function _checkCanGrantRoles(uint256 resource, uint256 roleBitmap, address account)
+        internal
+        view
+        override
+    {
+        if (!_isInitializing()) {
+            super._checkCanGrantRoles(resource, roleBitmap, account);
+        }
+    }
+
+    /// @dev Avoid permission checks during initialization.
+    function _checkCanRevokeRoles(uint256 resource, uint256 roleBitmap, address account)
+        internal
+        view
+        override
+    {
+        if (!_isInitializing()) {
+            super._checkCanRevokeRoles(resource, roleBitmap, account);
+        }
+    }
 }

--- a/contracts/src/resolver/PermissionedResolver.sol
+++ b/contracts/src/resolver/PermissionedResolver.sol
@@ -230,14 +230,17 @@ contract PermissionedResolver is
         return ResolverFeatures.RESOLVE_MULTICALL == feature;
     }
 
-    /// @inheritdoc IPermissionedResolver
-    function initialize(address admin, uint256 roleBitmap, bytes[] calldata setters)
+    /// @notice Initialize the contract.
+    /// @param rootAccount Account granted root roles.
+    /// @param roleBitmap The roles granted to `rootAccount`.
+    /// @param calls The calldata that avoids permission checks.
+    function initialize(address rootAccount, uint256 roleBitmap, bytes[] calldata calls)
         external
         initializer
     {
         __UUPSUpgradeable_init();
-        _grantRoles(ROOT_RESOURCE, roleBitmap, admin, false);
-        multicall(setters);
+        _grantRoles(ROOT_RESOURCE, roleBitmap, rootAccount, false);
+        multicall(calls);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -639,7 +642,7 @@ contract PermissionedResolver is
         return true;
     }
 
-    /// @notice Perform multiple write operations.
+    /// @notice Perform multiple operations.
     /// @dev Reverts with first error.
     /// @param calls The calls to make.
     /// @return results The results of the calls.

--- a/contracts/src/resolver/interfaces/IPermissionedResolver.sol
+++ b/contracts/src/resolver/interfaces/IPermissionedResolver.sol
@@ -5,7 +5,7 @@ import {IExtendedResolver} from "@ens/contracts/resolvers/profiles/IExtendedReso
 
 import {IEnhancedAccessControl} from "../../access-control/interfaces/IEnhancedAccessControl.sol";
 
-/// @dev Interface selector: `0x91413117`
+/// @dev Interface selector: `0xe119844e`
 interface IPermissionedResolver is IExtendedResolver, IEnhancedAccessControl {
     ////////////////////////////////////////////////////////////////////////
     // Events
@@ -42,12 +42,6 @@ interface IPermissionedResolver is IExtendedResolver, IEnhancedAccessControl {
     ////////////////////////////////////////////////////////////////////////
     // Functions
     ////////////////////////////////////////////////////////////////////////
-
-    /// @notice Initialize the contract.
-    /// @param admin The resolver owner.
-    /// @param roleBitmap The roles granted to `admin`.
-    /// @param setters The setter calldata that avoids permission checks.
-    function initialize(address admin, uint256 roleBitmap, bytes[] calldata setters) external;
 
     /// @notice Create an alias from `fromName` to `toName`.
     /// @param fromName The source DNS-encoded name.

--- a/contracts/test/fixtures/V2Fixture.sol
+++ b/contracts/test/fixtures/V2Fixture.sol
@@ -106,7 +106,7 @@ contract V2Fixture is Test, ERC1155Holder {
                 verifiableFactory.deployProxy(
                     address(userRegistryImpl),
                     salt,
-                    abi.encodeCall(UserRegistry.initialize, (owner, roleBitmap))
+                    abi.encodeCall(UserRegistry.initialize, (owner, roleBitmap, new bytes[](0)))
                 )
             );
     }

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -1552,6 +1552,64 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
     }
 
     ////////////////////////////////////////////////////////////////////////
+    // mulitcall()
+    ////////////////////////////////////////////////////////////////////////
+
+    function test_multicall() external {
+        bytes[] memory m = new bytes[](3);
+        m[0] = abi.encodeCall(
+            IStandardRegistry.register,
+            (
+                "test",
+                user1,
+                IRegistry(address(0)),
+                address(0),
+                EACBaseRolesLib.ALL_ROLES,
+                type(uint64).max
+            )
+        );
+        m[1] = abi.encodeCall(
+            IEnhancedAccessControl.grantRootRoles,
+            (EACBaseRolesLib.ALL_ROLES, user1)
+        );
+        m[2] = abi.encodeCall(
+            IEnhancedAccessControl.revokeRootRoles,
+            (EACBaseRolesLib.ALL_ROLES, user2)
+        );
+
+        registry.multicall(m);
+
+        assertEq(registry.findOwner("test"), user1, "owner");
+        assertEq(registry.roles(registry.ROOT_RESOURCE(), user1), EACBaseRolesLib.ALL_ROLES, "grant");
+        assertEq(registry.roles(registry.ROOT_RESOURCE(), user2), 0, "revoke");
+    }
+
+    function test_multicall_notAuthorized() external {
+        bytes[] memory m = new bytes[](1);
+        m[0] = abi.encodeCall(
+            IStandardRegistry.register,
+            (
+                "test",
+                user1,
+                IRegistry(address(0)),
+                address(0),
+                EACBaseRolesLib.ALL_ROLES,
+                type(uint64).max
+            )
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEnhancedAccessControl.EACUnauthorizedAccountRoles.selector,
+                registry.ROOT_RESOURCE(),
+                RegistryRolesLib.ROLE_REGISTRAR,
+                actor
+            )
+        );
+        vm.prank(actor);
+        registry.multicall(m);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
     // Specific Cases
     ////////////////////////////////////////////////////////////////////////
 

--- a/contracts/test/unit/registry/UserRegistry.t.sol
+++ b/contracts/test/unit/registry/UserRegistry.t.sol
@@ -76,7 +76,7 @@ contract UserRegistryTest is Test, ERC1155Holder {
     }
 
     function test_initialize_with_calls() external {
-        bytes[] memory m = new bytes[](2);
+        bytes[] memory m = new bytes[](3);
         m[0] = abi.encodeCall(
             IStandardRegistry.register,
             (
@@ -90,6 +90,10 @@ contract UserRegistryTest is Test, ERC1155Holder {
         );
         m[1] = abi.encodeCall(
             IEnhancedAccessControl.grantRootRoles,
+            (EACBaseRolesLib.ALL_ROLES, user1)
+        );
+        m[2] = abi.encodeCall(
+            IEnhancedAccessControl.revokeRootRoles,
             (EACBaseRolesLib.ALL_ROLES, admin)
         );
 
@@ -98,12 +102,16 @@ contract UserRegistryTest is Test, ERC1155Holder {
                 factory.deployProxy(
                     address(implementation),
                     SALT,
-                    abi.encodeCall(UserRegistry.initialize, (address(0), 0, m))
+                    abi.encodeCall(
+                        UserRegistry.initialize,
+                        (address(admin), EACBaseRolesLib.ALL_ROLES, m)
+                    )
                 )
             );
 
         assertEq(r.findOwner("test"), user1, "owner");
-        //assertTrue(r.hasRootRoles(EACBaseRolesLib.ALL_ROLES, admin), "grant");
+        assertEq(r.roles(r.ROOT_RESOURCE(), user1), EACBaseRolesLib.ALL_ROLES, "grant");
+        assertEq(r.roles(r.ROOT_RESOURCE(), admin), 0, "revoke");
     }
 
     function test_initialization() public view {

--- a/contracts/test/unit/registry/UserRegistry.t.sol
+++ b/contracts/test/unit/registry/UserRegistry.t.sol
@@ -8,12 +8,12 @@ import {Test} from "forge-std/Test.sol";
 import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
 
-import {InvalidOwner} from "~src/CommonErrors.sol";
 import {EACBaseRolesLib} from "~src/access-control/EnhancedAccessControl.sol";
 import {IEnhancedAccessControl} from "~src/access-control/interfaces/IEnhancedAccessControl.sol";
 import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
 import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
+import {IStandardRegistry} from "~src/registry/interfaces/IStandardRegistry.sol";
 import {UserRegistry} from "~src/registry/UserRegistry.sol";
 import {LabelStore, ILabelStore} from "~src/utils/LabelStore.sol";
 import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
@@ -44,7 +44,10 @@ contract UserRegistryTest is Test, ERC1155Holder {
 
         // Create initialization data
         bytes memory initData =
-            abi.encodeCall(UserRegistry.initialize, (admin, EACBaseRolesLib.ALL_ROLES));
+            abi.encodeCall(
+                UserRegistry.initialize,
+                (admin, EACBaseRolesLib.ALL_ROLES, new bytes[](0))
+            );
 
         // Deploy the proxy using the factory
         vm.expectEmit();
@@ -60,13 +63,47 @@ contract UserRegistryTest is Test, ERC1155Holder {
         assertTrue(implementation.isContractNamer(address(this)));
     }
 
-    function test_initialize_invalidOwner() external {
-        vm.expectRevert(abi.encodeWithSelector(InvalidOwner.selector));
-        factory.deployProxy(
-            address(implementation),
-            SALT,
-            abi.encodeCall(UserRegistry.initialize, (address(0), EACBaseRolesLib.ALL_ROLES))
+    function test_initialize_unowned() external {
+        UserRegistry r =
+            UserRegistry(
+                factory.deployProxy(
+                    address(implementation),
+                    SALT,
+                    abi.encodeCall(UserRegistry.initialize, (address(0), 0, new bytes[](0)))
+                )
+            );
+        assertEq(r.roleCount(r.ROOT_RESOURCE()), 0);
+    }
+
+    function test_initialize_with_calls() external {
+        bytes[] memory m = new bytes[](2);
+        m[0] = abi.encodeCall(
+            IStandardRegistry.register,
+            (
+                "test",
+                user1,
+                IRegistry(address(0)),
+                address(0),
+                EACBaseRolesLib.ALL_ROLES,
+                type(uint64).max
+            )
         );
+        m[1] = abi.encodeCall(
+            IEnhancedAccessControl.grantRootRoles,
+            (EACBaseRolesLib.ALL_ROLES, admin)
+        );
+
+        UserRegistry r =
+            UserRegistry(
+                factory.deployProxy(
+                    address(implementation),
+                    SALT,
+                    abi.encodeCall(UserRegistry.initialize, (address(0), 0, m))
+                )
+            );
+
+        assertEq(r.findOwner("test"), user1, "owner");
+        //assertTrue(r.hasRootRoles(EACBaseRolesLib.ALL_ROLES, admin), "grant");
     }
 
     function test_initialization() public view {

--- a/contracts/test/unit/resolver/PermissionedResolver.t.sol
+++ b/contracts/test/unit/resolver/PermissionedResolver.t.sol
@@ -83,7 +83,7 @@ contract PermissionedResolverTest is Test {
         assertEq(r.roleCount(r.ROOT_RESOURCE()), 0);
     }
 
-    function test_initalize_with_setters() external {
+    function test_initalize_with_calls() external {
         bytes[] memory m = new bytes[](2);
         m[0] = abi.encodeCall(PermissionedResolver.setName, (testNode, testString));
         m[1] = abi.encodeCall(PermissionedResolver.setContenthash, (testNode, testAddress));
@@ -925,7 +925,7 @@ contract PermissionedResolverTest is Test {
         answers[3] = abi.encode(testAddress);
 
         bytes memory result =
-            resolver.resolve(testName, abi.encodeCall(PermissionedResolver.multicall, (calls)));
+            resolver.resolve(testName, abi.encodeCall(IMulticallable.multicall, (calls)));
         assertEq(result, abi.encode(answers));
     }
 
@@ -945,7 +945,7 @@ contract PermissionedResolverTest is Test {
         );
 
         bytes memory result =
-            resolver.resolve(testName, abi.encodeCall(PermissionedResolver.multicall, (calls)));
+            resolver.resolve(testName, abi.encodeCall(IMulticallable.multicall, (calls)));
         assertEq(result, abi.encode(answers));
     }
 


### PR DESCRIPTION
- changed `UserRegistry`
    * added `bytes[] calldata calls` to `initialize()`
    * removed `InvalidOwner` revert
- changed `PermissionedRegistry`
    * added `multicall()`
- added tests
- updated devnet and fixtures
