### PR TITLE
Add `renewBatch()`

### DIFF
--- a/contracts/script/testNames/registrar.ts
+++ b/contracts/script/testNames/registrar.ts
@@ -201,8 +201,6 @@ export async function renewName(
 
   const duration = BigInt(durationInDays * ONE_DAY_SECONDS);
   const paymentToken = env.erc20.MockUSDC.address;
-  const referrer =
-    "0x0000000000000000000000000000000000000000000000000000000000000000";
 
   const price = await env.v2.ETHRegistrar.read.getRenewPrice([
     label,
@@ -228,9 +226,10 @@ export async function renewName(
   });
 
   const receipt = await env.waitFor(
-    env.v2.ETHRegistrar.write.renew([label, duration, paymentToken, referrer], {
-      account,
-    }),
+    env.v2.ETHRegistrar.write.renew(
+      [{ label, duration, referrer: namehash("referrer") }, paymentToken],
+      { account },
+    ),
   );
 
   const newExpiry = await env.v2.ETHRegistry.read.getExpiry([

--- a/contracts/src/registrar/AbstractETHRegistrar.sol
+++ b/contracts/src/registrar/AbstractETHRegistrar.sol
@@ -8,7 +8,7 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
 import {LibLabel} from "../utils/LibLabel.sol";
 
-import {IETHRenewer} from "./interfaces/IETHRenewer.sol";
+import {IETHRenewer, RenewData} from "./interfaces/IETHRenewer.sol";
 import {IRentPriceOracle} from "./interfaces/IRentPriceOracle.sol";
 
 /// @dev Abstract registrar implementation shared between `ETHRegistrar` and `ETHRenewerV1`.
@@ -81,16 +81,19 @@ abstract contract AbstractETHRegistrar is Ownable, ERC165, IETHRenewer {
     }
 
     /// @inheritdoc IETHRenewer
-    function renew(string calldata label, uint64 duration, IERC20 paymentToken, bytes32 referrer)
-        external
-    {
-        IPermissionedRegistry.State memory state = _requireRenewable(label, duration); // reverts if not
-        uint64 newExpiry = state.expiry + duration; // reverts if overflow
-        uint256 amount = rentPriceOracle.getRenewPrice(label, state.expiry, duration, paymentToken); // reverts if invalid
-        SafeERC20.safeTransferFrom(paymentToken, msg.sender, BENEFICIARY, amount); // reverts if payment failed
-        ETH_REGISTRY.renew(state.tokenId, newExpiry);
-        _onRenew(label, duration);
-        emit NameRenewed(state.tokenId, label, duration, newExpiry, paymentToken, referrer, amount);
+    function renew(RenewData calldata rd, IERC20 paymentToken) external {
+        SafeERC20.safeTransferFrom(paymentToken, msg.sender, BENEFICIARY, _renew(rd, paymentToken)); // reverts if payment failed
+    }
+
+    /// @inheritdoc IETHRenewer
+    function renewBatch(RenewData[] calldata rds, IERC20 paymentToken) external payable {
+        uint256 total;
+        for (uint256 i; i < rds.length; ++i) {
+            total += _renew(rds[i], paymentToken);
+        }
+        if (rds.length > 0) {
+            SafeERC20.safeTransferFrom(paymentToken, msg.sender, BENEFICIARY, total); // reverts if payment failed
+        }
     }
 
     /// @inheritdoc IETHRenewer
@@ -116,6 +119,24 @@ abstract contract AbstractETHRegistrar is Ownable, ERC165, IETHRenewer {
     ////////////////////////////////////////////////////////////////////////
     // Internal Functions
     ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Renew a name and return the amount of `paymentToken`.
+    function _renew(RenewData calldata rd, IERC20 paymentToken) internal returns (uint256 amount) {
+        IPermissionedRegistry.State memory state = _requireRenewable(rd.label, rd.duration); // reverts if not
+        uint64 newExpiry = state.expiry + rd.duration; // reverts if overflow
+        amount = rentPriceOracle.getRenewPrice(rd.label, state.expiry, rd.duration, paymentToken); // reverts if invalid
+        ETH_REGISTRY.renew(state.tokenId, newExpiry);
+        _onRenew(rd.label, rd.duration);
+        emit NameRenewed(
+            state.tokenId,
+            rd.label,
+            rd.duration,
+            newExpiry,
+            paymentToken,
+            rd.referrer,
+            amount
+        );
+    }
 
     /// @dev Callback for when a name is renewed.
     function _onRenew(string calldata label, uint64 duration) internal virtual {}

--- a/contracts/src/registrar/AbstractETHRegistrar.sol
+++ b/contracts/src/registrar/AbstractETHRegistrar.sol
@@ -81,12 +81,17 @@ abstract contract AbstractETHRegistrar is Ownable, ERC165, IETHRenewer {
     }
 
     /// @inheritdoc IETHRenewer
-    function renew(RenewData calldata rd, IERC20 paymentToken) external {
+    function isRenewable(string calldata label) external view returns (bool) {
+        return _isRenewable(ETH_REGISTRY.getState(LibLabel.id(label)));
+    }
+
+    /// @inheritdoc IETHRenewer
+    function renew(RenewData calldata rd, IERC20 paymentToken) public virtual {
         SafeERC20.safeTransferFrom(paymentToken, msg.sender, BENEFICIARY, _renew(rd, paymentToken)); // reverts if payment failed
     }
 
     /// @inheritdoc IETHRenewer
-    function renewBatch(RenewData[] calldata rds, IERC20 paymentToken) external payable {
+    function renewBatch(RenewData[] calldata rds, IERC20 paymentToken) public virtual {
         uint256 total;
         for (uint256 i; i < rds.length; ++i) {
             total += _renew(rds[i], paymentToken);
@@ -94,11 +99,6 @@ abstract contract AbstractETHRegistrar is Ownable, ERC165, IETHRenewer {
         if (rds.length > 0) {
             SafeERC20.safeTransferFrom(paymentToken, msg.sender, BENEFICIARY, total); // reverts if payment failed
         }
-    }
-
-    /// @inheritdoc IETHRenewer
-    function isRenewable(string calldata label) external view returns (bool) {
-        return _isRenewable(ETH_REGISTRY.getState(LibLabel.id(label)));
     }
 
     /// @inheritdoc IETHRenewer

--- a/contracts/src/registrar/ETHRenewerV1.sol
+++ b/contracts/src/registrar/ETHRenewerV1.sol
@@ -127,11 +127,13 @@ contract ETHRenewerV1 is AbstractETHRegistrar {
     /// @inheritdoc IETHRenewer
     function renewBatch(RenewData[] calldata rds, IERC20 paymentToken) public override {
         super.renewBatch(rds, paymentToken);
-        string[] memory labels = new string[](rds.length);
-        for (uint256 i; i < rds.length; ++i) {
-            labels[i] = rds[i].label;
+        if (rds.length > 0) {
+            string[] memory labels = new string[](rds.length);
+            for (uint256 i; i < rds.length; ++i) {
+                labels[i] = rds[i].label;
+            }
+            syncWrapper(labels);
         }
-        syncWrapper(labels);
     }
 
     /// @notice Sync `NameWrapper` expiry with `BaseRegistrarImplementation` expiry.

--- a/contracts/src/registrar/ETHRenewerV1.sol
+++ b/contracts/src/registrar/ETHRenewerV1.sol
@@ -5,12 +5,13 @@ import {
     BaseRegistrarImplementation
 } from "@ens/contracts/ethregistrar/BaseRegistrarImplementation.sol";
 import {INameWrapper} from "@ens/contracts/wrapper/INameWrapper.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
 import {LibLabel} from "../utils/LibLabel.sol";
 
 import {AbstractETHRegistrar} from "./AbstractETHRegistrar.sol";
-import {IETHRenewer} from "./interfaces/IETHRenewer.sol";
+import {IETHRenewer, RenewData} from "./interfaces/IETHRenewer.sol";
 import {IRentPriceOracle} from "./interfaces/IRentPriceOracle.sol";
 
 /// @notice `ETHRegistrarController.renew()` stub interface.
@@ -101,16 +102,6 @@ contract ETHRenewerV1 is AbstractETHRegistrar {
         BASE_REGISTRAR.setResolver(resolver);
     }
 
-    /// @notice Sync `NameWrapper` expiry with `BaseRegistrarImplementation` expiry.
-    /// @param labels The labels to sync.
-    function syncWrapper(string[] calldata labels) external {
-        BASE_REGISTRAR.addController(address(NAME_WRAPPER));
-        for (uint256 i; i < labels.length; ++i) {
-            WRAPPED_CONTROLLER.renew(labels[i], 0);
-        }
-        BASE_REGISTRAR.removeController(address(NAME_WRAPPER));
-    }
-
     /// @inheritdoc IETHRenewer
     function getRemainingGracePeriod(string calldata label) external view returns (uint64) {
         IPermissionedRegistry.State memory state = ETH_REGISTRY.getState(LibLabel.id(label));
@@ -123,6 +114,34 @@ contract ETHRenewerV1 is AbstractETHRegistrar {
             }
         }
         return 0;
+    }
+
+    /// @inheritdoc IETHRenewer
+    function renew(RenewData calldata rd, IERC20 paymentToken) public override {
+        super.renew(rd, paymentToken);
+        string[] memory labels = new string[](1);
+        labels[0] = rd.label;
+        syncWrapper(labels);
+    }
+
+    /// @inheritdoc IETHRenewer
+    function renewBatch(RenewData[] calldata rds, IERC20 paymentToken) public override {
+        super.renewBatch(rds, paymentToken);
+        string[] memory labels = new string[](rds.length);
+        for (uint256 i; i < rds.length; ++i) {
+            labels[i] = rds[i].label;
+        }
+        syncWrapper(labels);
+    }
+
+    /// @notice Sync `NameWrapper` expiry with `BaseRegistrarImplementation` expiry.
+    /// @param labels The labels to sync.
+    function syncWrapper(string[] memory labels) public {
+        BASE_REGISTRAR.addController(address(NAME_WRAPPER));
+        for (uint256 i; i < labels.length; ++i) {
+            WRAPPED_CONTROLLER.renew(labels[i], 0);
+        }
+        BASE_REGISTRAR.removeController(address(NAME_WRAPPER));
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/src/registrar/interfaces/IETHRenewer.sol
+++ b/contracts/src/registrar/interfaces/IETHRenewer.sol
@@ -61,7 +61,7 @@ interface IETHRenewer {
     /// @notice Renew multiple names.
     /// @param rds The renew data.
     /// @param paymentToken The payment token.
-    function renewBatch(RenewData[] calldata rds, IERC20 paymentToken) external payable;
+    function renewBatch(RenewData[] calldata rds, IERC20 paymentToken) external;
 
     /// @notice Determine renew price for a name.
     /// @param label The name to renew.

--- a/contracts/src/registrar/interfaces/IETHRenewer.sol
+++ b/contracts/src/registrar/interfaces/IETHRenewer.sol
@@ -3,8 +3,17 @@ pragma solidity >=0.8.13;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+struct RenewData {
+    /// @param label The name to renew.
+    string label;
+    /// @param duration The duration extension, in seconds.
+    uint64 duration;
+    /// @param referrer The referrer hash.
+    bytes32 referrer;
+}
+
 /// @notice Interface for renewing ".eth" names.
-/// @dev Interface selector: `0x06aaeb32`
+/// @dev Interface selector: `0x37e6a567`
 interface IETHRenewer {
     ////////////////////////////////////////////////////////////////////////
     // Events
@@ -45,12 +54,14 @@ interface IETHRenewer {
     ////////////////////////////////////////////////////////////////////////
 
     /// @notice Renew a name.
-    /// @param label The name to renew.
-    /// @param duration The duration extension, in seconds.
+    /// @param rd The renew data.
     /// @param paymentToken The payment token.
-    /// @param referrer The referrer hash.
-    function renew(string memory label, uint64 duration, IERC20 paymentToken, bytes32 referrer)
-        external;
+    function renew(RenewData calldata rd, IERC20 paymentToken) external;
+
+    /// @notice Renew multiple names.
+    /// @param rds The renew data.
+    /// @param paymentToken The payment token.
+    function renewBatch(RenewData[] calldata rds, IERC20 paymentToken) external payable;
 
     /// @notice Determine renew price for a name.
     /// @param label The name to renew.

--- a/contracts/test/e2e/migration.test.ts
+++ b/contracts/test/e2e/migration.test.ts
@@ -204,7 +204,10 @@ describe("Migration", () => {
         { account },
       );
       await env.v2.ETHRenewerV1.write.renew(
-        [label, duration, env.erc20.MockUSDC.address, namehash("referrer")],
+        [
+          { label, duration, referrer: namehash("referrer") },
+          env.erc20.MockUSDC.address,
+        ],
         { account },
       );
     }

--- a/contracts/test/unit/registrar/ETHRegistrar.t.sol
+++ b/contracts/test/unit/registrar/ETHRegistrar.t.sol
@@ -21,6 +21,11 @@ import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixt
 import {StandardRentPriceOracleFixture} from "~test/fixtures/StandardRentPriceOracleFixture.sol";
 import {StandardRegistrar} from "~test/StandardRegistrar.sol";
 
+// [gas analysis]
+// test_commit(): 24420
+// test_register(): 165841
+// test_renew(): 32012
+
 contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracleFixture {
     ETHRegistrar ethRegistrar;
 
@@ -138,7 +143,10 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
         );
         vm.expectEmit();
         emit IETHRegistrar.CommitmentMade(commitment);
+        uint256 g = gasleft();
         ethRegistrar.commit(commitment);
+        g -= gasleft();
+        console.log("Gas: %s", g);
         assertEq(ethRegistrar.commitmentAt(commitment), block.timestamp, "time");
     }
 
@@ -170,6 +178,30 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
 
     function test_isAvailable_unregistered() external view {
         assertTrue(ethRegistrar.isAvailable(testLabel));
+    }
+
+    function test_register_gas() external {
+        delete testRegistry;
+        delete testResolver;
+        labelStore.setLabel(testLabel);
+
+        ethRegistrar.commit(_makeCommitment());
+        vm.warp(block.timestamp + testCommitDelay);
+
+        vm.prank(testOwner);
+        uint256 g = gasleft();
+        ethRegistrar.register(
+            testLabel,
+            testOwner,
+            testSecret,
+            testRegistry,
+            testResolver,
+            testDuration,
+            testPaymentToken,
+            testReferrer
+        );
+        g -= gasleft();
+        console.log("Gas: %s", g);
     }
 
     function test_register(uint32 available, uint32 duration) external {

--- a/contracts/test/unit/registrar/ETHRegistrar.t.sol
+++ b/contracts/test/unit/registrar/ETHRegistrar.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
 
-// solhint-disable no-console, private-vars-leading-underscore, state-visibility, func-name-mixedcase, contracts-v2/ordering, one-contract-per-file
+import {console} from "forge-std/Test.sol";
 
 import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -14,7 +14,7 @@ import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
 import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
 import {IETHRegistrar} from "~src/registrar/interfaces/IETHRegistrar.sol";
-import {IETHRenewer} from "~src/registrar/interfaces/IETHRenewer.sol";
+import {IETHRenewer, RenewData} from "~src/registrar/interfaces/IETHRenewer.sol";
 import {ETHRegistrar, REGISTRATION_ROLE_BITMAP} from "~src/registrar/ETHRegistrar.sol";
 import {MockERC20, MockERC20Blacklist} from "~test/mocks/MockERC20.sol";
 import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixture.sol";
@@ -425,7 +425,11 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
             testReferrer,
             amount
         );
-        this.renew();
+        vm.prank(testOwner);
+        uint256 g = gasleft();
+        ethRegistrar.renew(RenewData(testLabel, testDuration, testReferrer), testPaymentToken);
+        g -= gasleft();
+        console.log("Gas: %s", g);
         assertEq(ethRegistry.getExpiry(tokenId), newExpiry);
     }
 
@@ -435,8 +439,8 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
         uint256 owner0 = testPaymentToken.balanceOf(testOwner);
         uint256 beneficiary0 = testPaymentToken.balanceOf(beneficiary);
         uint256 amount = ethRegistrar.getRenewPrice(testLabel, duration, testPaymentToken);
-        vm.prank(testOwner);
-        ethRegistrar.renew(testLabel, duration, testPaymentToken, testReferrer);
+        testDuration = duration;
+        this.renew();
         assertEq(owner0 - amount, testPaymentToken.balanceOf(testOwner), "owner");
         assertEq(beneficiary0 + amount, testPaymentToken.balanceOf(beneficiary), "beneficiary");
     }
@@ -499,6 +503,37 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
             )
         );
         this.renew();
+    }
+
+    function test_renewBatch(uint8 n) external {
+        vm.assume(n < 10);
+        RenewData[] memory rds = new RenewData[](n);
+        uint256 total;
+        for (uint256 i; i < n; ++i) {
+            testLabel = _label(i);
+            this.register();
+            uint64 duration = testDuration + uint64(i);
+            rds[i] = RenewData(testLabel, duration, testReferrer);
+            total += ethRegistrar.getRenewPrice(testLabel, duration, testPaymentToken);
+        }
+        uint256 owner0 = testPaymentToken.balanceOf(testOwner);
+        uint256 beneficiary0 = testPaymentToken.balanceOf(beneficiary);
+        vm.prank(testOwner);
+        ethRegistrar.renewBatch(rds, testPaymentToken);
+        assertEq(owner0 - total, testPaymentToken.balanceOf(testOwner), "payer");
+        assertEq(beneficiary0 + total, testPaymentToken.balanceOf(beneficiary), "beneficiary");
+    }
+
+    function test_renewBatch_repeated() external {
+        uint256 tokenId = this.register();
+        RenewData[] memory rds = new RenewData[](2);
+        for (uint256 i; i < rds.length; ++i) {
+            rds[i] = RenewData(testLabel, testDuration, testReferrer);
+        }
+        uint64 expiry = ethRegistry.getExpiry(tokenId);
+        vm.prank(testOwner);
+        ethRegistrar.renewBatch(rds, testPaymentToken);
+        assertEq(ethRegistry.getExpiry(tokenId), expiry + testDuration * rds.length);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -599,6 +634,6 @@ contract ETHRegistrarTest is MigrationControllerFixture, StandardRentPriceOracle
 
     function renew() external {
         vm.prank(testOwner);
-        ethRegistrar.renew(testLabel, testDuration, testPaymentToken, testReferrer);
+        ethRegistrar.renew(RenewData(testLabel, testDuration, testReferrer), testPaymentToken);
     }
 }

--- a/contracts/test/unit/registrar/ETHRenewerV1.t.sol
+++ b/contracts/test/unit/registrar/ETHRenewerV1.t.sol
@@ -11,7 +11,7 @@ import {IBaseRegistrar} from "@ens/contracts/ethregistrar/IBaseRegistrar.sol";
 import {LibLabel} from "~src/utils/LibLabel.sol";
 import {IRegistryEvents} from "~src/registry/interfaces/IRegistryEvents.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
-import {IETHRenewer} from "~src/registrar/interfaces/IETHRenewer.sol";
+import {IETHRenewer, RenewData} from "~src/registrar/interfaces/IETHRenewer.sol";
 import {ETHRenewerV1} from "~src/registrar/ETHRenewerV1.sol";
 import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixture.sol";
 import {StandardRentPriceOracleFixture} from "~test/fixtures/StandardRentPriceOracleFixture.sol";
@@ -135,7 +135,7 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
         );
         vm.prank(testOwner);
         uint256 g = gasleft();
-        ethRenewerV1.renew(testLabel, testDuration, testPaymentToken, testReferrer);
+        ethRenewerV1.renew(RenewData(testLabel, testDuration, testReferrer), testPaymentToken);
         g -= gasleft();
         console.log("Gas: %s", g);
     }
@@ -149,8 +149,8 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
 
         uint256 expiryV1 = baseRegistrar.nameExpires(tokenIdV1);
         uint64 expiryV2 = ethRegistry.getExpiry(tokenIdV1);
-        vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, duration, testPaymentToken, testReferrer);
+        testDuration = duration;
+        this.renew();
 
         assertEq(uint8(getStatusV1(tokenIdV1)), uint8(StatusV1.REGISTERED), "status"); // same
         assertEq(baseRegistrar.nameExpires(tokenIdV1), expiryV1 + duration, "expiryV1");
@@ -178,14 +178,13 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
             "remaining"
         );
 
-        uint64 duration = gracePeriodV1;
-        vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, duration, testPaymentToken, testReferrer);
+        testDuration = gracePeriodV1;
+        this.renew();
 
         assertEq(uint8(getStatusV1(tokenIdV1)), uint8(StatusV1.REGISTERED), "status");
         assertEq(ethRenewerV1.getRemainingGracePeriod(testLabel), 0, "remaining");
-        assertEq(baseRegistrar.nameExpires(tokenIdV1), expiryV1 + duration, "expiryV1");
-        assertEq(ethRegistry.getExpiry(tokenIdV1), expiryV2 + duration, "expiryV2");
+        assertEq(baseRegistrar.nameExpires(tokenIdV1), expiryV1 + testDuration, "expiryV1");
+        assertEq(ethRegistry.getExpiry(tokenIdV1), expiryV2 + testDuration, "expiryV2");
         assertEq(
             baseRegistrar.nameExpires(tokenIdV1) + premigrationBonusPeriod,
             ethRegistry.getExpiry(tokenIdV1),
@@ -200,7 +199,6 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
             graceDebt < gracePeriodV1
         );
         (, uint256 tokenIdV1) = registerUnwrapped(testLabel);
-
         uint256 expiryV1 = baseRegistrar.nameExpires(tokenIdV1);
         uint64 expiryV2 = ethRegistry.getExpiry(tokenIdV1);
 
@@ -208,8 +206,8 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
         assertEq(uint8(getStatusV1(tokenIdV1)), uint8(StatusV1.GRACE), "status0");
         assertTrue(ethRenewerV1.isRenewable(testLabel), "isRenewable");
 
-        vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, duration, testPaymentToken, testReferrer);
+        testDuration = duration;
+        this.renew();
 
         assertEq(uint8(getStatusV1(tokenIdV1)), uint8(StatusV1.GRACE), "status"); // still
         assertEq(
@@ -234,10 +232,9 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
         assertFalse(ethRenewerV1.isRenewable(testLabel), "isRenewable");
         assertEq(ethRenewerV1.getRemainingGracePeriod(testLabel), 0, "remaining");
 
-        uint64 duration = ethRenewerV1.MIN_RENEW_DURATION();
+        testDuration = ethRenewerV1.MIN_RENEW_DURATION();
         vm.expectRevert(abi.encodeWithSelector(IETHRenewer.NameNotRenewable.selector, testLabel));
-        vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, duration, testPaymentToken, testReferrer);
+        this.renew();
     }
 
     function test_renew_balanceChanges(uint32 during, uint32 duration) external {
@@ -249,19 +246,20 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
         uint256 owner0 = testPaymentToken.balanceOf(testOwner);
         uint256 beneficiary0 = testPaymentToken.balanceOf(beneficiary);
         uint256 amount = ethRenewerV1.getRenewPrice(testLabel, duration, testPaymentToken);
-        vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, duration, testPaymentToken, testReferrer);
+        testDuration = duration;
+        this.renew();
         assertEq(owner0 - amount, testPaymentToken.balanceOf(testOwner), "owner");
         assertEq(beneficiary0 + amount, testPaymentToken.balanceOf(beneficiary), "beneficiary");
     }
 
     function test_renew_durationTooShort() external {
-        uint64 min = ethRenewerV1.MIN_RENEW_DURATION();
-        uint64 duration = min - 1;
         registerUnwrapped(testLabel);
-        vm.expectRevert(abi.encodeWithSelector(IETHRenewer.DurationTooShort.selector, duration, min));
-        vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, duration, testPaymentToken, testReferrer);
+        uint64 min = ethRenewerV1.MIN_RENEW_DURATION();
+        testDuration = min - 1;
+        vm.expectRevert(
+            abi.encodeWithSelector(IETHRenewer.DurationTooShort.selector, testDuration, min)
+        );
+        this.renew();
     }
 
     function test_renew_insufficientAllowance() external {
@@ -277,8 +275,7 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
                 amount // needed
             )
         );
