### PR TITLE
Add `IPermissionedRegistry.getURI()`

### DIFF
--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -154,7 +154,7 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
         emit ResolverUpdated(tokenId, resolver, msg.sender);
     }
 
-    /// @inheritdoc IStandardRegistry
+    /// @inheritdoc IPermissionedRegistry
     function setURI(string calldata uri_, IRegistryURIRenderer renderer)
         public
         virtual
@@ -262,8 +262,8 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
         return (_parentRegistry, _childLabel);
     }
 
-    /// @inheritdoc IStandardRegistry
-    function getURI() public view returns (string memory uri, IRegistryURIRenderer renderer) {
+    /// @inheritdoc IPermissionedRegistry
+    function getURI() public view returns (string memory uri_, IRegistryURIRenderer renderer) {
         return (_uri, _uriRenderer);
     }
 

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -154,9 +154,7 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
         emit ResolverUpdated(tokenId, resolver, msg.sender);
     }
 
-    /// @notice Set the URI for the registry.
-    /// @param uri_ The new URI.
-    /// @param renderer The new renderer address.
+    /// @inheritdoc IStandardRegistry
     function setURI(string calldata uri_, IRegistryURIRenderer renderer)
         public
         virtual
@@ -262,6 +260,11 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
     /// @inheritdoc IRegistry
     function getParent() public view returns (IRegistry parent, string memory label) {
         return (_parentRegistry, _childLabel);
+    }
+
+    /// @inheritdoc IStandardRegistry
+    function getURI() public view returns (string memory uri, IRegistryURIRenderer renderer) {
+        return (_uri, _uriRenderer);
     }
 
     /// @inheritdoc IContractNamer

--- a/contracts/src/registry/interfaces/IPermissionedRegistry.sol
+++ b/contracts/src/registry/interfaces/IPermissionedRegistry.sol
@@ -4,9 +4,10 @@ pragma solidity >=0.8.13;
 import {IEnhancedAccessControl} from "../../access-control/interfaces/IEnhancedAccessControl.sol";
 import {IContractNamer} from "../../reverse-registrar/interfaces/IContractNamer.sol";
 
+import {IRegistryURIRenderer} from "./IRegistryURIRenderer.sol";
 import {IStandardRegistry} from "./IStandardRegistry.sol";
 
