### PR TITLE
test: deploy the HCA factory artifact in the migration helper test

### DIFF
--- a/contracts/test/unit/migration/MigrationHelper.t.sol
+++ b/contracts/test/unit/migration/MigrationHelper.t.sol
@@ -14,10 +14,13 @@ import {LockedMigrationController} from "~src/migration/LockedMigrationControlle
 import {WrapperRegistry} from "~src/registry/WrapperRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
 import {MigrationHelper, LockedChildren} from "~src/migration/MigrationHelper.sol";
-import {StandaloneHCAFactory} from "~src/hca/StandaloneHCAFactory.sol";
+import {IStandaloneHCAFactory} from "~src/hca/interfaces/IStandaloneHCAFactory.sol";
 import {MigrationControllerFixture} from "~test/fixtures/MigrationControllerFixture.sol";
 
 contract MigrationHelperTest is MigrationControllerFixture {
+    string internal constant STANDALONE_HCA_FACTORY_ARTIFACT =
+        "src/hca/StandaloneHCAFactory.sol:StandaloneHCAFactory";
+
     UnlockedMigrationController unlockedController;
     LockedMigrationController lockedController;
     WrapperRegistry wrapperRegistryImpl;
@@ -73,7 +76,12 @@ contract MigrationHelperTest is MigrationControllerFixture {
             rootRegistry,
             unlockedController,
             lockedController,
-            new StandaloneHCAFactory(verifiableFactory, address(this)),
+            IStandaloneHCAFactory(
+                deployCode(
+                    STANDALONE_HCA_FACTORY_ARTIFACT,
+                    abi.encode(verifiableFactory, address(this))
+                )
+            ),
             contractNamer
         );
     }


### PR DESCRIPTION
#402 imported the concrete `StandaloneHCAFactory` into `MigrationHelper.t.sol`, which pulls an exact-`0.8.27` source into the migration compilation unit pinned to `0.8.25`. Since #391 pinned the compiler pragmas, no single solc can satisfy that unit, so forge and Hardhat compilation both fail on this branch (the current CI failures here).

changes:
- deploy the factory from its compiled artifact via `deployCode` and type it as `IStandaloneHCAFactory`, matching the `HCAFixture` pattern