-        vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, testDuration, testPaymentToken, testReferrer);
+        this.renew();
     }
 
     function test_renew_insufficientBalance() external {
@@ -293,8 +290,38 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
                 amount // needed
             )
         );
+        this.renew();
+    }
+
+    function test_renewBatch(uint8 n) external {
+        vm.assume(n < 10);
+        RenewData[] memory rds = new RenewData[](n);
+        uint256 total;
+        for (uint256 i; i < n; ++i) {
+            string memory label = _label(i);
+            registerUnwrapped(label);
+            uint64 duration = testDuration + uint64(i);
+            rds[i] = RenewData(label, duration, testReferrer);
+            total += ethRenewerV1.getRenewPrice(label, duration, testPaymentToken);
+        }
+        uint256 owner0 = testPaymentToken.balanceOf(testOwner);
+        uint256 beneficiary0 = testPaymentToken.balanceOf(beneficiary);
         vm.prank(testOwner);
-        ethRenewerV1.renew(testLabel, testDuration, testPaymentToken, testReferrer);
+        ethRenewerV1.renewBatch(rds, testPaymentToken);
+        assertEq(owner0 - total, testPaymentToken.balanceOf(testOwner), "payer");
+        assertEq(beneficiary0 + total, testPaymentToken.balanceOf(beneficiary), "beneficiary");
+    }
+
+    function test_renewBatch_repeated() external {
+        (, uint256 tokenIdV1) = registerUnwrapped(testLabel);
+        RenewData[] memory rds = new RenewData[](2);
+        for (uint256 i; i < rds.length; ++i) {
+            rds[i] = RenewData(testLabel, testDuration, testReferrer);
+        }
+        uint256 expiry = baseRegistrar.nameExpires(tokenIdV1);
+        vm.prank(testOwner);
+        ethRenewerV1.renewBatch(rds, testPaymentToken);
+        assertEq(baseRegistrar.nameExpires(tokenIdV1), expiry + testDuration * rds.length);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -330,6 +357,15 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
             g -= gasleft();
             console.log("%s | %s", n, g);
         }
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Helpers
+    ////////////////////////////////////////////////////////////////////////
+
+    function renew() external {
+        vm.prank(testOwner);
+        ethRenewerV1.renew(RenewData(testLabel, testDuration, testReferrer), testPaymentToken);
     }
 
     function _activateV2(bool on) internal {

--- a/contracts/test/unit/registrar/ETHRenewerV1.t.sol
+++ b/contracts/test/unit/registrar/ETHRenewerV1.t.sol
@@ -349,13 +349,57 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
                 string memory label = labels[i] = _label(k++);
                 registerWrappedETH2LD(label, 0);
                 vm.prank(address(ethControllerV1));
-                baseRegistrar.renew(LibLabel.id(label), 1);
+                baseRegistrar.renew(LibLabel.id(label), 10 ** i);
             }
             _activateV2(true);
             uint256 g = gasleft();
             ethRenewerV1.syncWrapper(labels);
             g -= gasleft();
             console.log("%s | %s", n, g);