-/// @dev Interface selector: `0x6be50c69`
+/// @dev Interface selector: `0x54d9b3a0`
 interface IPermissionedRegistry is IStandardRegistry, IEnhancedAccessControl, IContractNamer {
     ////////////////////////////////////////////////////////////////////////
     // Types
@@ -48,6 +49,17 @@ interface IPermissionedRegistry is IStandardRegistry, IEnhancedAccessControl, IC
     ////////////////////////////////////////////////////////////////////////
     // Functions
     ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Change metadata parameters.
+    /// @dev Should emit `URIUpdated`.
+    /// @param uri The new URI.
+    /// @param renderer The new renderer address.
+    function setURI(string calldata uri, IRegistryURIRenderer renderer) external;
+
+    /// @notice Get metadata parameters.
+    /// @return uri The metadata URI.
+    /// @return renderer The metadata renderer address.
+    function getURI() external view returns (string memory uri, IRegistryURIRenderer renderer);
 
     /// @notice Get the latest owner of a token.
     ///         If the token was burned, returns null.

--- a/contracts/src/registry/interfaces/IStandardRegistry.sol
+++ b/contracts/src/registry/interfaces/IStandardRegistry.sol
@@ -2,13 +2,12 @@
 pragma solidity >=0.8.13;
 
 import {IRegistry} from "./IRegistry.sol";
-import {IRegistryURIRenderer} from "./IRegistryURIRenderer.sol";
 import {ITemporalRegistry} from "./ITemporalRegistry.sol";
 import {ITokenizedRegistry} from "./ITokenizedRegistry.sol";
 
 /// @title IStandardRegistry
 /// @notice A tokenized registry with registrations that expire.
-/// @dev Interface selector: `0x877814a5`
+/// @dev Interface selector: `0xb844ab6c`
 interface IStandardRegistry is ITemporalRegistry, ITokenizedRegistry {
     ////////////////////////////////////////////////////////////////////////
     // Errors
@@ -83,17 +82,6 @@ interface IStandardRegistry is ITemporalRegistry, ITokenizedRegistry {
     /// @param parent The canonical parent of this registry.
     /// @param label The canonical subdomain of this registry.
     function setParent(IRegistry parent, string calldata label) external;
-
-    /// @notice Change metadata parameters.
-    /// @dev Should emit `URIUpdated`.
-    /// @param uri The new URI.
-    /// @param renderer The new renderer address.
-    function setURI(string calldata uri, IRegistryURIRenderer renderer) external;
-
-    /// @notice Get metadata parameters.
-    /// @return uri The metadata URI.
-    /// @return renderer The metadata renderer address.
-    function getURI() external view returns (string memory uri, IRegistryURIRenderer renderer);
 
     /// @notice Get expiry of label.
     /// @param anyId The labelhash, token ID, or resource.

--- a/contracts/src/registry/interfaces/IStandardRegistry.sol
+++ b/contracts/src/registry/interfaces/IStandardRegistry.sol
@@ -2,12 +2,13 @@
 pragma solidity >=0.8.13;
 
 import {IRegistry} from "./IRegistry.sol";
+import {IRegistryURIRenderer} from "./IRegistryURIRenderer.sol";
 import {ITemporalRegistry} from "./ITemporalRegistry.sol";
 import {ITokenizedRegistry} from "./ITokenizedRegistry.sol";
 
 /// @title IStandardRegistry
 /// @notice A tokenized registry with registrations that expire.
-/// @dev Interface selector: `0xb844ab6c`
+/// @dev Interface selector: `0x877814a5`
 interface IStandardRegistry is ITemporalRegistry, ITokenizedRegistry {
     ////////////////////////////////////////////////////////////////////////
     // Errors
@@ -66,11 +67,13 @@ interface IStandardRegistry is ITemporalRegistry, ITokenizedRegistry {
     function unregister(uint256 anyId) external;
 
     /// @notice Change registry of label.
+    /// @dev Should emit `SubregistryUpdated`.
     /// @param anyId The labelhash, token ID, or resource.
     /// @param registry The new registry.
     function setSubregistry(uint256 anyId, IRegistry registry) external;
 
     /// @notice Change resolver of label.
+    /// @dev Should emit `ResolverUpdated`.
     /// @param anyId The labelhash, token ID, or resource.
     /// @param resolver The new resolver.
     function setResolver(uint256 anyId, address resolver) external;
@@ -80,6 +83,17 @@ interface IStandardRegistry is ITemporalRegistry, ITokenizedRegistry {
     /// @param parent The canonical parent of this registry.
     /// @param label The canonical subdomain of this registry.
     function setParent(IRegistry parent, string calldata label) external;
+
+    /// @notice Change metadata parameters.
+    /// @dev Should emit `URIUpdated`.
+    /// @param uri The new URI.
+    /// @param renderer The new renderer address.
+    function setURI(string calldata uri, IRegistryURIRenderer renderer) external;
+
+    /// @notice Get metadata parameters.
+    /// @return uri The metadata URI.
+    /// @return renderer The metadata renderer address.
+    function getURI() external view returns (string memory uri, IRegistryURIRenderer renderer);
 
     /// @notice Get expiry of label.
     /// @param anyId The labelhash, token ID, or resource.

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -1507,12 +1507,20 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
     }
 
     ////////////////////////////////////////////////////////////////////////
-    // setURI() and uri()
+    // setURI(), getURI(), and uri()
     ////////////////////////////////////////////////////////////////////////
 
     function test_uri_unset() external view {
         assertEq(registry.uri(0), "");
         assertEq(registry.uri(1), "");
+    }
+
+    function test_getURI(string memory uri, address renderer) external {
+        registry.setURI(uri, IRegistryURIRenderer(renderer));
+
+        (string memory uri_, IRegistryURIRenderer renderer_) = registry.getURI();
+        assertEq(uri_, uri, "uri");
+        assertEq(address(renderer_), renderer, "renderer");
     }
 
     function test_setURI_onlyURI() external {


### PR DESCRIPTION
- changed `IPermissionedRegistry`
     * added `setURI(uri, renderer)` &mdash; was just defined on `PermissionedRegistry`
     * added `getURI() returns (uri, renderer)`
- implemented `PermissionedRegistry.getURI()`
- added test