### PR TITLE
feat: support addr.reverse claims in HCA sessions

### DIFF
--- a/contracts/deploy/hca/01_HCAOwnerAndSessionValidator.ts
+++ b/contracts/deploy/hca/01_HCAOwnerAndSessionValidator.ts
@@ -17,6 +17,9 @@ export default execute(
     const defaultReverseRegistrarAdapter = get<
       (typeof artifacts.DefaultReverseRegistrarAdapter)["abi"]
     >("DefaultReverseRegistrarAdapter");
+    const reverseRegistrarAdapter = get<
+      (typeof artifacts.ReverseRegistrarAdapter)["abi"]
+    >("ReverseRegistrarAdapter");
     const permittedResolverImpl = get<
       (typeof artifacts.PermissionedResolver)["abi"]
     >("PermissionedResolverImpl");
@@ -61,6 +64,7 @@ export default execute(
       artifact: artifacts.HCAOwnerAndSessionValidator,
       args: [
         defaultReverseRegistrarAdapter.address,
+        reverseRegistrarAdapter.address,
         permittedResolverImpl.address,
         ethRegistry.address,
         verifiableFactory.address,
@@ -81,6 +85,7 @@ export default execute(
     ],
     dependencies: [
       "DefaultReverseRegistrarAdapter",
+      "ReverseRegistrarAdapter",
       "PermissionedResolverImpl",
       "ETHRegistry",
       "VerifiableFactory",

--- a/contracts/script/liveHcaRhinestoneRegistration.ts
+++ b/contracts/script/liveHcaRhinestoneRegistration.ts
@@ -47,6 +47,8 @@ import {
   HCAOwnerAndSessionValidator,
   PermissionedRegistry,
   PermissionedResolver,
+  ReverseRegistrar,
+  ReverseRegistrarAdapter,
   StandaloneHCAFactory,
   StandaloneSingleOwnerHCA,
   test_mocks_MockERC20_sol_MockERC20 as MockERC20,
@@ -302,9 +304,11 @@ type HcaDeployments = {
   standaloneHcaImplementation: Address;
   validator: Address;
   defaultReverseRegistrarAdapter: Address;
+  reverseRegistrarAdapter: Address;
   universalResolver: Address;
   v1Registry: Address;
   defaultReverseRegistrar: Address;
+  reverseRegistrar: Address;
   intentExecutor: Address;
   gasRefundPaymaster: Address;
 };
@@ -699,12 +703,18 @@ async function main() {
       ["DefaultReverseRegistrarAdapter"],
       HCA_DEPLOYMENT_NETWORK,
     ),
+    reverseRegistrarAdapter: deploymentFromEnv(
+      "HCA_REVERSE_REGISTRAR_ADAPTER",
+      ["ReverseRegistrarAdapter"],
+      HCA_DEPLOYMENT_NETWORK,
+    ),
     universalResolver: deploymentFromEnv("UNIVERSAL_RESOLVER", [
       "UniversalResolverV2",
       "UniversalResolver",
     ]),
     v1Registry: v1Deployment("ENSRegistry"),
     defaultReverseRegistrar: v1Deployment("DefaultReverseRegistrar"),
+    reverseRegistrar: v1Deployment("ReverseRegistrar"),
     intentExecutor: RHINESTONE_INTENT_EXECUTOR,
     gasRefundPaymaster: RHINESTONE_GAS_REFUND_PAYMASTER,
   };
@@ -749,10 +759,21 @@ async function main() {
     adapterFactory,
     deployments.standaloneHcaFactory,
   );
+  const v1AdapterFactory = (await publicClient.readContract({
+    address: deployments.reverseRegistrarAdapter,
+    abi: ReverseRegistrarAdapter.abi,
+    functionName: "STANDALONE_HCA_FACTORY",
+  })) as Address;
+  assertAddress(
+    "addr.reverse adapter StandaloneHCAFactory",
+    v1AdapterFactory,
+    deployments.standaloneHcaFactory,
+  );
 
   const validatorBindings = await Promise.all(
     [
       "DEFAULT_REVERSE_REGISTRAR_HCA_ADAPTER",
+      "REVERSE_REGISTRAR_HCA_ADAPTER",
       "PERMITTED_RESOLVER_IMPL",
       "ETH_REGISTRY",
       "VERIFIABLE_FACTORY",
@@ -771,6 +792,7 @@ async function main() {
   );
   const [
     boundReverseAdapter,
+    boundV1ReverseAdapter,
     boundResolverImpl,
     boundRegistry,
     boundFactory,
@@ -783,6 +805,11 @@ async function main() {
     "validator reverse adapter",
     boundReverseAdapter,
     deployments.defaultReverseRegistrarAdapter,
+  );
+  assertAddress(
+    "validator addr.reverse adapter",
+    boundV1ReverseAdapter,
+    deployments.reverseRegistrarAdapter,
   );
   assertAddress(
     "validator resolver implementation",
@@ -856,6 +883,17 @@ async function main() {
   });
   if (!adapterIsController) {
     throw new Error("HCA reverse adapter is not a default.reverse controller");
+  }
+  const v1AdapterIsController = await publicClient.readContract({
+    address: deployments.reverseRegistrar,
+    abi: ReverseRegistrar.abi,
+    functionName: "controllers",
+    args: [deployments.reverseRegistrarAdapter],
+  });
+  if (!v1AdapterIsController) {
+    throw new Error(
+      "HCA addr.reverse adapter is not an addr.reverse controller",
+    );
   }
   const implementationIsApproved = await publicClient.readContract({
     address: deployments.standaloneHcaFactory,

--- a/contracts/src/hca/HCAOwnerAndSessionValidator.sol
+++ b/contracts/src/hca/HCAOwnerAndSessionValidator.sol
@@ -1246,7 +1246,8 @@ contract HCAOwnerAndSessionValidator is IValidator {
     /// @dev Checks target, selector, value, and selected ABI arguments for each execution.
     ///      A default reverse name may be updated when the policy has a nonzero resolver and the
     ///      named account is the HCA owner. The owner's `addr.reverse` node may be claimed with
-    ///      either a zero resolver or the session's bound resolver.
+    ///      either a zero resolver or the session's bound resolver; a nonzero claim resolver
+    ///      counts as resolver use and must pass the resolver binding checks.
     /// @param account The HCA that executes the operation.
     /// @param owner The owner recorded for the HCA.
     /// @param allowedResolver The resolver bound to the enabled session.
@@ -1432,8 +1433,11 @@ contract HCAOwnerAndSessionValidator is IValidator {
                     revert PolicyRuleFailed();
                 }
                 address claimResolver = _readAddress(execution.callData, 4 + 32);
-                if (claimResolver != address(0) && claimResolver != policyResolver) {
-                    revert PolicyRuleFailed();
+                if (claimResolver != address(0)) {
+                    if (claimResolver != policyResolver) {
+                        revert PolicyRuleFailed();
+                    }
+                    state.usesResolver = true;
                 }
                 continue;
             }

--- a/contracts/src/hca/HCAOwnerAndSessionValidator.sol
+++ b/contracts/src/hca/HCAOwnerAndSessionValidator.sol
@@ -15,6 +15,12 @@ import {EACBaseRolesLib} from "../access-control/libraries/EACBaseRolesLib.sol";
 import {IETHRegistrar} from "../registrar/interfaces/IETHRegistrar.sol";
 import {IPermissionedRegistry} from "../registry/interfaces/IPermissionedRegistry.sol";
 import {RegistryRolesLib} from "../registry/libraries/RegistryRolesLib.sol";
+import {
+    IDefaultReverseRegistrarAdapter
+} from "../reverse-registrar/interfaces/IDefaultReverseRegistrarAdapter.sol";
+import {
+    IReverseRegistrarAdapter
+} from "../reverse-registrar/interfaces/IReverseRegistrarAdapter.sol";
 
 import {IStandaloneHCAOwner} from "./interfaces/IStandaloneHCAOwner.sol";
 
@@ -36,16 +42,6 @@ interface IHCARegistrationResolver {
     function authorizeNameRoles(bytes calldata name, uint256 roleBitmap, address account, bool grant)
         external
         returns (bool success);
-}
-
-
-/// @notice Reverse-registration call encoded and validated by the HCA registration policy.
-/// @dev Interface selector: `0xab863445`
-interface IHCAReverseRegistrarAdapter {
-    /// @notice Sets the primary name for an account through its HCA.
-    /// @param account The account whose primary name is set.
-    /// @param name The primary name to set.
-    function setNameWithHCA(address account, string calldata name) external;
 }
 
 
@@ -331,7 +327,10 @@ contract HCAOwnerAndSessionValidator is IValidator {
 
     /// @notice Selector for DefaultReverseRegistrarAdapter.setNameWithHCA(address,string).
     bytes4 public constant SET_NAME_WITH_HCA_SELECTOR =
-        IHCAReverseRegistrarAdapter.setNameWithHCA.selector;
+        IDefaultReverseRegistrarAdapter.setNameWithHCA.selector;
+
+    /// @notice Selector for ReverseRegistrarAdapter.claimWithHCA(address,address).
+    bytes4 public constant CLAIM_WITH_HCA_SELECTOR = IReverseRegistrarAdapter.claimWithHCA.selector;
 
     /// @notice Selector for PermissionedResolver.clearRecords(bytes32).
     bytes4 public constant CLEAR_RECORDS_SELECTOR = 0x3603d758;
@@ -375,6 +374,9 @@ contract HCAOwnerAndSessionValidator is IValidator {
 
     /// @notice The HCA-aware default reverse registrar adapter permitted for default primary-name setup.
     address public immutable DEFAULT_REVERSE_REGISTRAR_HCA_ADAPTER;
+
+    /// @notice The HCA-aware `addr.reverse` registrar adapter permitted for v1 reverse claims.
+    address public immutable REVERSE_REGISTRAR_HCA_ADAPTER;
 
     /// @notice The resolver implementation permitted for resolver deployment.
     address public immutable PERMITTED_RESOLVER_IMPL;
@@ -490,6 +492,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
     ////////////////////////////////////////////////////////////////////////
 
     /// @param defaultReverseRegistrarHcaAdapter The HCA-aware default reverse registrar adapter.
+    /// @param reverseRegistrarHcaAdapter The HCA-aware `addr.reverse` registrar adapter.
     /// @param permittedResolverImpl The resolver implementation accepted in resolver deployment actions.
     /// @param ethRegistry The ENS registry that authorizes registrars through its root roles.
     /// @param verifiableFactory The VerifiableFactory accepted by the registration policy.
@@ -499,6 +502,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
     /// @param gasRefundPaymaster The paymaster allowed to settle signed executor refunds.
     constructor(
         address defaultReverseRegistrarHcaAdapter,
+        address reverseRegistrarHcaAdapter,
         address permittedResolverImpl,
         address ethRegistry,
         address verifiableFactory,
@@ -509,6 +513,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
     )
     {
         DEFAULT_REVERSE_REGISTRAR_HCA_ADAPTER = defaultReverseRegistrarHcaAdapter;
+        REVERSE_REGISTRAR_HCA_ADAPTER = reverseRegistrarHcaAdapter;
         PERMITTED_RESOLVER_IMPL = permittedResolverImpl;
         ETH_REGISTRY = ethRegistry;
         VERIFIABLE_FACTORY = verifiableFactory;
@@ -1240,7 +1245,8 @@ contract HCAOwnerAndSessionValidator is IValidator {
     /// @notice Validates every execution against the hardcoded registration and name-management action set.
     /// @dev Checks target, selector, value, and selected ABI arguments for each execution.
     ///      A default reverse name may be updated when the policy has a nonzero resolver and the
-    ///      named account is the HCA owner.
+    ///      named account is the HCA owner. The owner's `addr.reverse` node may be claimed with
+    ///      either a zero resolver or the session's bound resolver.
     /// @param account The HCA that executes the operation.
     /// @param owner The owner recorded for the HCA.
     /// @param allowedResolver The resolver bound to the enabled session.
@@ -1412,6 +1418,21 @@ contract HCAOwnerAndSessionValidator is IValidator {
                 }
                 address namedAccount = _readAddress(execution.callData, 4);
                 if (namedAccount != owner) {
+                    revert PolicyRuleFailed();
+                }
+                continue;
+            }
+
+            if (execution.target == REVERSE_REGISTRAR_HCA_ADAPTER) {
+                if (selector != CLAIM_WITH_HCA_SELECTOR) {
+                    revert ActionNotAllowed(execution.target, selector);
+                }
+                address claimedAccount = _readAddress(execution.callData, 4);
+                if (claimedAccount != owner) {
+                    revert PolicyRuleFailed();
+                }
+                address claimResolver = _readAddress(execution.callData, 4 + 32);
+                if (claimResolver != address(0) && claimResolver != policyResolver) {
                     revert PolicyRuleFailed();
                 }
                 continue;

--- a/contracts/src/hca/HCAOwnerAndSessionValidator.sol
+++ b/contracts/src/hca/HCAOwnerAndSessionValidator.sol
@@ -1245,9 +1245,8 @@ contract HCAOwnerAndSessionValidator is IValidator {
     /// @notice Validates every execution against the hardcoded registration and name-management action set.
     /// @dev Checks target, selector, value, and selected ABI arguments for each execution.
     ///      A default reverse name may be updated when the policy has a nonzero resolver and the
-    ///      named account is the HCA owner. The owner's `addr.reverse` node may be claimed with
-    ///      either a zero resolver or the session's bound resolver; a nonzero claim resolver
-    ///      counts as resolver use and must pass the resolver binding checks.
+    ///      named account is the HCA owner. The owner's `addr.reverse` node may be claimed with a
+    ///      zero resolver or the session's bound resolver; the latter counts as resolver use.
     /// @param account The HCA that executes the operation.
     /// @param owner The owner recorded for the HCA.
     /// @param allowedResolver The resolver bound to the enabled session.

--- a/contracts/src/reverse-registrar/DefaultReverseRegistrarAdapter.sol
+++ b/contracts/src/reverse-registrar/DefaultReverseRegistrarAdapter.sol
@@ -10,12 +10,17 @@ import {IStandaloneHCAFactory} from "../hca/interfaces/IStandaloneHCAFactory.sol
 import {DelegatedContractNamer} from "../utils/DelegatedContractNamer.sol";
 
 import {IContractNamer} from "./interfaces/IContractNamer.sol";
+import {IDefaultReverseRegistrarAdapter} from "./interfaces/IDefaultReverseRegistrarAdapter.sol";
 import {AccountNamerLib} from "./libraries/AccountNamerLib.sol";
 
 /// @title Default Reverse Registrar Adapter
 /// @notice Forwarder for v1 `default.reverse` registrar updates.
 /// @dev The adapter must be configured as a controller on the default reverse registrar.
-contract DefaultReverseRegistrarAdapter is DelegatedContractNamer, HCAAuthorizer {
+contract DefaultReverseRegistrarAdapter is
+    DelegatedContractNamer,
+    HCAAuthorizer,
+    IDefaultReverseRegistrarAdapter
+{
     ////////////////////////////////////////////////////////////////////////
     // Immutables
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/src/reverse-registrar/DefaultReverseRegistrarAdapter.sol
+++ b/contracts/src/reverse-registrar/DefaultReverseRegistrarAdapter.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import {
     IDefaultReverseRegistrar
 } from "@ens/contracts/reverseRegistrar/IDefaultReverseRegistrar.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 import {HCAAuthorizer} from "../hca/HCAAuthorizer.sol";
 import {IStandaloneHCAFactory} from "../hca/interfaces/IStandaloneHCAFactory.sol";
@@ -64,5 +65,12 @@ contract DefaultReverseRegistrarAdapter is
     function setNameWithHCA(address account, string calldata name) external {
         _requireHCAForAccount(account);
         DEFAULT_REVERSE_REGISTRAR.setNameForAddr(account, name);
+    }
+
+    /// @inheritdoc ERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IDefaultReverseRegistrarAdapter).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/src/reverse-registrar/DefaultReverseRegistrarAdapter.sol
+++ b/contracts/src/reverse-registrar/DefaultReverseRegistrarAdapter.sol
@@ -47,6 +47,13 @@ contract DefaultReverseRegistrarAdapter is
         DEFAULT_REVERSE_REGISTRAR = defaultReverseRegistrar;
     }
 
+    /// @inheritdoc ERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IDefaultReverseRegistrarAdapter).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // Implementation
     ////////////////////////////////////////////////////////////////////////
@@ -65,12 +72,5 @@ contract DefaultReverseRegistrarAdapter is
     function setNameWithHCA(address account, string calldata name) external {
         _requireHCAForAccount(account);
         DEFAULT_REVERSE_REGISTRAR.setNameForAddr(account, name);
-    }
-
-    /// @inheritdoc ERC165
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
-        return
-            interfaceId == type(IDefaultReverseRegistrarAdapter).interfaceId ||
-            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/src/reverse-registrar/ReverseRegistrarAdapter.sol
+++ b/contracts/src/reverse-registrar/ReverseRegistrarAdapter.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.25;
 
 import {IReverseRegistrar} from "@ens/contracts/reverseRegistrar/IReverseRegistrar.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 import {HCAAuthorizer} from "../hca/HCAAuthorizer.sol";
 import {IStandaloneHCAFactory} from "../hca/interfaces/IStandaloneHCAFactory.sol";
@@ -65,5 +66,12 @@ contract ReverseRegistrarAdapter is
     function claimWithHCA(address account, address resolver) external returns (bytes32) {
         address hcaOwner = _requireHCAForAccount(account);
         return REVERSE_REGISTRAR.claimForAddr(account, hcaOwner, resolver);
+    }
+
+    /// @inheritdoc ERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IReverseRegistrarAdapter).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/src/reverse-registrar/ReverseRegistrarAdapter.sol
+++ b/contracts/src/reverse-registrar/ReverseRegistrarAdapter.sol
@@ -8,12 +8,17 @@ import {IStandaloneHCAFactory} from "../hca/interfaces/IStandaloneHCAFactory.sol
 import {DelegatedContractNamer} from "../utils/DelegatedContractNamer.sol";
 
 import {IContractNamer} from "./interfaces/IContractNamer.sol";
+import {IReverseRegistrarAdapter} from "./interfaces/IReverseRegistrarAdapter.sol";
 import {AccountNamerLib} from "./libraries/AccountNamerLib.sol";
 
 /// @title Reverse Registrar Adapter
 /// @notice Forwarder for v1 `addr.reverse` registrar updates.
 /// @dev The adapter must be configured as a controller on the reverse registrar.
-contract ReverseRegistrarAdapter is DelegatedContractNamer, HCAAuthorizer {
+contract ReverseRegistrarAdapter is
+    DelegatedContractNamer,
+    HCAAuthorizer,
+    IReverseRegistrarAdapter
+{
     ////////////////////////////////////////////////////////////////////////
     // Immutables
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/src/reverse-registrar/ReverseRegistrarAdapter.sol
+++ b/contracts/src/reverse-registrar/ReverseRegistrarAdapter.sol
@@ -45,6 +45,13 @@ contract ReverseRegistrarAdapter is
         REVERSE_REGISTRAR = reverseRegistrar;
     }
 
+    /// @inheritdoc ERC165
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IReverseRegistrarAdapter).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // Implementation
     ////////////////////////////////////////////////////////////////////////
@@ -66,12 +73,5 @@ contract ReverseRegistrarAdapter is
     function claimWithHCA(address account, address resolver) external returns (bytes32) {
         address hcaOwner = _requireHCAForAccount(account);
         return REVERSE_REGISTRAR.claimForAddr(account, hcaOwner, resolver);
-    }
-
-    /// @inheritdoc ERC165
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
-        return
-            interfaceId == type(IReverseRegistrarAdapter).interfaceId ||
-            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/src/reverse-registrar/interfaces/IDefaultReverseRegistrarAdapter.sol
+++ b/contracts/src/reverse-registrar/interfaces/IDefaultReverseRegistrarAdapter.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {
+    IDefaultReverseRegistrar
+} from "@ens/contracts/reverseRegistrar/IDefaultReverseRegistrar.sol";
+
+/// @title Default Reverse Registrar Adapter Interface
+/// @notice Forwards v1 `default.reverse` registrar updates for contracts and HCAs.
+/// @dev Interface selector: `0x1c946734`
+interface IDefaultReverseRegistrarAdapter {
+    /// @notice Sets account's `default.reverse` primary name.
+    /// @param account The contract address.
+    /// @param name The primary name to store.
+    function setName(address account, string calldata name) external;
+
+    /// @notice Sets account's `default.reverse` primary name through an HCA caller.
+    /// @param account The account to name.
+    /// @param name The primary name to store.
+    function setNameWithHCA(address account, string calldata name) external;
+
+    /// @notice Returns the v1 default reverse registrar for `default.reverse`.
+    function DEFAULT_REVERSE_REGISTRAR() external view returns (IDefaultReverseRegistrar);
+}

--- a/contracts/src/reverse-registrar/interfaces/IReverseRegistrarAdapter.sol
+++ b/contracts/src/reverse-registrar/interfaces/IReverseRegistrarAdapter.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IReverseRegistrar} from "@ens/contracts/reverseRegistrar/IReverseRegistrar.sol";
+
+/// @title Reverse Registrar Adapter Interface
+/// @notice Forwards v1 `addr.reverse` registrar claims for contracts and HCAs.
+/// @dev Interface selector: `0x7deeb961`
+interface IReverseRegistrarAdapter {
+    /// @notice Claims account's `addr.reverse` node and sets its resolver.
+    /// @param account The account to claim.
+    /// @param resolver The resolver to set.
+    /// @return The ENS node hash for the contract's reverse record.
+    function claim(address account, address resolver) external returns (bytes32);
+
+    /// @notice Claims account's `addr.reverse` node through an HCA caller.
+    /// @param account The account to claim.
+    /// @param resolver The resolver to set.
+    /// @return The ENS node hash for the contract's reverse record.
+    function claimWithHCA(address account, address resolver) external returns (bytes32);
+
+    /// @notice Returns the v1 reverse registrar for `addr.reverse`.
+    function REVERSE_REGISTRAR() external view returns (IReverseRegistrar);
+}

--- a/contracts/src/reverse-registrar/interfaces/IReverseRegistrarAdapter.sol
+++ b/contracts/src/reverse-registrar/interfaces/IReverseRegistrarAdapter.sol
@@ -5,7 +5,7 @@ import {IReverseRegistrar} from "@ens/contracts/reverseRegistrar/IReverseRegistr
 
 /// @title Reverse Registrar Adapter Interface
 /// @notice Forwards v1 `addr.reverse` registrar claims for contracts and HCAs.
-/// @dev Interface selector: `0x7deeb961`
+/// @dev Interface selector: `0x7deebf61`
 interface IReverseRegistrarAdapter {
     /// @notice Claims account's `addr.reverse` node and sets its resolver.
     /// @param account The account to claim.

--- a/contracts/test/unit/hca/HCAOwnerAndSessionValidator.t.sol
+++ b/contracts/test/unit/hca/HCAOwnerAndSessionValidator.t.sol
@@ -105,6 +105,7 @@ contract HCAOwnerAndSessionValidatorTest is Test {
         VerifiableFactory factory = new VerifiableFactory();
         validator = new HCAOwnerAndSessionValidatorEnableHarness(
             makeAddr("reverse-adapter"),
+            makeAddr("addr-reverse-adapter"),
             makeAddr("resolver-implementation"),
             address(ethRegistry),
             address(factory),
@@ -1067,6 +1068,7 @@ contract HCAOwnerAndSessionValidatorTest is Test {
 contract HCAOwnerAndSessionValidatorEnableHarness is HCAOwnerAndSessionValidator {
     constructor(
         address defaultReverseRegistrarHCAAdapter,
+        address reverseRegistrarHCAAdapter,
         address permittedResolverImpl,
         address ethRegistry,
         address verifiableFactory,
@@ -1077,6 +1079,7 @@ contract HCAOwnerAndSessionValidatorEnableHarness is HCAOwnerAndSessionValidator
     )
         HCAOwnerAndSessionValidator(
             defaultReverseRegistrarHCAAdapter,
+            reverseRegistrarHCAAdapter,
             permittedResolverImpl,
             ethRegistry,
             verifiableFactory,

--- a/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
+++ b/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
@@ -1315,6 +1315,19 @@ contract StandaloneSingleOwnerHCATest is Test {
         );
     }
 
+    function test_validator_rejectsReverseClaimWithUndeployedResolver() public {
+        address codelessResolver = makeAddr("codeless-resolver");
+        _expectValidationRevert(
+            _singleOperationData(
+                reverseRegistrarHCAAdapter,
+                0,
+                abi.encodeWithSelector(CLAIM_WITH_HCA_SELECTOR, owner, codelessResolver)
+            ),
+            codelessResolver,
+            HCAOwnerAndSessionValidator.PolicyRuleFailed.selector
+        );
+    }
+
     function test_validator_rejectsReverseClaimPolicyViolations() public {
         _expectValidationRevert(
             _singleOperationData(

--- a/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
+++ b/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
@@ -64,6 +64,7 @@ contract StandaloneSingleOwnerHCATest is Test {
     bytes4 constant APPROVE_SELECTOR = 0x095ea7b3;
     bytes4 constant DEPLOY_PROXY_SELECTOR = 0x5d84121a;
     bytes4 constant SET_NAME_WITH_HCA_SELECTOR = 0xab863445;
+    bytes4 constant CLAIM_WITH_HCA_SELECTOR = 0xc90695df;
     bytes4 constant SET_ADDR_SELECTOR = 0xd5fa2b00;
     bytes4 constant SET_TEXT_SELECTOR = 0x10f13a8c;
     bytes4 constant SET_NAME_SELECTOR = 0x77372213;
@@ -78,6 +79,7 @@ contract StandaloneSingleOwnerHCATest is Test {
     address owner = vm.addr(ownerKey);
     address sessionSigner = vm.addr(sessionKey);
     address defaultReverseRegistrarHCAAdapter = makeAddr("default-reverse-adapter");
+    address reverseRegistrarHCAAdapter = makeAddr("addr-reverse-adapter");
     address permittedResolverImpl = makeAddr("resolver-impl");
     address ethRegistrar = makeAddr("eth-registrar");
     address verifiableFactory = makeAddr("verifiable-factory");
@@ -130,6 +132,7 @@ contract StandaloneSingleOwnerHCATest is Test {
 
         validator = new HCAOwnerAndSessionValidator(
             defaultReverseRegistrarHCAAdapter,
+            reverseRegistrarHCAAdapter,
             permittedResolverImpl,
             address(ethRegistry),
             verifiableFactory,
@@ -140,6 +143,7 @@ contract StandaloneSingleOwnerHCATest is Test {
         );
         validatorHarness = new HCAOwnerAndSessionValidatorHarness(
             defaultReverseRegistrarHCAAdapter,
+            reverseRegistrarHCAAdapter,
             permittedResolverImpl,
             address(ethRegistry),
             verifiableFactory,
@@ -679,6 +683,7 @@ contract StandaloneSingleOwnerHCATest is Test {
         HCAOwnerAndSessionValidatorHarness vectorValidator =
             new HCAOwnerAndSessionValidatorHarness(
                 defaultReverseRegistrarHCAAdapter,
+                reverseRegistrarHCAAdapter,
                 permittedResolverImpl,
                 address(ethRegistry),
                 verifiableFactory,
@@ -1271,6 +1276,81 @@ contract StandaloneSingleOwnerHCATest is Test {
             owner,
             resolver,
             _operationData(executions)
+        );
+    }
+
+    function test_validator_acceptsReverseClaimForOwnerWithSessionResolver() public view {
+        validatorHarness.checkRegistrationPolicyHarness(
+            address(hca),
+            owner,
+            resolver,
+            _singleOperationData(
+                reverseRegistrarHCAAdapter,
+                0,
+                abi.encodeWithSelector(CLAIM_WITH_HCA_SELECTOR, owner, resolver)
+            )
+        );
+    }
+
+    function test_validator_acceptsReverseClaimWithZeroResolver() public view {
+        validatorHarness.checkRegistrationPolicyHarness(
+            address(hca),
+            owner,
+            resolver,
+            _singleOperationData(
+                reverseRegistrarHCAAdapter,
+                0,
+                abi.encodeWithSelector(CLAIM_WITH_HCA_SELECTOR, owner, address(0))
+            )
+        );
+        validatorHarness.checkRegistrationPolicyHarness(
+            address(hca),
+            owner,
+            address(0),
+            _singleOperationData(
+                reverseRegistrarHCAAdapter,
+                0,
+                abi.encodeWithSelector(CLAIM_WITH_HCA_SELECTOR, owner, address(0))
+            )
+        );
+    }
+
+    function test_validator_rejectsReverseClaimPolicyViolations() public {
+        _expectValidationRevert(
+            _singleOperationData(
+                reverseRegistrarHCAAdapter,
+                0,
+                abi.encodeWithSelector(COMMIT_SELECTOR, bytes32("commitment"))
+            ),
+            resolver,
+            HCAOwnerAndSessionValidator.ActionNotAllowed.selector
+        );
+        _expectValidationRevert(
+            _singleOperationData(
+                reverseRegistrarHCAAdapter,
+                0,
+                abi.encodeWithSelector(CLAIM_WITH_HCA_SELECTOR, owner, resolver)
+            ),
+            address(0),
+            HCAOwnerAndSessionValidator.PolicyRuleFailed.selector
+        );
+        _expectValidationRevert(
+            _singleOperationData(
+                reverseRegistrarHCAAdapter,
+                0,
+                abi.encodeWithSelector(CLAIM_WITH_HCA_SELECTOR, vm.addr(badKey), resolver)
+            ),
+            resolver,
+            HCAOwnerAndSessionValidator.PolicyRuleFailed.selector
+        );
+        _expectValidationRevert(
+            _singleOperationData(
+                reverseRegistrarHCAAdapter,
+                0,
+                abi.encodeWithSelector(CLAIM_WITH_HCA_SELECTOR, owner, permittedResolverImpl)
+            ),
+            resolver,
+            HCAOwnerAndSessionValidator.PolicyRuleFailed.selector
         );
     }
 
@@ -2326,6 +2406,7 @@ contract StandaloneSingleOwnerHCATest is Test {
 contract HCAOwnerAndSessionValidatorHarness is HCAOwnerAndSessionValidator {
     constructor(
         address defaultReverseRegistrarHCAAdapter,
+        address reverseRegistrarHCAAdapter,
         address permittedResolverImpl,
         address ethRegistry,
         address verifiableFactory,
@@ -2336,6 +2417,7 @@ contract HCAOwnerAndSessionValidatorHarness is HCAOwnerAndSessionValidator {
     )
         HCAOwnerAndSessionValidator(
             defaultReverseRegistrarHCAAdapter,
+            reverseRegistrarHCAAdapter,
             permittedResolverImpl,
             ethRegistry,
             verifiableFactory,

--- a/contracts/test/unit/reverse-registrar/DefaultReverseRegistrarAdapter.t.sol
+++ b/contracts/test/unit/reverse-registrar/DefaultReverseRegistrarAdapter.t.sol
@@ -13,6 +13,9 @@ import {
 } from "~src/reverse-registrar/DefaultReverseRegistrarAdapter.sol";
 import {MockContractNamer} from "~test/mocks/MockContractNamer.sol";
 import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
+import {
+    IDefaultReverseRegistrarAdapter
+} from "~src/reverse-registrar/interfaces/IDefaultReverseRegistrarAdapter.sol";
 import {AccountNamerLib} from "~src/reverse-registrar/libraries/AccountNamerLib.sol";
 import {HCAAuthorizer} from "~src/hca/HCAAuthorizer.sol";
 import {IStandaloneHCAFactory} from "~src/hca/interfaces/IStandaloneHCAFactory.sol";
@@ -66,6 +69,12 @@ contract DefaultReverseRegistrarAdapterTest is HCAFixture {
             ERC165Checker.supportsInterface(
                 address(defaultAdapter),
                 type(IContractNamer).interfaceId
+            )
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(defaultAdapter),
+                type(IDefaultReverseRegistrarAdapter).interfaceId
             )
         );
     }

--- a/contracts/test/unit/reverse-registrar/ReverseRegistrarAdapter.t.sol
+++ b/contracts/test/unit/reverse-registrar/ReverseRegistrarAdapter.t.sol
@@ -11,6 +11,9 @@ import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165C
 import {MockContractNamer} from "~test/mocks/MockContractNamer.sol";
 import {ReverseRegistrarAdapter} from "~src/reverse-registrar/ReverseRegistrarAdapter.sol";
 import {IContractNamer} from "~src/reverse-registrar/interfaces/IContractNamer.sol";
+import {
+    IReverseRegistrarAdapter
+} from "~src/reverse-registrar/interfaces/IReverseRegistrarAdapter.sol";
 import {AccountNamerLib} from "~src/reverse-registrar/libraries/AccountNamerLib.sol";
 import {HCAAuthorizer} from "~src/hca/HCAAuthorizer.sol";
 import {IStandaloneHCAFactory} from "~src/hca/interfaces/IStandaloneHCAFactory.sol";
@@ -70,6 +73,12 @@ contract ReverseRegistrarAdapterTest is HCAFixture {
             ERC165Checker.supportsInterface(
                 address(reverseAdapter),
                 type(IContractNamer).interfaceId
+            )
+        );
+        assertTrue(
+            ERC165Checker.supportsInterface(
+                address(reverseAdapter),
+                type(IReverseRegistrarAdapter).interfaceId
             )
         );
     }

--- a/docs/HCA.md
+++ b/docs/HCA.md
@@ -271,7 +271,8 @@ The reveal is one atomic HCA operation. Set `value` to zero for every inner call
 |     3 | `ETHRegistrar.register(...)`                                                | Use the wallet as owner, the session resolver, and the commitment inputs.                                                                 |
 |     4 | Resolver setters                                                            | Add only the records selected by the user.                                                                                                |
 |     5 | `DefaultReverseRegistrarAdapter.setNameWithHCA(wallet, name)`               | Add this call when the user selects a primary name.                                                                                       |
-|     6 | `PermissionedResolver.authorizeNameRoles(hex"00", ROLES.ALL, wallet, true)` | Include this call in every session registration batch.                                                                                    |
+|     6 | `ReverseRegistrarAdapter.claimWithHCA(wallet, resolver)`                    | Add this call to claim the wallet's `addr.reverse` node. Use the session resolver or the zero address.                                   |
+|     7 | `PermissionedResolver.authorizeNameRoles(hex"00", ROLES.ALL, wallet, true)` | Include this call in every session registration batch.                                                                                    |
 
 The session supports these resolver calls:
 
@@ -298,9 +299,9 @@ The same HCA, resolver, and session can register more names. Each name needs a n
 
 ### Resolver records and primary name
 
-A valid session can change supported resolver records. It can also call `setNameWithHCA(wallet, name)`. These actions do not need a new wallet prompt.
+A valid session can change supported resolver records. It can also call `setNameWithHCA(wallet, name)` and `claimWithHCA(wallet, resolver)`. These actions do not need a new wallet prompt.
 
-The session can select the record values and primary-name string. The HCA must still own the required resolver roles. The reverse adapter must trust the HCA implementation.
+The session can select the record values and primary-name string. The HCA must still own the required resolver roles. The reverse adapter must trust the HCA implementation. A reverse claim must name the wallet and use the session resolver or the zero address.
 
 ### Renewal
 


### PR DESCRIPTION
HCA session batches can only reach the `default.reverse` adapter, so a session-signed registration can't claim the owner's v1 `addr.reverse` node; that currently needs a separate owner-signed step.

changes:
- the session policy accepts `claimWithHCA` on a pinned `ReverseRegistrarAdapter`: only the owner's node, with either a zero resolver or the session's bound resolver
- the validator gains a `REVERSE_REGISTRAR_HCA_ADAPTER` constructor binding, wired from the deployment record in the deploy script
- `IReverseRegistrarAdapter` and `IDefaultReverseRegistrarAdapter` are extracted as real interfaces, both adapters implement them, and the validator's policy selectors derive from them instead of an inline mirror
- tests cover the accepted claims (session resolver and zero resolver) and the rejections (wrong selector, wrong account, mismatched resolver)