+            for (uint256 i; i < n; ++i) {
+                uint256 tokenIdV1 = LibLabel.id(labels[i]);
+                (, , uint64 expiry) =
+                    nameWrapper.getData(
+                        uint256(NameCoder.namehash(NameCoder.ETH_NODE, bytes32(tokenIdV1)))
+                    );
+                assertEq(baseRegistrar.nameExpires(tokenIdV1) + baseRegistrar.GRACE_PERIOD(), expiry);
+            }
+        }
+    }
+
+    function test_renew_autoSync() external {
+        registerWrappedETH2LD(testLabel, 0);
+        uint256 tokenIdV1 = LibLabel.id(testLabel);
+        vm.prank(address(ethControllerV1));
+        baseRegistrar.renew(tokenIdV1, 1);
+        _activateV2(true);
+        this.renew();
+        (, , uint64 expiry) =
+            nameWrapper.getData(uint256(NameCoder.namehash(NameCoder.ETH_NODE, bytes32(tokenIdV1))));
+        assertEq(baseRegistrar.nameExpires(tokenIdV1) + baseRegistrar.GRACE_PERIOD(), expiry);
+    }
+
+    function test_renewBatch_autoSync(uint8 n) external {
+        vm.assume(n < 5);
+        RenewData[] memory rds = new RenewData[](n);
+        for (uint256 i; i < n; ++i) {
+            string memory label = _label(i);
+            rds[i].label = label;
+            rds[i].duration = 1000;
+            registerWrappedETH2LD(label, 0);
+            vm.prank(address(ethControllerV1));
+            baseRegistrar.renew(LibLabel.id(label), 1);
+        }
+        _activateV2(true);
+        vm.prank(testOwner);
+        ethRenewerV1.renewBatch(rds, testPaymentToken);
+        for (uint256 i; i < n; ++i) {
+            uint256 tokenIdV1 = LibLabel.id(rds[i].label);
+            (, , uint64 expiry) =
+                nameWrapper.getData(
+                    uint256(NameCoder.namehash(NameCoder.ETH_NODE, bytes32(tokenIdV1)))
+                );
+            assertEq(baseRegistrar.nameExpires(tokenIdV1) + baseRegistrar.GRACE_PERIOD(), expiry);
         }
     }
 

--- a/contracts/test/unit/registrar/ETHRenewerV1.t.sol
+++ b/contracts/test/unit/registrar/ETHRenewerV1.t.sol
@@ -19,16 +19,16 @@ import {MockERC20} from "~test/mocks/MockERC20.sol";
 import {StandardRegistrar} from "~test/StandardRegistrar.sol";
 
 // [gas analysis]
-// test_renew(): 56159
-// test_syncWrapper_unwrapped(): 52572
+// test_renew(): 80798
+// test_syncWrapper_unwrapped(): 25412
 // test_syncWrapper_wrapped():
 //   N | Gas
-//   0 | 36785
-//   1 | 43289
-//   2 | 47798
-//   3 | 58807
-//   4 | 69819
-//   5 | 80833
+//   0 | 8904
+//   1 | 24626
+//   2 | 31342
+//   3 | 42558
+//   4 | 53787
+//   5 | 65019
 
 contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracleFixture {
     ETHRenewerV1 ethRenewerV1;
@@ -307,7 +307,10 @@ contract ETHRenewerV1Test is MigrationControllerFixture, StandardRentPriceOracle
         uint256 owner0 = testPaymentToken.balanceOf(testOwner);
         uint256 beneficiary0 = testPaymentToken.balanceOf(beneficiary);
         vm.prank(testOwner);
+        uint256 g = gasleft();
         ethRenewerV1.renewBatch(rds, testPaymentToken);
+        g -= gasleft();
+        console.log("Gas: %s", g);
         assertEq(owner0 - total, testPaymentToken.balanceOf(testOwner), "payer");
         assertEq(beneficiary0 + total, testPaymentToken.balanceOf(beneficiary), "beneficiary");
     }


### PR DESCRIPTION
- added `IETHRegistrar.renewBatch()`
    * automatically calls `syncWrapper()`
- changed `IETHRegistrar.renew()` to use `RenewData` struct
    * automatically calls `syncWrapper()`
- added tests

---

~~Note: `renew(RenewData, *)` could stay `renew(label, duration, referrer, *)`~~ frontend likes structs