### PR TITLE
perf: reduce first-use HCA registration gas

### DIFF
--- a/contracts/deploy/hca/03_StandaloneHCAImplementation.ts
+++ b/contracts/deploy/hca/03_StandaloneHCAImplementation.ts
@@ -26,6 +26,7 @@ export default execute(
     const validator = get<Abi_HCAOwnerAndSessionValidator>(
       "HCAOwnerAndSessionValidator",
     );
+    const ownerRegistry = get("StandaloneHCAFactory");
     const localExecutor = getOrNull<Abi_MockRegistrationIntentExecutor>(
       "MockRegistrationIntentExecutor",
     );
@@ -61,6 +62,7 @@ export default execute(
         "0x",
         upgradeSet.address,
         zeroAddress,
+        ownerRegistry.address,
       ],
     });
   },
@@ -75,6 +77,7 @@ export default execute(
     dependencies: [
       "HCAOwnerAndSessionValidator",
       "MockRegistrationIntentExecutor",
+      "StandaloneHCAFactory",
     ],
   },
 );

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -43,6 +43,17 @@ const hcaCompiler = {
     outputSelection,
   },
 } as const;
+const hcaHotRuntimeCompiler = {
+  version: hcaVersion,
+  settings: {
+    optimizer: {
+      enabled: true,
+      runs: 23_000,
+    },
+    evmVersion: "cancun",
+    outputSelection,
+  },
+} as const;
 const tenderlySepoliaRpcUrl =
   process.env.TENDERLY_SEPOLIA_RPC_URL ??
   configVariable("TENDERLY_SEPOLIA_RPC_URL");
@@ -62,8 +73,9 @@ const config = {
   solidity: {
     compilers: [protocolCompiler],
     overrides: {
+      "src/hca/HCAValidatorBase.sol": hcaCompiler,
       "src/hca/HCAFundingSessionValidator.sol": hcaCompiler,
-      "src/hca/HCAOwnerAndSessionValidator.sol": hcaCompiler,
+      "src/hca/HCAOwnerAndSessionValidator.sol": hcaHotRuntimeCompiler,
       "src/hca/StandaloneHCAFactory.sol": hcaCompiler,
       "src/hca/StandaloneSingleOwnerHCA.sol": hcaCompiler,
       "src/hca/libraries/HCAExecutionLib.sol": hcaCompiler,

--- a/contracts/script/checkLiveHcaRegistration.ts
+++ b/contracts/script/checkLiveHcaRegistration.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { generatePrivateKey } from "viem/accounts";
 
 import { SEPOLIA_USDC } from "./deploy-constants.ts";
 
@@ -258,7 +258,7 @@ type DeferredSummary = {
     destinationPermissionId: string;
     ownerAuthorizationReused?: boolean;
     sourcePolicyInstalledAtCommit: boolean;
-    destinationEnabledAtCommit: boolean;
+    destinationAuthorizationStateless: boolean;
   };
   routes: { commit: DeferredRoute; reveal: DeferredRoute };
 };
@@ -352,11 +352,12 @@ function deferredOwner(
     state = JSON.parse(readFileSync(stateFile, "utf8")) as LiveState;
   }
   if (!state) {
-    const owner = privateKeyToAccount(key as `0x${string}`);
-    const tag = owner.address.slice(2, 10).toLowerCase();
-    const run = Date.now().toString(36).slice(-6);
+    const run = BigInt(generatePrivateKey())
+      .toString(36)
+      .padStart(8, "0")
+      .slice(-8);
     state = {
-      labels: [`hca${tag}${run}a`, `hca${tag}${run}b`],
+      labels: [`hca${run}a`, `hca${run}b`],
       secrets: [generatePrivateKey(), generatePrivateKey()],
       sessionKey: generatePrivateKey(),
       validUntil: Math.floor(Date.now() / 1000) + 24 * 60 * 60,
@@ -937,7 +938,7 @@ function assertDeferred(summary: DeferredSummary, printResult = true) {
   assert.equal(summary.funds.deliveredAtCommit, "1");
   assert(BigInt(summary.funds.deliveredAtReveal) > 1n);
   assert.equal(summary.sessions.sourcePolicyInstalledAtCommit, true);
-  assert.equal(summary.sessions.destinationEnabledAtCommit, true);
+  assert.equal(summary.sessions.destinationAuthorizationStateless, true);
   assert.equal(summary.routes.commit.sourceSignedBySession, true);
   assert.equal(summary.routes.commit.destinationSignedBySession, true);
   assert.equal(summary.routes.commit.walletSignatures, 0);

--- a/contracts/script/liveHcaRhinestoneRegistration.ts
+++ b/contracts/script/liveHcaRhinestoneRegistration.ts
@@ -66,7 +66,7 @@ import {
   ROLES,
   SEPOLIA_USDC,
 } from "./deploy-constants.js";
-import { ADDR_ABI } from "../test/utils/resolver-abis.ts";
+import { ADDR_ABI, PROFILE_ABI } from "../test/utils/resolver-abis.ts";
 
 const DEPLOYMENT_NETWORK = process.env.DEPLOYMENT_NETWORK ?? "sepolia";
 const HCA_DEPLOYMENT_NETWORK =
@@ -337,6 +337,15 @@ type LiveSessionEnableData = {
   hashesAndChainIds: { chainId: bigint; sessionDigest: Hex }[];
   sessionToEnableIndex: number;
   hcaSessionNonce?: bigint;
+  hcaSessionConfig?: {
+    sessionKey: Address;
+    validUntil: number;
+    resolver: Address;
+    refundToken: Address;
+    maxRefundExchangeRate: bigint;
+    maxRefundGasOverhead: number;
+    maxRefundAmount: bigint;
+  };
 };
 
 function asPrivateKey(value: string): Hex {
@@ -592,23 +601,31 @@ async function ensureFundingSessionValidator() {
     address,
     sourcePublicClient! as unknown as PublicClient,
   );
-  const [intentExecutor, permit2, router] = await Promise.all([
-    sourcePublicClient!.readContract({
-      address,
-      abi: HCAFundingSessionValidator.abi,
-      functionName: "INTENT_EXECUTOR",
-    }),
-    sourcePublicClient!.readContract({
-      address,
-      abi: HCAFundingSessionValidator.abi,
-      functionName: "PERMIT2",
-    }),
-    sourcePublicClient!.readContract({
-      address,
-      abi: HCAFundingSessionValidator.abi,
-      functionName: "ROUTER",
-    }),
-  ]);
+  let bindings: readonly [Address, Address, Address];
+  try {
+    bindings = await Promise.all([
+      sourcePublicClient!.readContract({
+        address,
+        abi: HCAFundingSessionValidator.abi,
+        functionName: "INTENT_EXECUTOR",
+      }),
+      sourcePublicClient!.readContract({
+        address,
+        abi: HCAFundingSessionValidator.abi,
+        functionName: "PERMIT2",
+      }),
+      sourcePublicClient!.readContract({
+        address,
+        abi: HCAFundingSessionValidator.abi,
+        functionName: "ROUTER",
+      }),
+    ]);
+  } catch {
+    throw new Error(
+      `funding-session validator ${address} is incompatible with the stateless HCA source; set HCA_FUNDING_SESSION_VALIDATOR to a compatible deployment`,
+    );
+  }
+  const [intentExecutor, permit2, router] = bindings;
   assertAddress(
     "funding-session validator IntentExecutor",
     intentExecutor,
@@ -679,10 +696,15 @@ async function main() {
   }
 
   const deployments = {
-    verifiableFactory: deployment("VerifiableFactory"),
-    permissionedResolverImpl: deployment("PermissionedResolverImpl"),
-    ethRegistrar: deployment("ETHRegistrar"),
-    ethRegistry: deployment("ETHRegistry"),
+    verifiableFactory: deploymentFromEnv("HCA_VERIFIABLE_FACTORY", [
+      "VerifiableFactory",
+    ]),
+    permissionedResolverImpl: deploymentFromEnv(
+      "HCA_PERMISSIONED_RESOLVER_IMPL",
+      ["PermissionedResolverImpl"],
+    ),
+    ethRegistrar: deploymentFromEnv("HCA_ETH_REGISTRAR", ["ETHRegistrar"]),
+    ethRegistry: deploymentFromEnv("HCA_ETH_REGISTRY", ["ETHRegistry"]),
     paymentToken: deploymentFromEnv("HCA_TEST_PAYMENT_TOKEN", ["MockUSDC"]),
     standaloneHcaFactory: deploymentFromEnv(
       "HCA_STANDALONE_HCA_FACTORY",
@@ -713,9 +735,15 @@ async function main() {
       "UniversalResolverV2",
       "UniversalResolver",
     ]),
-    v1Registry: v1Deployment("ENSRegistry"),
-    defaultReverseRegistrar: v1Deployment("DefaultReverseRegistrar"),
-    reverseRegistrar: v1Deployment("ReverseRegistrar"),
+    v1Registry:
+      (process.env.HCA_V1_REGISTRY as Address | undefined) ??
+      v1Deployment("ENSRegistry"),
+    defaultReverseRegistrar:
+      (process.env.HCA_V1_DEFAULT_REVERSE_REGISTRAR as Address | undefined) ??
+      v1Deployment("DefaultReverseRegistrar"),
+    reverseRegistrar:
+      (process.env.HCA_V1_REVERSE_REGISTRAR as Address | undefined) ??
+      v1Deployment("ReverseRegistrar"),
     intentExecutor: RHINESTONE_INTENT_EXECUTOR,
     gasRefundPaymaster: RHINESTONE_GAS_REFUND_PAYMASTER,
   };
@@ -771,24 +799,31 @@ async function main() {
     deployments.standaloneHcaFactory,
   );
 
-  const validatorBindings = await Promise.all(
-    [
-      "DEFAULT_REVERSE_REGISTRAR_HCA_ADAPTER",
-      "REVERSE_REGISTRAR_HCA_ADAPTER",
-      "PERMITTED_RESOLVER_IMPL",
-      "ETH_REGISTRY",
-      "VERIFIABLE_FACTORY",
-      "INTENT_EXECUTOR",
-      "GAS_REFUND_PAYMASTER",
-    ].map(
-      (functionName) =>
-        publicClient.readContract({
-          address: deployments.validator,
-          abi: HCAOwnerAndSessionValidator.abi,
-          functionName: functionName as never,
-        }) as Promise<Address>,
-    ),
-  );
+  let validatorBindings: Address[];
+  try {
+    validatorBindings = await Promise.all(
+      [
+        "DEFAULT_REVERSE_REGISTRAR_HCA_ADAPTER",
+        "REVERSE_REGISTRAR_HCA_ADAPTER",
+        "PERMITTED_RESOLVER_IMPL",
+        "ETH_REGISTRY",
+        "VERIFIABLE_FACTORY",
+        "INTENT_EXECUTOR",
+        "GAS_REFUND_PAYMASTER",
+      ].map(
+        (functionName) =>
+          publicClient.readContract({
+            address: deployments.validator,
+            abi: HCAOwnerAndSessionValidator.abi,
+            functionName: functionName as never,
+          }) as Promise<Address>,
+      ),
+    );
+  } catch {
+    throw new Error(
+      `destination validator ${deployments.validator} is incompatible with the stateless HCA source; set HCA_OWNER_AND_SESSION_VALIDATOR and HCA_STANDALONE_HCA_IMPLEMENTATION to a compatible deployment`,
+    );
+  }
   const [
     boundReverseAdapter,
     boundV1ReverseAdapter,
@@ -1061,21 +1096,8 @@ async function main() {
 
   let sourceSession: Session | undefined;
   let sourcePermissionId: Hex | undefined;
-  let sourceEnableData:
-    | {
-        userSignature: Hex;
-        hashesAndChainIds: { chainId: bigint; sessionDigest: Hex }[];
-        sessionToEnableIndex: number;
-      }
-    | undefined;
-  let destinationEnableData:
-    | {
-        userSignature: Hex;
-        hashesAndChainIds: { chainId: bigint; sessionDigest: Hex }[];
-        sessionToEnableIndex: number;
-        hcaSessionNonce: bigint;
-      }
-    | undefined;
+  let sourceEnableData: LiveSessionEnableData | undefined;
+  let destinationEnableData: LiveSessionEnableData | undefined;
   let sourceAccount: RhinestoneAccount | undefined;
   if (HCA_CROSS_CHAIN || HCA_SAME_CHAIN_USER_PAID_USDC) {
     if (HCA_CROSS_CHAIN_SOURCE === "eoa") {
@@ -1229,6 +1251,15 @@ async function main() {
         hashesAndChainIds: sessionDetails.hashesAndChainIds,
         sessionToEnableIndex: 0,
         hcaSessionNonce,
+        hcaSessionConfig: {
+          sessionKey: session.address,
+          validUntil: Number(validUntil),
+          resolver,
+          refundToken: deployments.paymentToken,
+          maxRefundExchangeRate: MAX_REFUND_EXCHANGE_RATE,
+          maxRefundGasOverhead: Number(MAX_REFUND_GAS_OVERHEAD),
+          maxRefundAmount: MAX_REFUND_AMOUNT,
+        },
       };
       sourceEnableData = {
         userSignature: multiChainSignature,
@@ -1244,6 +1275,29 @@ async function main() {
         },
       });
     }
+  }
+
+  if (!destinationEnableData) {
+    const sessionDetails =
+      await candidateAccount.experimental_getSessionDetails([sessionConfig]);
+    const sessionAuthorization =
+      HCA_MULTI_CHAIN_SESSION_SIGNATURE ??
+      (await candidateAccount.experimental_signEnableSession(sessionDetails));
+    destinationEnableData = {
+      userSignature: sessionAuthorization,
+      hashesAndChainIds: sessionDetails.hashesAndChainIds,
+      sessionToEnableIndex: 0,
+      hcaSessionNonce,
+      hcaSessionConfig: {
+        sessionKey: session.address,
+        validUntil: Number(validUntil),
+        resolver,
+        refundToken: deployments.paymentToken,
+        maxRefundExchangeRate: MAX_REFUND_EXCHANGE_RATE,
+        maxRefundGasOverhead: Number(MAX_REFUND_GAS_OVERHEAD),
+        maxRefundAmount: MAX_REFUND_AMOUNT,
+      },
+    };
   }
 
   const firstAccount = initiallyDeployed
@@ -1310,9 +1364,6 @@ async function main() {
         paymentToken: deployments.paymentToken,
       });
 
-  const sessionEnabled =
-    await firstAccount.experimental_isSessionEnabled(sessionConfig);
-
   const commitments = await Promise.all(
     labels.map((label, index) =>
       makeCommitment(
@@ -1343,7 +1394,6 @@ async function main() {
         destinationPermissionId: permissionId,
         validUntil,
         initiallyDeployed,
-        destinationSessionEnabled: sessionEnabled,
         sourceWalletSignatureCount: () => sourceWalletSignatureCount,
         hcaOwnerSignatureCount: () => hcaOwnerSignatureCount,
         recordSourceWalletSignature: countSourceWalletSignature,
@@ -1394,30 +1444,6 @@ async function main() {
         | "permit-pull",
     });
     const firstRegistrationCalls: Call[] = [];
-    if (!sessionEnabled) {
-      firstRegistrationCalls.push({
-        to: deployments.validator,
-        value: 0n,
-        data: encodeFunctionData({
-          abi: HCAOwnerAndSessionValidator.abi,
-          functionName: HCA_USER_PAID_USDC
-            ? "enableSessionWithRefund"
-            : "enableSession",
-          args: HCA_USER_PAID_USDC
-            ? [
-                permissionId,
-                session.address,
-                Number(validUntil),
-                resolver,
-                deployments.paymentToken,
-                MAX_REFUND_EXCHANGE_RATE,
-                Number(MAX_REFUND_GAS_OVERHEAD),
-                MAX_REFUND_AMOUNT,
-              ]
-            : [permissionId, session.address, Number(validUntil), resolver],
-        }),
-      });
-    }
     if (HCA_USER_PAID_USDC) {
       firstRegistrationCalls.push({
         to: deployments.ethRegistrar,
@@ -1442,6 +1468,7 @@ async function main() {
       );
     }
 
+    const hcaOwnerSignaturesBeforeFirstRegistration = hcaOwnerSignatureCount;
     const firstRegistration = await executeCrossChainRegistration({
       account: sourceAccount!,
       recipient: recipientAccount.config,
@@ -1469,9 +1496,9 @@ async function main() {
         ? "new-user cross-chain deploy and commit"
         : "new-user cross-chain registration",
     });
-    if (hcaOwnerSignatureCount !== 0) {
+    if (hcaOwnerSignatureCount !== hcaOwnerSignaturesBeforeFirstRegistration) {
       throw new Error(
-        `cross-chain registration requested ${hcaOwnerSignatureCount} additional HCA owner signatures`,
+        "cross-chain registration requested an additional HCA owner signature",
       );
     }
 
@@ -1616,11 +1643,6 @@ async function main() {
       ...baseAccountConfig,
       initData: { address: hca },
     });
-    if (!(await sessionAccount.experimental_isSessionEnabled(sessionConfig))) {
-      throw new Error(
-        "fixed HCA session was not enabled by the Permit2-authorized intent",
-      );
-    }
     const hcaBalanceAfterCrossChain = (await publicClient.readContract({
       address: deployments.paymentToken,
       abi: MockERC20.abi,
@@ -1650,10 +1672,12 @@ async function main() {
           signers: {
             type: "experimental_session",
             session: sessionConfig,
+            enableData: destinationEnableData,
             verifyExecutions: true,
           },
           permissionId,
           expectedMode: MODE_ERC1271,
+          expectedSessionMode: "05",
           expectedSetupOps: 0,
           feeToken: deployments.paymentToken,
           protocolTokenSpend: prices[0],
@@ -1695,10 +1719,12 @@ async function main() {
       signers: {
         type: "experimental_session",
         session: sessionConfig,
+        enableData: destinationEnableData,
         verifyExecutions: true,
       },
       permissionId,
       expectedMode: MODE_ERC1271,
+      expectedSessionMode: "05",
       expectedSetupOps: 0,
       ...(HCA_USER_PAID_USDC && {
         feeToken: deployments.paymentToken,
@@ -1722,10 +1748,12 @@ async function main() {
       signers: {
         type: "experimental_session",
         session: sessionConfig,
+        enableData: destinationEnableData,
         verifyExecutions: true,
       },
       permissionId,
       expectedMode: MODE_ERC1271,
+      expectedSessionMode: "05",
       expectedSetupOps: 0,
       ...(HCA_USER_PAID_USDC && {
         feeToken: deployments.paymentToken,
@@ -1794,56 +1822,28 @@ async function main() {
     return;
   }
 
-  const firstCommitCalls: Call[] = HCA_SAME_CHAIN_USER_PAID_USDC
-    ? []
-    : [...(sameChainFunding?.calls ?? [])];
-  if (!sessionEnabled) {
-    firstCommitCalls.push({
-      to: deployments.validator,
-      value: 0n,
-      data: encodeFunctionData({
-        abi: HCAOwnerAndSessionValidator.abi,
-        functionName: HCA_SAME_CHAIN_USER_PAID_USDC
-          ? "enableSessionWithRefund"
-          : "enableSession",
-        args: HCA_SAME_CHAIN_USER_PAID_USDC
-          ? [
-              permissionId,
-              session.address,
-              Number(validUntil),
-              resolver,
-              deployments.paymentToken,
-              MAX_REFUND_EXCHANGE_RATE,
-              Number(MAX_REFUND_GAS_OVERHEAD),
-              MAX_REFUND_AMOUNT,
-            ]
-          : [permissionId, session.address, Number(validUntil), resolver],
-      }),
-    });
-  }
-  firstCommitCalls.push({
-    to: deployments.ethRegistrar,
-    value: 0n,
-    data: encodeFunctionData({
-      abi: ETHRegistrar.abi,
-      functionName: "commit",
-      args: [commitments[0]],
-    }),
-  });
-
   const firstCommit = await executeIntent({
     account: firstAccount,
-    calls: firstCommitCalls,
-    ...(HCA_SAME_CHAIN_USER_PAID_USDC && {
-      signers: {
-        type: "experimental_session" as const,
-        session: sessionConfig,
-        enableData: destinationEnableData,
-        verifyExecutions: true,
+    calls: [
+      ...(HCA_SAME_CHAIN_USER_PAID_USDC ? [] : (sameChainFunding?.calls ?? [])),
+      {
+        to: deployments.ethRegistrar,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: ETHRegistrar.abi,
+          functionName: "commit",
+          args: [commitments[0]],
+        }),
       },
-      permissionId,
-      ...(destinationEnableData && { expectedSessionMode: "05" as const }),
-    }),
+    ],
+    signers: {
+      type: "experimental_session",
+      session: sessionConfig,
+      enableData: destinationEnableData,
+      verifyExecutions: true,
+    },
+    permissionId,
+    expectedSessionMode: "05",
     expectedMode: MODE_ERC1271,
     expectedSetupOps: initiallyDeployed ? 0 : 1,
     ...(HCA_SAME_CHAIN_USER_PAID_USDC && {
@@ -1857,13 +1857,10 @@ async function main() {
     phase: "new-user commit",
   });
   const expectedSessionAuthorizationSignatures =
-    HCA_SAME_CHAIN_USER_PAID_USDC &&
-    (sessionEnabled || HCA_MULTI_CHAIN_SESSION_SIGNATURE)
-      ? 0
-      : 1;
+    HCA_MULTI_CHAIN_SESSION_SIGNATURE ? 0 : 1;
   if (hcaOwnerSignatureCount !== expectedSessionAuthorizationSignatures) {
     throw new Error(
-      `new-user commit: expected ${expectedSessionAuthorizationSignatures} session authorization signatures, got ${hcaOwnerSignatureCount}`,
+      `same-chain route: expected ${expectedSessionAuthorizationSignatures} session authorization signatures, got ${hcaOwnerSignatureCount}`,
     );
   }
   if (HCA_DRY_RUN_ONLY) {
@@ -1901,10 +1898,12 @@ async function main() {
       signers: {
         type: "experimental_session",
         session: sessionConfig,
+        enableData: destinationEnableData,
         verifyExecutions: true,
       },
       permissionId,
       expectedMode: MODE_ERC1271,
+      expectedSessionMode: "05",
       expectedSetupOps: initiallyDeployed ? 0 : 1,
       phase: "new-user reveal",
     });
@@ -1933,10 +1932,11 @@ async function main() {
     ...baseAccountConfig,
     initData: { address: hca },
   });
-  if (!(await existingAccount.experimental_isSessionEnabled(sessionConfig))) {
-    throw new Error("fixed HCA session was not enabled by the first intent");
+  if (await existingAccount.experimental_isSessionEnabled(sessionConfig)) {
+    throw new Error(
+      "stateless HCA session unexpectedly wrote enablement state",
+    );
   }
-
   const funding = await verifySameChainWalletFunding(
     sameChainFunding!,
     HCA_SAME_CHAIN_USER_PAID_USDC ? firstCommit.feePayment!.totalCharge : 0n,
@@ -1957,10 +1957,12 @@ async function main() {
     signers: {
       type: "experimental_session",
       session: sessionConfig,
+      enableData: destinationEnableData,
       verifyExecutions: true,
     },
     permissionId,
     expectedMode: MODE_ERC1271,
+    expectedSessionMode: "05",
     expectedSetupOps: 0,
     ...(HCA_SAME_CHAIN_USER_PAID_USDC && {
       feeToken: deployments.paymentToken,
@@ -1974,6 +1976,23 @@ async function main() {
     resolver,
     deployments,
     owner.address,
+  );
+  console.error(
+    JSON.stringify(
+      {
+        checkpoint: "new-user registration confirmed",
+        name: `${labels[0]}.eth`,
+        owner: owner.address,
+        hca,
+        resolver,
+        commitTransactionHash: firstCommit.transactionHash,
+        revealTransactionHash: firstReveal.transactionHash,
+        commitGasUsed: firstCommit.gasUsed,
+        revealGasUsed: firstReveal.gasUsed,
+        roundTripGasUsed: firstCommit.gasUsed + firstReveal.gasUsed,
+      },
+      jsonReplacer,
+    ),
   );
 
   const secondCommit = await executeIntent({
@@ -1992,10 +2011,12 @@ async function main() {
     signers: {
       type: "experimental_session",
       session: sessionConfig,
+      enableData: destinationEnableData,
       verifyExecutions: true,
     },
     permissionId,
     expectedMode: MODE_ERC1271,
+    expectedSessionMode: "05",
     expectedSetupOps: 0,
     ...(HCA_SAME_CHAIN_USER_PAID_USDC && {
       feeToken: deployments.paymentToken,
@@ -2018,10 +2039,12 @@ async function main() {
     signers: {
       type: "experimental_session",
       session: sessionConfig,
+      enableData: destinationEnableData,
       verifyExecutions: true,
     },
     permissionId,
     expectedMode: MODE_ERC1271,
+    expectedSessionMode: "05",
     expectedSetupOps: 0,
     ...(HCA_SAME_CHAIN_USER_PAID_USDC && {
       feeToken: deployments.paymentToken,
@@ -2658,7 +2681,6 @@ async function runDeferredCrossChainRegistration({
   destinationPermissionId,
   validUntil,
   initiallyDeployed,
-  destinationSessionEnabled,
   sourceWalletSignatureCount,
   hcaOwnerSignatureCount,
   recordSourceWalletSignature,
@@ -2682,7 +2704,6 @@ async function runDeferredCrossChainRegistration({
   destinationPermissionId: Hex;
   validUntil: bigint;
   initiallyDeployed: boolean;
-  destinationSessionEnabled: boolean;
   sourceWalletSignatureCount: () => number;
   hcaOwnerSignatureCount: () => number;
   recordSourceWalletSignature: () => void;
@@ -2740,36 +2761,17 @@ async function runDeferredCrossChainRegistration({
       walletSignatures: 0,
     };
   } else {
-    const firstCalls: Call[] = [];
-    if (!destinationSessionEnabled) {
-      firstCalls.push({
-        to: deployments.validator,
+    const firstCalls: Call[] = [
+      {
+        to: deployments.ethRegistrar,
         value: 0n,
         data: encodeFunctionData({
-          abi: HCAOwnerAndSessionValidator.abi,
-          functionName: "enableSessionWithRefund",
-          args: [
-            destinationPermissionId,
-            session.address,
-            Number(validUntil),
-            resolver,
-            deployments.paymentToken,
-            MAX_REFUND_EXCHANGE_RATE,
-            Number(MAX_REFUND_GAS_OVERHEAD),
-            MAX_REFUND_AMOUNT,
-          ],
+          abi: ETHRegistrar.abi,
+          functionName: "commit",
+          args: [commitment],
         }),
-      });
-    }
-    firstCalls.push({
-      to: deployments.ethRegistrar,
-      value: 0n,
-      data: encodeFunctionData({
-        abi: ETHRegistrar.abi,
-        functionName: "commit",
-        args: [commitment],
-      }),
-    });
+      },
+    ];
     firstRoute = await executeSessionCrossChainRegistration({
       account: sourceAccount,
       recipient: destinationAccount.config,
@@ -2788,9 +2790,7 @@ async function runDeferredCrossChainRegistration({
           },
           [sepolia.id]: {
             session: destinationSession,
-            ...(!destinationSessionEnabled && {
-              enableData: destinationEnableData,
-            }),
+            enableData: destinationEnableData,
             verifyExecutions: true,
           },
         },
@@ -2798,7 +2798,7 @@ async function runDeferredCrossChainRegistration({
       },
       sourcePermissionId,
       destinationPermissionId,
-      expectedDestinationSessionMode: destinationSessionEnabled ? "03" : "04",
+      expectedDestinationSessionMode: "04",
       expectedSourceSetupOps: 1,
       expectedRecipientSetupOps: initiallyDeployed ? 0 : 1,
       sourceWalletSignatureCount,
@@ -2850,14 +2850,8 @@ async function runDeferredCrossChainRegistration({
     functionName: "isInitialized",
     args: [sourceAddress],
   });
-  const destinationSessionIsEnabled =
-    await destinationSessionAccount.experimental_isSessionEnabled(
-      destinationSession,
-    );
-  if (!sourcePolicyEnabled || !destinationSessionIsEnabled) {
-    throw new Error(
-      "the commit route did not install the source policy and enable the HCA session",
-    );
+  if (!sourcePolicyEnabled) {
+    throw new Error("the commit route did not install the source policy");
   }
 
   const afterCommit = await readDeferredFundingState({
@@ -2922,6 +2916,7 @@ async function runDeferredCrossChainRegistration({
         },
         [sepolia.id]: {
           session: destinationSession,
+          enableData: destinationEnableData,
           verifyExecutions: true,
         },
       },
@@ -2929,7 +2924,7 @@ async function runDeferredCrossChainRegistration({
     },
     sourcePermissionId,
     destinationPermissionId,
-    expectedDestinationSessionMode: "03",
+    expectedDestinationSessionMode: "04",
     expectedSourceSetupOps: 0,
     expectedRecipientSetupOps: 0,
     sourceWalletSignatureCount,
@@ -3038,7 +3033,7 @@ async function runDeferredCrossChainRegistration({
             HCA_MULTI_CHAIN_SESSION_SIGNATURE && !HCA_RESUME_DEFERRED,
           ),
           sourcePolicyInstalledAtCommit: sourcePolicyEnabled,
-          destinationEnabledAtCommit: destinationSessionIsEnabled,
+          destinationAuthorizationStateless: true,
         },
         routes: { commit: firstRoute, reveal: revealRoute },
         registrationPriceBeforeCommit: price,
@@ -4599,39 +4594,63 @@ async function preparePermissionlessCrossChainRegistration({
     await assertCode("permissionlessly deployed HCA", hca);
   }
 
+  const commit = await executePermissionlessCommit({
+    commitment,
+    ethRegistrar: deployments.ethRegistrar,
+    phase: "permissionless cross-chain commit",
+  });
+
+  return {
+    phase: "permissionless deploy and commit",
+    deploymentTransactionHash,
+    commitTransactionHash: commit.transactionHash,
+    deploymentGasUsed,
+    commitGasUsed: commit.gasUsed,
+    gasUsed: deploymentGasUsed + commit.gasUsed,
+  };
+}
+
+async function executePermissionlessCommit({
+  commitment,
+  ethRegistrar,
+  phase,
+}: {
+  commitment: Hex;
+  ethRegistrar: Address;
+  phase: string;
+}) {
   await publicClient.simulateContract({
     account: relayer,
-    address: deployments.ethRegistrar,
+    address: ethRegistrar,
     abi: ETHRegistrar.abi,
     functionName: "commit",
     args: [commitment],
   });
-  const commitTransactionHash = await walletClient.writeContract({
+  const transactionHash = await walletClient.writeContract({
     account: relayer,
     chain: sepolia,
-    address: deployments.ethRegistrar,
+    address: ethRegistrar,
     abi: ETHRegistrar.abi,
     functionName: "commit",
     args: [commitment],
     maxFeePerGas: OPERATOR_MAX_FEE_PER_GAS,
     maxPriorityFeePerGas: OPERATOR_MAX_PRIORITY_FEE_PER_GAS,
   });
-  const commitReceipt = await publicClient.waitForTransactionReceipt({
-    hash: commitTransactionHash,
+  const receipt = await publicClient.waitForTransactionReceipt({
+    hash: transactionHash,
   });
-  if (commitReceipt.status !== "success") {
-    throw new Error(
-      `permissionless commitment reverted: ${commitTransactionHash}`,
-    );
+  if (receipt.status !== "success") {
+    throw new Error(`permissionless commitment reverted: ${transactionHash}`);
   }
 
   return {
-    phase: "permissionless deploy and commit",
-    deploymentTransactionHash,
-    commitTransactionHash,
-    deploymentGasUsed,
-    commitGasUsed: commitReceipt.gasUsed,
-    gasUsed: deploymentGasUsed + commitReceipt.gasUsed,
+    phase,
+    transactionHash,
+    setupOps: 0,
+    mode: "permissionless",
+    gasUsed: receipt.gasUsed,
+    gasRefunds: [],
+    feePayment: undefined,
   };
 }
 
@@ -4975,10 +4994,12 @@ async function waitForCommitment(commitment: Hex, ethRegistrar: Address) {
       functionName: "MIN_COMMITMENT_AGE",
     }) as Promise<bigint>,
   ]);
-  const latest = await publicClient.getBlock();
   const validAt = committedAt + minAge;
-  if (latest.timestamp <= validAt) {
-    await Bun.sleep(Number(validAt - latest.timestamp + 2n) * 1000);
+  let latest = await publicClient.getBlock();
+  while (latest.timestamp <= validAt) {
+    const remaining = validAt - latest.timestamp + 1n;
+    await Bun.sleep(Number(remaining > 2n ? remaining : 2n) * 1000);
+    latest = await publicClient.getBlock();
   }
 }
 
@@ -5008,7 +5029,21 @@ async function registrationCalls({
   const name = `${label}.eth`;
   const calls: Call[] = [];
   const resolverCode = await publicClient.getCode({ address: resolver });
-  if (!resolverCode || resolverCode === "0x") {
+  const deploysResolver = !resolverCode || resolverCode === "0x";
+  if (deploysResolver) {
+    const encodedName = dnsEncodeName(name);
+    const resolverCalls = [
+      encodeFunctionData({
+        abi: PermissionedResolver.abi,
+        functionName: "setAddress",
+        args: [encodedName, COIN_TYPE_ETH, owner.address],
+      }),
+      encodeFunctionData({
+        abi: PermissionedResolver.abi,
+        functionName: "setText",
+        args: [encodedName, "avatar", `https://euc.li/${name}`],
+      }),
+    ];
     calls.push({
       to: deployments.verifiableFactory,
       value: 0n,
@@ -5026,7 +5061,7 @@ async function registrationCalls({
                 { account: hca, roleBitmap: ROLES.ALL },
                 { account: owner.address, roleBitmap: ROLES.ALL },
               ],
-              [],
+              resolverCalls,
             ],
           }),
         ],
@@ -5061,33 +5096,28 @@ async function registrationCalls({
         ],
       }),
     },
-    {
-      to: resolver,
-      value: 0n,
-      data: encodeFunctionData({
-        abi: PermissionedResolver.abi,
-        functionName: "setAddress",
-        args: [dnsEncodeName(name), COIN_TYPE_ETH, owner.address],
-      }),
-    },
-    {
-      to: resolver,
-      value: 0n,
-      data: encodeFunctionData({
-        abi: PermissionedResolver.abi,
-        functionName: "setText",
-        args: [dnsEncodeName(name), "url", `https://example.com/${label}`],
-      }),
-    },
-    {
-      to: resolver,
-      value: 0n,
-      data: encodeFunctionData({
-        abi: PermissionedResolver.abi,
-        functionName: "setName",
-        args: [dnsEncodeName(getReverseName(owner.address)), name],
-      }),
-    },
+    ...(!deploysResolver
+      ? [
+          {
+            to: resolver,
+            value: 0n,
+            data: encodeFunctionData({
+              abi: PermissionedResolver.abi,
+              functionName: "setAddress",
+              args: [dnsEncodeName(name), COIN_TYPE_ETH, owner.address],
+            }),
+          },
+          {
+            to: resolver,
+            value: 0n,
+            data: encodeFunctionData({
+              abi: PermissionedResolver.abi,
+              functionName: "setText",
+              args: [dnsEncodeName(name), "avatar", `https://euc.li/${name}`],
+            }),
+          },
+        ]
+      : []),
     {
       to: deployments.defaultReverseRegistrarAdapter,
       value: 0n,
@@ -5161,13 +5191,42 @@ async function verifyRegistration(
     throw new Error("resolver roles were not retained for both wallet and HCA");
   }
 
-  const resolvedAddress = (await publicClient.readContract({
-    address: resolver,
+  const forwardCall = encodeFunctionData({
     abi: ADDR_ABI,
     functionName: "addr",
     args: [node],
-  })) as Address;
+  });
+  const resolvedAddressData = (await publicClient.readContract({
+    address: resolver,
+    abi: PermissionedResolver.abi,
+    functionName: "resolve",
+    args: [dnsEncodeName(name), forwardCall],
+  })) as Hex;
+  const resolvedAddress = decodeFunctionResult({
+    abi: ADDR_ABI,
+    functionName: "addr",
+    data: resolvedAddressData,
+  }) as Address;
   assertAddress("resolver address", resolvedAddress, expectedOwner);
+  const avatarCall = encodeFunctionData({
+    abi: PROFILE_ABI,
+    functionName: "text",
+    args: [node, "avatar"],
+  });
+  const avatarData = (await publicClient.readContract({
+    address: resolver,
+    abi: PermissionedResolver.abi,
+    functionName: "resolve",
+    args: [dnsEncodeName(name), avatarCall],
+  })) as Hex;
+  const avatar = decodeFunctionResult({
+    abi: PROFILE_ABI,
+    functionName: "text",
+    data: avatarData,
+  }) as string;
+  if (avatar !== `https://euc.li/${name}`) {
+    throw new Error(`resolver avatar=${avatar}`);
+  }
   const defaultPrimary = (await publicClient.readContract({
     address: deployments.defaultReverseRegistrar,
     abi: DefaultReverseRegistrar.abi,
@@ -5198,11 +5257,6 @@ async function verifyRegistration(
     args: [expectedOwner, COIN_TYPE_ETH],
   })) as [string, Address, Address];
   if (reversePrimary !== name) throw new Error(`UR reverse=${reversePrimary}`);
-  const forwardCall = encodeFunctionData({
-    abi: ADDR_ABI,
-    functionName: "addr",
-    args: [node],
-  });
   const [answer] = (await publicClient.readContract({
     address: deployments.universalResolver,
     abi: UniversalResolverV2.abi,

--- a/contracts/src/hca/HCAFundingSessionValidator.sol
+++ b/contracts/src/hca/HCAFundingSessionValidator.sol
@@ -5,13 +5,10 @@ import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC2
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {PackedUserOperation} from "account-abstraction/interfaces/PackedUserOperation.sol";
-import {IValidator} from "nexus/interfaces/modules/IValidator.sol";
-import {
-    ERC1271_MAGICVALUE,
-    MODULE_TYPE_VALIDATOR,
-    VALIDATION_FAILED
-} from "nexus/types/Constants.sol";
+import {ERC1271_MAGICVALUE, VALIDATION_FAILED} from "nexus/types/Constants.sol";
+import {Execution} from "nexus/types/DataTypes.sol";
 
+import {HCAValidatorBase} from "./HCAValidatorBase.sol";
 import {HCAExecutionLib} from "./libraries/HCAExecutionLib.sol";
 import {HCAOperationHashLib} from "./libraries/HCAOperationHashLib.sol";
 import {HCAPermit2Lib} from "./libraries/HCAPermit2Lib.sol";
@@ -39,7 +36,7 @@ interface IRhinestoneClaimRouter {
 /// @dev The Nexus installs one session during account creation. The session can pull the
 ///      owner's permitted token into the Nexus and sign a Permit2 claim that delivers the
 ///      configured token to the configured HCA.
-contract HCAFundingSessionValidator is IValidator {
+contract HCAFundingSessionValidator is HCAValidatorBase {
     ////////////////////////////////////////////////////////////////////////
     // Types
     ////////////////////////////////////////////////////////////////////////
@@ -58,28 +55,15 @@ contract HCAFundingSessionValidator is IValidator {
         uint96 maxDestinationAmount;
     }
 
-    /// @notice One ERC-7579 execution.
-    struct Execution {
-        address target;
-        uint256 value;
-        bytes callData;
-    }
-
     /// @notice Operation supplied by the IntentExecutor.
     struct Operation {
         bytes data;
     }
 
-    /// @dev One chain and session digest from a standard Rhinestone multi-chain session authorization.
-    struct HashAndChainId {
-        uint64 chainId;
-        bytes32 sessionDigest;
-    }
-
-    /// @dev The reusable owner authorization supplied with each source claim.
+    /// @notice Reusable owner authorization represented for off-chain construction.
     struct FundingAuthorizationProof {
         uint8 sessionToEnableIndex;
-        HashAndChainId[] hashesAndChainIds;
+        HCASmartSessionLib.HashAndChainId[] hashesAndChainIds;
         bytes32 ownerR;
         bytes32 ownerS;
         uint8 ownerV;
@@ -92,22 +76,12 @@ contract HCAFundingSessionValidator is IValidator {
     /// @dev Fixed source-session mode carrying the reusable multi-chain owner authorization.
     bytes1 internal constant FUNDING_SESSION_MODE = 0x04;
 
-    /// @dev Size of the mode, permission ID, and four-byte authorization-proof length.
-    uint256 internal constant FUNDING_SESSION_PREFIX_LENGTH = 37;
+    /// @dev Selected-session index and entry count preceding packed chain sessions.
+    uint256 private constant _FUNDING_PROOF_HEADER_LENGTH = 2;
 
-    /// @dev Size of the fixed signature and claim data following the authorization proof.
-    uint256 internal constant FUNDING_SESSION_SUFFIX_LENGTH =
-        HCASignatureLib.SIGNATURE_LENGTH + HCAPermit2Lib.CLAIM_DATA_LENGTH;
-
-    /// @notice Rhinestone operation mode for ERC-1271 ERC-7579 execution.
-    bytes32 public constant ERC7579_ERC1271_MODE = bytes32(uint256(0x0201) << 240);
-
-    /// @notice Rhinestone operation mode for emissary ERC-7579 execution.
-    bytes32 public constant ERC7579_EMISSARY_EXECUTION_MODE = bytes32(uint256(0x0204) << 240);
-
-    /// @notice Rhinestone operation mode for ERC-1271 with emissary-execution fallback.
-    bytes32 public constant ERC7579_ERC1271_EMISSARY_EXECUTION_MODE =
-        bytes32(uint256(0x0206) << 240);
+    /// @dev Fixed proof bytes including the owner signature but excluding chain entries.
+    uint256 private constant _FUNDING_PROOF_BASE_LENGTH =
+        _FUNDING_PROOF_HEADER_LENGTH + HCASignatureLib.SIGNATURE_LENGTH;
 
     /// @notice Rhinestone protocol version used by the supported Across claim.
     bytes2 public constant RHINESTONE_PROTOCOL_VERSION = 0x0001;
@@ -265,25 +239,9 @@ contract HCAFundingSessionValidator is IValidator {
         if (sender != PERMIT2 && sender != INTENT_EXECUTOR) {
             revert UnauthorizedCaller();
         }
-        SessionConfig storage config = _sessions[msg.sender];
+        SessionConfig memory config = _sessions[msg.sender];
         _validateFundingClaim(hash, data, config);
         return ERC1271_MAGICVALUE;
-    }
-
-    /// @notice Reports the permission as disabled so the SDK includes its reusable owner proof.
-    /// @dev The validator does not store the owner authorization. Each claim must carry the same
-    ///      standard multi-chain signature, so returning true here would let the SDK omit it.
-    /// @param account Unused source Nexus address.
-    /// @param permissionId Unused session permission identifier.
-    /// @return Always false.
-    function isPermissionEnabled(address account, bytes32 permissionId)
-        external
-        pure
-        returns (bool)
-    {
-        account;
-        permissionId;
-        return false;
     }
 
     /// @notice Rejects the separate emissary-execution path.
@@ -324,19 +282,12 @@ contract HCAFundingSessionValidator is IValidator {
         return VALIDATION_FAILED;
     }
 
-    /// @notice Returns whether this module is an ERC-7579 validator.
-    /// @param moduleTypeId The module type to inspect.
-    /// @return True only for the validator module type.
-    function isModuleType(uint256 moduleTypeId) external pure returns (bool) {
-        return moduleTypeId == MODULE_TYPE_VALIDATOR;
-    }
-
     ////////////////////////////////////////////////////////////////////////
     // Internal Functions
     ////////////////////////////////////////////////////////////////////////
 
     /// @dev Loads and validates the installed session for a permission identifier.
-    function _validateConfig(SessionConfig storage config, bytes32 permissionId) internal view {
+    function _validateConfig(SessionConfig memory config, bytes32 permissionId) internal view {
         if (config.sessionKey == address(0) || config.permissionId != permissionId) {
             revert InvalidSession();
         }
@@ -346,29 +297,35 @@ contract HCAFundingSessionValidator is IValidator {
     }
 
     /// @dev Decodes and validates one fixed source funding envelope.
-    function _validateFundingClaim(bytes32 hash, bytes calldata data, SessionConfig storage config)
+    function _validateFundingClaim(bytes32 hash, bytes calldata data, SessionConfig memory config)
         internal
         view
     {
-        if (data.length <= FUNDING_SESSION_PREFIX_LENGTH + FUNDING_SESSION_SUFFIX_LENGTH) {
+        (
+            bytes32 permissionId,
+            uint256 selectedIndex,
+            bytes calldata packedSessions,
+            bytes calldata ownerSignature,
+            uint256 proofEnd
+        ) =
+            _decodeFundingAuthorization(
+                data,
+                HCASignatureLib.SIGNATURE_LENGTH + HCAPermit2Lib.CLAIM_DATA_LENGTH
+            );
+        if (proofEnd == 0 || data[0] != FUNDING_SESSION_MODE) {
             revert InvalidSession();
         }
-
-        bytes32 permissionId = bytes32(data[1:33]);
         _validateConfig(config, permissionId);
-        if (data[0] != FUNDING_SESSION_MODE) {
-            revert InvalidSession();
-        }
-
-        uint256 proofLength = uint32(bytes4(data[33:37]));
-        uint256 proofEnd = FUNDING_SESSION_PREFIX_LENGTH + proofLength;
-        uint256 operationOffset = proofEnd + FUNDING_SESSION_SUFFIX_LENGTH;
-        if (proofLength == 0 || operationOffset >= data.length) {
-            revert InvalidSession();
-        }
-        FundingAuthorizationProof memory proof =
-            abi.decode(data[FUNDING_SESSION_PREFIX_LENGTH:proofEnd], (FundingAuthorizationProof));
-        _validateMultiChainAuthorization(msg.sender, config, permissionId, proof);
+        uint256 operationOffset =
+            proofEnd + HCASignatureLib.SIGNATURE_LENGTH + HCAPermit2Lib.CLAIM_DATA_LENGTH;
+        _validateMultiChainAuthorization(
+            msg.sender,
+            config,
+            permissionId,
+            selectedIndex,
+            packedSessions,
+            ownerSignature
+        );
         _validateSignedPermit2Claim(hash, data, proofEnd, operationOffset, config);
     }
 
@@ -378,7 +335,7 @@ contract HCAFundingSessionValidator is IValidator {
         bytes calldata data,
         uint256 proofEnd,
         uint256 operationOffset,
-        SessionConfig storage config
+        SessionConfig memory config
     )
         internal
         view
@@ -397,10 +354,15 @@ contract HCAFundingSessionValidator is IValidator {
         bytes calldata claimData = data[claimOffset:operationOffset];
         bytes calldata operationData = data[operationOffset:];
         uint256 claimSourceAmount = _validatePermit2Claim(hash, claimData, config);
-        if (_operationHash(operationData) != _readWord(claimData, 314)) {
+        if (operationData.length < 3) {
+            revert InvalidOperation();
+        }
+        (HCAOperationHashLib.DecodedOperation memory operation, bytes32 operationHash) =
+            HCAOperationHashLib.decodeAndHash(operationData);
+        if (operationHash != _readWord(claimData, 314)) {
             revert ClaimFieldMismatch(10);
         }
-        if (_validateFundingOperation(msg.sender, config, operationData) != claimSourceAmount) {
+        if (_validateFundingOperation(msg.sender, config, operation) != claimSourceAmount) {
             revert FundingPolicyFailed();
         }
     }
@@ -408,87 +370,49 @@ contract HCAFundingSessionValidator is IValidator {
     /// @dev Verifies the reusable owner signature and the selected chain session.
     function _validateMultiChainAuthorization(
         address account,
-        SessionConfig storage config,
+        SessionConfig memory config,
         bytes32 permissionId,
-        FundingAuthorizationProof memory proof
+        uint256 selectedIndex,
+        bytes calldata packedSessions,
+        bytes calldata ownerSignature
     )
         internal
         view
     {
-        uint256 count = proof.hashesAndChainIds.length;
-        uint256 selectedIndex = proof.sessionToEnableIndex;
-        if (count == 0 || selectedIndex >= count) {
-            revert InvalidSession();
-        }
-
         bytes32 salt = _fundingAuthorizationSalt(config);
         (bytes32 expectedPermissionId, bytes32 expectedSessionDigest) =
             HCASmartSessionLib.authorizationHashes(account, config.sessionKey, salt);
         if (permissionId != expectedPermissionId) {
             revert InvalidSession();
         }
-        HashAndChainId memory selected = proof.hashesAndChainIds[selectedIndex];
-        if (selected.chainId != block.chainid || selected.sessionDigest != expectedSessionDigest) {
-            revert InvalidSession();
-        }
-
-        bytes32[] memory chainSessionHashes = new bytes32[](count);
-        for (uint256 i; i < count; ++i) {
-            HashAndChainId memory item = proof.hashesAndChainIds[i];
-            chainSessionHashes[i] = HCASmartSessionLib.chainSessionHash(
-                item.chainId,
-                item.sessionDigest
-            );
-        }
-        bytes32 digest = HCASmartSessionLib.multiChainDigest(chainSessionHashes);
         if (
-            HCASignatureLib.recover(digest, proof.ownerR, proof.ownerS, proof.ownerV) !=
-            config.owner
+            HCASmartSessionLib.validateMultiChainAuthorization(
+                config.owner,
+                expectedSessionDigest,
+                selectedIndex,
+                packedSessions,
+                ownerSignature
+            ) !=
+            HCASmartSessionLib.AuthorizationStatus.Valid
         ) {
             revert InvalidSession();
         }
     }
 
-    /// @dev Hashes the fields fixed by one source funding session.
-    function _fundingAuthorizationSalt(SessionConfig storage config)
-        internal
-        view
-        returns (bytes32)
-    {
-        return
-            keccak256(
-                abi.encode(
-                    config.owner,
-                    config.validUntil,
-                    config.sourceToken,
-                    config.destinationRecipient,
-                    config.destinationToken,
-                    config.destinationChainId,
-                    config.maxSourceAmount,
-                    config.maxDestinationAmount
-                )
-            );
-    }
-
     /// @dev Validates the source calls and returns the amount pulled from the owner.
     function _validateFundingOperation(
         address account,
-        SessionConfig storage config,
-        bytes calldata operationData
+        SessionConfig memory config,
+        HCAOperationHashLib.DecodedOperation memory operation
     )
         internal
         view
         returns (uint256 totalPulled)
     {
-        if (operationData.length < 32) {
+        if (!HCAOperationHashLib.isSupportedMode(operation.mode)) {
             revert InvalidOperation();
         }
-        bytes32 mode = bytes32(operationData[:32]);
-        if (!HCAOperationHashLib.isSupportedMode(mode)) {
-            revert InvalidOperation();
-        }
-
-        Execution[] memory executions = abi.decode(operationData[32:], (Execution[]));
+        Execution[] memory executions = operation.executions;
         uint256 approvedAmount;
         uint256 approvalCount;
         uint256 permitCount;
@@ -539,7 +463,7 @@ contract HCAFundingSessionValidator is IValidator {
     function _validatePermit2Claim(
         bytes32 expectedDigest,
         bytes calldata data,
-        SessionConfig storage config
+        SessionConfig memory config
     )
         internal
         view
@@ -557,7 +481,7 @@ contract HCAFundingSessionValidator is IValidator {
     }
 
     /// @dev Decodes the route fields and checks them against the installed session.
-    function _decodeAndValidateClaim(bytes calldata data, SessionConfig storage config)
+    function _decodeAndValidateClaim(bytes calldata data, SessionConfig memory config)
         internal
         view
         returns (HCAPermit2Lib.Claim memory claim)
@@ -604,12 +528,60 @@ contract HCAFundingSessionValidator is IValidator {
         }
     }
 
-    /// @dev Hashes an encoded ERC-7579 operation.
-    function _operationHash(bytes calldata operationData) internal pure returns (bytes32) {
-        if (operationData.length < 32) {
-            revert InvalidOperation();
+    /// @dev Locates the packed multi-chain authorization and its trailing owner signature.
+    ///      Returns a zero proof end when the envelope cannot contain the required tail.
+    function _decodeFundingAuthorization(bytes calldata data, uint256 tailLength)
+        internal
+        pure
+        returns (
+            bytes32 permissionId,
+            uint256 selectedIndex,
+            bytes calldata packedSessions,
+            bytes calldata ownerSignature,
+            uint256 proofEnd
+        )
+    {
+        packedSessions = data[0:0];
+        ownerSignature = data[0:0];
+        uint256 proofOffset = HCASmartSessionLib.ENABLE_PREFIX_LENGTH;
+        if (data.length <= proofOffset + _FUNDING_PROOF_BASE_LENGTH + tailLength) {
+            return (permissionId, selectedIndex, packedSessions, ownerSignature, 0);
         }
-        return HCAOperationHashLib.hash(operationData);
+
+        permissionId = bytes32(data[1:proofOffset]);
+        selectedIndex = uint8(data[proofOffset]);
+        uint256 chainCount = uint8(data[proofOffset + 1]);
+        if (chainCount == 0) {
+            return (permissionId, selectedIndex, packedSessions, ownerSignature, 0);
+        }
+
+        uint256 sessionsOffset = proofOffset + _FUNDING_PROOF_HEADER_LENGTH;
+        uint256 signatureOffset =
+            sessionsOffset + chainCount * HCASmartSessionLib.AUTHORIZATION_ENTRY_LENGTH;
+        proofEnd = signatureOffset + HCASignatureLib.SIGNATURE_LENGTH;
+        if (proofEnd + tailLength >= data.length) {
+            return (permissionId, selectedIndex, packedSessions, ownerSignature, 0);
+        }
+
+        packedSessions = data[sessionsOffset:signatureOffset];
+        ownerSignature = data[signatureOffset:proofEnd];
+    }
+
+    /// @dev Hashes the fields fixed by one source funding session.
+    function _fundingAuthorizationSalt(SessionConfig memory config) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    config.owner,
+                    config.validUntil,
+                    config.sourceToken,
+                    config.destinationRecipient,
+                    config.destinationToken,
+                    config.destinationChainId,
+                    config.maxSourceAmount,
+                    config.maxDestinationAmount
+                )
+            );
     }
 
     /// @dev Reads a function selector from ABI call data.
@@ -638,20 +610,6 @@ contract HCAFundingSessionValidator is IValidator {
         if (data.length < offset + 32) {
             revert ClaimPolicyFailed();
         }
-        assembly ("memory-safe") {
-            value := calldataload(add(data.offset, offset))
-        }
-    }
-
-    /// @dev Recovers a Rhinestone signature and maps malformed signatures to `InvalidSession`.
-    function _recover(bytes32 digest, bytes calldata signature)
-        internal
-        pure
-        returns (address signer)
-    {
-        signer = HCASignatureLib.recover(digest, signature);
-        if (signer == address(0)) {
-            revert InvalidSession();
-        }
+        return bytes32(data[offset:offset + 32]);
     }
 }

--- a/contracts/src/hca/HCAOwnerAndSessionValidator.sol
+++ b/contracts/src/hca/HCAOwnerAndSessionValidator.sol
@@ -1,30 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import {IMulticallable} from "@ens/contracts/resolvers/IMulticallable.sol";
 import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
 import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
 import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {PackedUserOperation} from "account-abstraction/interfaces/PackedUserOperation.sol";
-import {IValidator} from "nexus/interfaces/modules/IValidator.sol";
-import {
-    ERC1271_MAGICVALUE,
-    MODULE_TYPE_VALIDATOR,
-    VALIDATION_FAILED,
-    VALIDATION_SUCCESS
-} from "nexus/types/Constants.sol";
+import {ERC1271_MAGICVALUE, VALIDATION_FAILED, VALIDATION_SUCCESS} from "nexus/types/Constants.sol";
+import {Execution} from "nexus/types/DataTypes.sol";
 
 import {IETHRegistrar} from "../registrar/interfaces/IETHRegistrar.sol";
-import {IPermissionedResolver} from "../resolver/interfaces/IPermissionedResolver.sol";
-import {IABISetter} from "../resolver/interfaces/setters/IABISetter.sol";
-import {IAddressSetter} from "../resolver/interfaces/setters/IAddressSetter.sol";
-import {IContenthashSetter} from "../resolver/interfaces/setters/IContenthashSetter.sol";
-import {IDataSetter} from "../resolver/interfaces/setters/IDataSetter.sol";
-import {IInterfaceSetter} from "../resolver/interfaces/setters/IInterfaceSetter.sol";
-import {INameSetter} from "../resolver/interfaces/setters/INameSetter.sol";
-import {ITextSetter} from "../resolver/interfaces/setters/ITextSetter.sol";
 import {
     IDefaultReverseRegistrarAdapter
 } from "../reverse-registrar/interfaces/IDefaultReverseRegistrarAdapter.sol";
@@ -32,6 +18,7 @@ import {
     IReverseRegistrarAdapter
 } from "../reverse-registrar/interfaces/IReverseRegistrarAdapter.sol";
 
+import {HCAValidatorBase} from "./HCAValidatorBase.sol";
 import {IStandaloneHCAOwner} from "./interfaces/IStandaloneHCAOwner.sol";
 import {HCAExecutionLib} from "./libraries/HCAExecutionLib.sol";
 import {HCAOperationHashLib} from "./libraries/HCAOperationHashLib.sol";
@@ -43,25 +30,13 @@ import {HCASmartSessionLib} from "./libraries/HCASmartSessionLib.sol";
 
 /// @title HCA Owner and Session Validator
 /// @notice Fixed validator for standalone HCA owner authorization and scoped ENS sessions.
-/// @dev Owner signatures use Rhinestone's existing HCA format. Sessions are enabled by an
-///      owner-authorized HCA call and consumed through the IntentExecutor's ERC-1271 path. The
-///      permission checks remain hardcoded here rather than in dynamic policy modules.
-contract HCAOwnerAndSessionValidator is IValidator {
+/// @dev Owner signatures use Rhinestone's existing HCA format. Session operations carry a
+///      reusable owner authorization and are consumed through the IntentExecutor's ERC-1271 path.
+///      The permission checks remain hardcoded here rather than in dynamic policy modules.
+contract HCAOwnerAndSessionValidator is HCAValidatorBase {
     ////////////////////////////////////////////////////////////////////////
     // Types
     ////////////////////////////////////////////////////////////////////////
-
-    /// @notice A single ERC-7579 execution.
-    struct Execution {
-        address target;
-        uint256 value;
-        bytes callData;
-    }
-
-    /// @notice Operation supplied by the IntentExecutor to an emissary verifier.
-    struct Operation {
-        bytes data;
-    }
 
     /// @notice Executor reimbursement included in a single-chain intent.
     struct GasRefund {
@@ -70,25 +45,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
         uint256 overhead;
     }
 
-    /// @notice Compact configuration for one pre-enabled registration session.
-    struct SessionConfig {
-        address sessionKey;
-        uint48 validUntil;
-        uint48 maxRefundGasOverhead;
-        address resolver;
-        uint96 sessionNonce;
-        address refundToken;
-        uint96 maxRefundExchangeRate;
-        uint96 maxRefundAmount;
-    }
-
-    /// @dev One chain and session digest from a Rhinestone multi-chain session authorization.
-    struct HashAndChainId {
-        uint64 chainId;
-        bytes32 sessionDigest;
-    }
-
-    /// @dev Owner authorization used when the first route enables an HCA session.
+    /// @dev Reusable owner authorization for a fixed HCA session.
     struct SessionEnableProof {
         address sessionKey;
         uint48 validUntil;
@@ -99,73 +56,45 @@ contract HCAOwnerAndSessionValidator is IValidator {
         uint48 maxRefundGasOverhead;
         uint96 maxRefundAmount;
         uint8 sessionToEnableIndex;
-        HashAndChainId[] hashesAndChainIds;
-        bytes32 ownerR;
-        bytes32 ownerS;
-        uint8 ownerV;
     }
 
     /// @dev State collected while the validator checks one operation batch.
     struct RegistrationPolicyState {
         bool usesResolver;
         bool deploysResolver;
+        address authorizedRegistrar;
+    }
+
+    /// @dev State collected while validating an optional owner-funded token pull.
+    struct FundingPolicyState {
+        address account;
+        address owner;
+        bool enabled;
+        bool permitted;
+        bool transferred;
+        uint256 permitIndex;
+        uint256 permittedAmount;
     }
 
     ////////////////////////////////////////////////////////////////////////
     // Constants & Immutables
     ////////////////////////////////////////////////////////////////////////
 
-    /// @dev Fixed-session discriminator inside the validator signature.
-    bytes1 internal constant FIXED_SESSION_MODE = 0x01;
-
-    /// @dev Refund-aware fixed-session discriminator inside the validator signature.
-    bytes1 internal constant FIXED_SESSION_REFUND_MODE = 0x02;
-
-    /// @dev Fixed-session discriminator for a Permit2-backed cross-chain intent.
-    bytes1 internal constant FIXED_SESSION_PERMIT2_MODE = 0x03;
-
-    /// @dev First-use Permit2 mode carrying one reusable multi-chain session authorization.
+    /// @dev Permit2 mode carrying one reusable multi-chain session authorization.
     bytes1 internal constant FIXED_SESSION_PERMIT2_ENABLE_MODE = 0x04;
 
-    /// @dev First-use single-chain mode carrying one reusable multi-chain session authorization.
+    /// @dev Single-chain mode carrying one reusable multi-chain session authorization.
     bytes1 internal constant FIXED_SESSION_REFUND_ENABLE_MODE = 0x05;
 
-    /// @dev Size of the fixed-session mode, permission ID, and standalone-intent nonce.
-    uint256 internal constant FIXED_SESSION_PREFIX_LENGTH = 65;
+    /// @dev Fixed fields in a packed session authorization before its chain entries.
+    uint256 private constant _SESSION_PROOF_HEADER_LENGTH = 110;
 
-    /// @dev Size of the fixed-session prefix when it also carries a gas-refund tuple.
-    uint256 internal constant FIXED_SESSION_REFUND_PREFIX_LENGTH = 149;
+    /// @dev Fixed proof bytes including the owner signature but excluding chain entries.
+    uint256 private constant _SESSION_PROOF_BASE_LENGTH =
+        _SESSION_PROOF_HEADER_LENGTH + HCASignatureLib.SIGNATURE_LENGTH;
 
-    /// @dev Fields after a first-use proof and before its single-chain operation.
-    uint256 internal constant FIXED_SESSION_REFUND_ENABLE_FIELDS_LENGTH = 116;
-
-    /// @dev Mode, permission ID, origin chain ID, and fixed Permit2 claim fields.
-    uint256 internal constant FIXED_SESSION_PERMIT2_OPERATION_OFFSET =
-        65 + HCAPermit2Lib.CLAIM_DATA_LENGTH;
-
-    /// @dev Mode, permission ID, and four-byte enable-proof length.
-    uint256 internal constant FIXED_SESSION_ENABLE_PREFIX_LENGTH = 37;
-
-    /// @dev Minimum envelope size before the first same-chain operation.
-    uint256 internal constant FIXED_SESSION_REFUND_ENABLE_MIN_LENGTH =
-        FIXED_SESSION_ENABLE_PREFIX_LENGTH +
-        FIXED_SESSION_REFUND_ENABLE_FIELDS_LENGTH + HCASignatureLib.SIGNATURE_LENGTH;
-
-    /// @dev Smart Session payload mode for an already-enabled permission.
-    bytes1 internal constant SMART_SESSION_MODE_USE = 0x00;
-
-    /// @dev Existing Smart Session USE payload size for one ECDSA session signer.
-    uint256 internal constant SMART_SESSION_USE_LENGTH = 98;
-
-    /// @notice Rhinestone operation mode for pure emissary ERC-7579 execution.
-    bytes32 public constant ERC7579_EMISSARY_EXECUTION_MODE = bytes32(uint256(0x0204) << 240);
-
-    /// @notice Rhinestone operation mode for ERC-1271 ERC-7579 execution.
-    bytes32 public constant ERC7579_ERC1271_MODE = bytes32(uint256(0x0201) << 240);
-
-    /// @notice Rhinestone operation mode for ERC-1271 with emissary-execution fallback.
-    bytes32 public constant ERC7579_ERC1271_EMISSARY_EXECUTION_MODE =
-        bytes32(uint256(0x0206) << 240);
+    /// @dev Packed fields after a first-use proof and before its single-chain operation.
+    uint256 internal constant FIXED_SESSION_REFUND_ENABLE_FIELDS_LENGTH = 82;
 
     /// @dev EIP-712 domain type used by the production IntentExecutor.
     bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
@@ -194,61 +123,6 @@ contract HCAOwnerAndSessionValidator is IValidator {
     /// @dev Canonical Permit2 deployment used by Rhinestone intents.
     address internal constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
 
-    /// @notice Selector for ETHRegistrar.commit(bytes32).
-    bytes4 public constant COMMIT_SELECTOR = IETHRegistrar.commit.selector;
-
-    /// @notice Selector for ETHRegistrar.register(string,address,bytes32,address,address,uint64,address,bytes32).
-    bytes4 public constant REGISTER_SELECTOR = IETHRegistrar.register.selector;
-
-    /// @notice Selector for ERC20.approve(address,uint256).
-    bytes4 public constant APPROVE_SELECTOR = IERC20.approve.selector;
-
-    /// @notice Selector for EIP-2612 permit(address,address,uint256,uint256,uint8,bytes32,bytes32).
-    bytes4 public constant PERMIT_SELECTOR = 0xd505accf;
-
-    /// @notice Selector for ERC20.transferFrom(address,address,uint256).
-    bytes4 public constant TRANSFER_FROM_SELECTOR = IERC20.transferFrom.selector;
-
-    /// @notice Selector for VerifiableFactory.deployProxy(address,uint256,bytes).
-    bytes4 public constant DEPLOY_PROXY_SELECTOR = IVerifiableFactory.deployProxy.selector;
-
-    /// @notice Selector for DefaultReverseRegistrarAdapter.setNameWithHCA(address,string).
-    bytes4 public constant SET_NAME_WITH_HCA_SELECTOR =
-        IDefaultReverseRegistrarAdapter.setNameWithHCA.selector;
-
-    /// @notice Selector for ReverseRegistrarAdapter.claimWithHCA(address,address).
-    bytes4 public constant CLAIM_WITH_HCA_SELECTOR = IReverseRegistrarAdapter.claimWithHCA.selector;
-
-    /// @notice Selector for PermissionedResolver.linkToRecord(bytes,uint256).
-    bytes4 public constant LINK_TO_RECORD_SELECTOR = IPermissionedResolver.linkToRecord.selector;
-
-    /// @notice Selector for PermissionedResolver.linkToNode(bytes,bytes32).
-    bytes4 public constant LINK_TO_NODE_SELECTOR = IPermissionedResolver.linkToNode.selector;
-
-    /// @notice Selector for PermissionedResolver.setABI(bytes,uint256,bytes).
-    bytes4 public constant SET_ABI_SELECTOR = IABISetter.setABI.selector;
-
-    /// @notice Selector for PermissionedResolver.setAddress(bytes,uint256,bytes).
-    bytes4 public constant SET_ADDRESS_SELECTOR = IAddressSetter.setAddress.selector;
-
-    /// @notice Selector for PermissionedResolver.setContenthash(bytes,bytes).
-    bytes4 public constant SET_CONTENTHASH_SELECTOR = IContenthashSetter.setContenthash.selector;
-
-    /// @notice Selector for PermissionedResolver.setData(bytes,string,bytes).
-    bytes4 public constant SET_DATA_SELECTOR = IDataSetter.setData.selector;
-
-    /// @notice Selector for PermissionedResolver.setInterface(bytes,bytes4,address).
-    bytes4 public constant SET_INTERFACE_SELECTOR = IInterfaceSetter.setInterface.selector;
-
-    /// @notice Selector for PermissionedResolver.setText(bytes,string,string).
-    bytes4 public constant SET_TEXT_SELECTOR = ITextSetter.setText.selector;
-
-    /// @notice Selector for PermissionedResolver.setName(bytes,string).
-    bytes4 public constant SET_NAME_SELECTOR = INameSetter.setName.selector;
-
-    /// @notice Selector for PermissionedResolver.multicall(bytes[]).
-    bytes4 public constant MULTICALL_SELECTOR = IMulticallable.multicall.selector;
-
     /// @notice The HCA-aware default reverse registrar adapter permitted for default primary-name setup.
     address public immutable DEFAULT_REVERSE_REGISTRAR_HCA_ADAPTER;
 
@@ -274,49 +148,6 @@ contract HCAOwnerAndSessionValidator is IValidator {
     address public immutable GAS_REFUND_PAYMASTER;
 
     ////////////////////////////////////////////////////////////////////////
-    // Storage
-    ////////////////////////////////////////////////////////////////////////
-
-    /// @dev Fixed session configuration by account and permission ID.
-    mapping(address account => mapping(bytes32 permissionId => SessionConfig config)) internal _sessions;
-
-    ////////////////////////////////////////////////////////////////////////
-    // Events
-    ////////////////////////////////////////////////////////////////////////
-
-    /// @notice Emitted when an account enables a fixed session.
-    /// @param account The HCA that enabled the session.
-    /// @param permissionId The session permission identifier.
-    /// @param sessionKey The authorized session signer.
-    /// @param resolver The resolver allowed by the session policy.
-    /// @param validUntil The last timestamp at which the session is valid.
-    /// @param sessionNonce The account nonce that invalidates older sessions.
-    event SessionEnabled(
-        address indexed account,
-        bytes32 indexed permissionId,
-        address indexed sessionKey,
-        address resolver,
-        uint48 validUntil,
-        uint96 sessionNonce
-    );
-
-    /// @notice Emitted when a fixed session permits executor reimbursement.
-    /// @param account The HCA that enabled the session.
-    /// @param permissionId The session permission identifier.
-    /// @param token The permitted reimbursement token.
-    /// @param maxExchangeRate The maximum signed token exchange rate.
-    /// @param maxGasOverhead The maximum signed gas overhead.
-    /// @param maxRefundAmount The maximum token reimbursement.
-    event SessionRefundConfigured(
-        address indexed account,
-        bytes32 indexed permissionId,
-        address indexed token,
-        uint96 maxExchangeRate,
-        uint48 maxGasOverhead,
-        uint96 maxRefundAmount
-    );
-
-    ////////////////////////////////////////////////////////////////////////
     // Errors
     ////////////////////////////////////////////////////////////////////////
 
@@ -331,10 +162,6 @@ contract HCAOwnerAndSessionValidator is IValidator {
     /// @notice The HCA did not expose an owner.
     /// @dev Error selector: `0xbff8a462`
     error OwnerUnavailable();
-
-    /// @notice The session has expired.
-    /// @dev Error selector: `0x1fd05a4a`
-    error SessionExpired();
 
     /// @notice A session was presented by an address other than the fixed IntentExecutor.
     /// @dev Error selector: `0x037b5679`
@@ -393,69 +220,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
     // Implementation
     ////////////////////////////////////////////////////////////////////////
 
-    /// @notice Enables one fixed-policy session through an owner-authorized HCA execution.
-    /// @dev `msg.sender` is the HCA, so the enable call can be batched with its first owner-signed
-    ///      intent. `permissionId` is the ID used by Rhinestone's existing session USE payload.
-    /// @param permissionId The session permission identifier.
-    /// @param sessionKey The ECDSA key authorized for the fixed ENS policy.
-    /// @param validUntil The last timestamp at which the session is valid.
-    /// @param resolver The resolver accepted by the fixed ENS policy.
-    function enableSession(
-        bytes32 permissionId,
-        address sessionKey,
-        uint48 validUntil,
-        address resolver
-    )
-        external
-    {
-        _enableSession(permissionId, sessionKey, validUntil, resolver, address(0), 0, 0, 0);
-    }
-
-    /// @notice Enables one fixed-policy session that may reimburse the executor in a payment token.
-    /// @param permissionId The ID used by Rhinestone's existing session USE payload.
-    /// @param sessionKey The ECDSA key authorized for the fixed ENS policy.
-    /// @param validUntil The last timestamp at which the session is valid.
-    /// @param resolver The resolver accepted by the fixed ENS policy.
-    /// @param refundToken The payment token accepted for executor reimbursement.
-    /// @param maxRefundExchangeRate The largest token exchange rate the session may sign.
-    /// @param maxRefundGasOverhead The largest gas-unit overhead the session may sign.
-    /// @param maxRefundAmount The largest token-denominated refund cap the session may sign.
-    function enableSessionWithRefund(
-        bytes32 permissionId,
-        address sessionKey,
-        uint48 validUntil,
-        address resolver,
-        address refundToken,
-        uint96 maxRefundExchangeRate,
-        uint48 maxRefundGasOverhead,
-        uint96 maxRefundAmount
-    )
-        external
-    {
-        if (refundToken == address(0) || maxRefundExchangeRate == 0 || maxRefundAmount == 0) {
-            revert GasRefundNotAllowed();
-        }
-        _enableSession(
-            permissionId,
-            sessionKey,
-            validUntil,
-            resolver,
-            refundToken,
-            maxRefundExchangeRate,
-            maxRefundGasOverhead,
-            maxRefundAmount
-        );
-        emit SessionRefundConfigured(
-            msg.sender,
-            permissionId,
-            refundToken,
-            maxRefundExchangeRate,
-            maxRefundGasOverhead,
-            maxRefundAmount
-        );
-    }
-
-    /// @notice Validates an HCA owner signature or a pre-enabled fixed session.
+    /// @notice Validates an HCA owner signature or reusable fixed-session proof.
     /// @param sender The caller forwarded by the account.
     /// @param hash The digest supplied by the intent executor.
     /// @param data A 65-byte owner signature or fixed-session envelope.
@@ -479,75 +244,6 @@ contract HCAOwnerAndSessionValidator is IValidator {
         return ERC1271_MAGICVALUE;
     }
 
-    /// @notice Returns whether a fixed-policy session is currently usable.
-    /// @param account The HCA that owns the session.
-    /// @param permissionId The session permission identifier.
-    /// @return Whether the session exists, has not expired, and matches the account nonce.
-    function isPermissionEnabled(address account, bytes32 permissionId)
-        external
-        view
-        returns (bool)
-    {
-        SessionConfig memory config = _sessions[account][permissionId];
-        if (config.sessionKey == address(0) || block.timestamp > config.validUntil) {
-            return false;
-        }
-        try IStandaloneHCAOwner(account).ownerAndSessionNonce() returns (
-            address owner_,
-            uint96 sessionNonce
-        ) {
-            return owner_ != address(0) && sessionNonce == config.sessionNonce;
-        } catch {
-            return false;
-        }
-    }
-
-    /// @notice Verifies an existing Smart Session USE payload against the fixed ENS policy.
-    /// @dev The fixed IntentExecutor supplies the actual operation. Only the compact USE mode is
-    ///      supported; session enablement is an ordinary owner-authorized HCA call.
-    /// @param account The HCA that owns the session.
-    /// @param digest The operation digest signed by the session key.
-    /// @param data The Smart Session USE payload.
-    /// @param operation The operation supplied by the fixed executor.
-    /// @return The verification function selector on success.
-    function verifyExecution(
-        address account,
-        bytes32 digest,
-        bytes calldata data,
-        Operation calldata operation
-    )
-        external
-        view
-        returns (bytes4)
-    {
-        if (msg.sender != INTENT_EXECUTOR) {
-            revert CallerNotIntentExecutor();
-        }
-        if (data.length != SMART_SESSION_USE_LENGTH || data[0] != SMART_SESSION_MODE_USE) {
-            revert InvalidSessionData();
-        }
-
-        bytes32 permissionId = bytes32(data[1:33]);
-        SessionConfig memory config = _sessions[account][permissionId];
-        if (config.sessionKey == address(0)) {
-            revert InvalidSigner();
-        }
-        if (block.timestamp > config.validUntil) {
-            revert SessionExpired();
-        }
-
-        (address owner_, uint96 sessionNonce) = _ownerAndSessionNonce(account);
-        if (sessionNonce != config.sessionNonce) {
-            revert InvalidSigner();
-        }
-        if (HCASignatureLib.recover(digest, data[33:]) != config.sessionKey) {
-            revert InvalidSigner();
-        }
-
-        _checkRegistrationPolicy(account, owner_, config.resolver, operation.data);
-        return this.verifyExecution.selector;
-    }
-
     /// @notice Validates an owner-signed ERC-4337 UserOperation.
     /// @dev Accepts both raw-digest and `personal_sign` ECDSA signatures, matching Nexus's K1 validator.
     ///      Fixed sessions remain limited to the intent path.
@@ -567,13 +263,6 @@ contract HCAOwnerAndSessionValidator is IValidator {
             HCASignatureLib.isValidUserOpSignature(expectedOwner, userOpHash, userOp.signature)
                 ? VALIDATION_SUCCESS
                 : VALIDATION_FAILED;
-    }
-
-    /// @notice Returns whether this module is a validator.
-    /// @param moduleTypeId The ERC-7579 module type id.
-    /// @return True when the module type is validator.
-    function isModuleType(uint256 moduleTypeId) external pure returns (bool) {
-        return moduleTypeId == MODULE_TYPE_VALIDATOR;
     }
 
     /// @notice Returns whether this fixed module is available for an account.
@@ -601,57 +290,6 @@ contract HCAOwnerAndSessionValidator is IValidator {
     // Internal Functions
     ////////////////////////////////////////////////////////////////////////
 
-    /// @dev Stores a fixed session and binds it to the account's current session nonce.
-    function _enableSession(
-        bytes32 permissionId,
-        address sessionKey,
-        uint48 validUntil,
-        address resolver,
-        address refundToken,
-        uint96 maxRefundExchangeRate,
-        uint48 maxRefundGasOverhead,
-        uint96 maxRefundAmount
-    )
-        internal
-    {
-        _enableSessionFor(
-            msg.sender,
-            permissionId,
-            sessionKey,
-            validUntil,
-            resolver,
-            refundToken,
-            maxRefundExchangeRate,
-            maxRefundGasOverhead,
-            maxRefundAmount
-        );
-    }
-
-    /// @dev Stores a fixed session for an HCA after checking its current session nonce.
-    function _enableSessionFor(
-        address account,
-        bytes32 permissionId,
-        address sessionKey,
-        uint48 validUntil,
-        address resolver,
-        address refundToken,
-        uint96 maxRefundExchangeRate,
-        uint48 maxRefundGasOverhead,
-        uint96 maxRefundAmount
-    )
-        internal
-    {
-        if (sessionKey == address(0)) {
-            revert InvalidSigner();
-        }
-        if (validUntil < block.timestamp) {
-            revert SessionExpired();
-        }
-        (, uint96 sessionNonce) = _ownerAndSessionNonce(account);
-        _sessions[account][permissionId] = SessionConfig({sessionKey: sessionKey, validUntil: validUntil, maxRefundGasOverhead: maxRefundGasOverhead, resolver: resolver, sessionNonce: sessionNonce, refundToken: refundToken, maxRefundExchangeRate: maxRefundExchangeRate, maxRefundAmount: maxRefundAmount});
-        emit SessionEnabled(account, permissionId, sessionKey, resolver, validUntil, sessionNonce);
-    }
-
     /// @dev Reads the account owner and session nonce, reverting if either is unavailable.
     function _ownerAndSessionNonce(address account)
         internal
@@ -674,7 +312,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
 
     /// @dev Validates an ERC-1271 session envelope and binds its operation copy to `hash`.
     function _validateFixedSession(bytes32 hash, bytes calldata data) internal view {
-        if (data.length < FIXED_SESSION_PREFIX_LENGTH + HCASignatureLib.SIGNATURE_LENGTH) {
+        if (data.length == 0) {
             revert InvalidSessionData();
         }
 
@@ -687,62 +325,38 @@ contract HCAOwnerAndSessionValidator is IValidator {
             _validateFixedRefundSessionEnable(hash, data);
             return;
         }
-        if (mode == FIXED_SESSION_PERMIT2_MODE) {
-            _validateFixedPermit2Session(hash, data);
-            return;
-        }
-        if (mode == FIXED_SESSION_MODE) {
-            _validateFixedSessionPayload(
-                hash,
-                data,
-                FIXED_SESSION_PREFIX_LENGTH,
-                GasRefund(address(0), 0, 0)
-            );
-            return;
-        }
-        if (mode == FIXED_SESSION_REFUND_MODE) {
-            if (data.length < FIXED_SESSION_REFUND_PREFIX_LENGTH + HCASignatureLib.SIGNATURE_LENGTH) {
-                revert InvalidSessionData();
-            }
-            _validateFixedSessionPayload(
-                hash,
-                data,
-                FIXED_SESSION_REFUND_PREFIX_LENGTH,
-                GasRefund({token: address(bytes20(data[65:85])), exchangeRate: uint256(
-                    bytes32(data[85:117])
-                ), overhead: uint256(bytes32(data[117:149]))})
-            );
-            return;
-        }
         revert InvalidSessionData();
     }
 
     /// @dev Validates the first Permit2 route and its reusable multi-chain session authorization.
     function _validateFixedPermit2SessionEnable(bytes32 hash, bytes calldata data) internal view {
-        if (
-            data.length <=
-            FIXED_SESSION_ENABLE_PREFIX_LENGTH + 32 + HCAPermit2Lib.CLAIM_DATA_LENGTH + 65
-        ) {
+        (
+            bytes32 permissionId,
+            SessionEnableProof memory proof,
+            bytes calldata packedSessions,
+            bytes calldata ownerSignature,
+            uint256 proofEnd
+        ) =
+            _decodeSessionEnableProof(
+                data,
+                32 + HCAPermit2Lib.CLAIM_DATA_LENGTH + HCASignatureLib.SIGNATURE_LENGTH
+            );
+        if (proofEnd == 0) {
             revert InvalidSessionData();
         }
 
-        bytes32 permissionId = bytes32(data[1:33]);
-        uint256 proofLength = uint32(bytes4(data[33:37]));
-        uint256 proofEnd = FIXED_SESSION_ENABLE_PREFIX_LENGTH + proofLength;
-        uint256 operationOffset = proofEnd + 32 + HCAPermit2Lib.CLAIM_DATA_LENGTH;
-        uint256 signatureOffset = data.length - HCASignatureLib.SIGNATURE_LENGTH;
-        if (proofLength == 0 || operationOffset >= signatureOffset) {
-            revert InvalidSessionData();
-        }
-
-        SessionEnableProof memory proof =
-            abi.decode(data[FIXED_SESSION_ENABLE_PREFIX_LENGTH:proofEnd], (SessionEnableProof));
-        address accountOwner = _validateSessionEnableProof(permissionId, proof);
-        _validatePermit2EnableIntent(hash, data, proofEnd, permissionId, accountOwner, proof);
+        address accountOwner =
+            _validateSessionEnableProof(permissionId, proof, packedSessions, ownerSignature);
+        _validatePermit2EnableIntent(hash, data, proofEnd, accountOwner, proof);
     }
 
     /// @dev Validates the fixed HCA fields authorized by the owner.
-    function _validateSessionEnableProof(bytes32 permissionId, SessionEnableProof memory proof)
+    function _validateSessionEnableProof(
+        bytes32 permissionId,
+        SessionEnableProof memory proof,
+        bytes calldata packedSessions,
+        bytes calldata ownerSignature
+    )
         internal
         view
         returns (address owner_)
@@ -766,7 +380,13 @@ contract HCAOwnerAndSessionValidator is IValidator {
         if (permissionId != expectedPermissionId) {
             revert InvalidSessionData();
         }
-        _validateMultiChainSessionAuthorization(owner_, sessionDigest, proof);
+        _validateMultiChainSessionAuthorization(
+            owner_,
+            sessionDigest,
+            proof.sessionToEnableIndex,
+            packedSessions,
+            ownerSignature
+        );
         return owner_;
     }
 
@@ -775,7 +395,6 @@ contract HCAOwnerAndSessionValidator is IValidator {
         bytes32 hash,
         bytes calldata data,
         uint256 proofEnd,
-        bytes32 permissionId,
         address accountOwner,
         SessionEnableProof memory proof
     )
@@ -788,52 +407,44 @@ contract HCAOwnerAndSessionValidator is IValidator {
         if (HCASignatureLib.recover(hash, data[signatureOffset:]) != proof.sessionKey) {
             revert InvalidSigner();
         }
-        _validatePermit2Destination(
-            hash,
-            uint256(bytes32(data[proofEnd:proofEnd + 32])),
-            data[proofEnd + 32:operationOffset],
-            operationData
-        );
-        _checkInitialRegistrationPolicy(
+        HCAOperationHashLib.DecodedOperation memory operation =
+            _validatePermit2Destination(
+                hash,
+                uint256(bytes32(data[proofEnd:proofEnd + 32])),
+                data[proofEnd + 32:operationOffset],
+                operationData
+            );
+        _checkStatelessRegistrationPolicy(
             msg.sender,
             accountOwner,
-            permissionId,
             proof,
-            operationData,
+            operation,
             GasRefund(address(0), 0, 0)
         );
     }
 
     /// @dev Validates the first same-chain operation and its reusable session authorization.
     function _validateFixedRefundSessionEnable(bytes32 hash, bytes calldata data) internal view {
-        if (data.length <= FIXED_SESSION_REFUND_ENABLE_MIN_LENGTH) {
+        (
+            bytes32 permissionId,
+            SessionEnableProof memory proof,
+            bytes calldata packedSessions,
+            bytes calldata ownerSignature,
+            uint256 proofEnd
+        ) =
+            _decodeSessionEnableProof(
+                data,
+                FIXED_SESSION_REFUND_ENABLE_FIELDS_LENGTH + HCASignatureLib.SIGNATURE_LENGTH
+            );
+        if (proofEnd == 0) {
             revert InvalidSessionData();
         }
 
-        bytes32 permissionId = bytes32(data[1:33]);
-        uint256 proofLength = uint32(bytes4(data[33:37]));
-        uint256 proofEnd = FIXED_SESSION_ENABLE_PREFIX_LENGTH + proofLength;
-        if (
-            proofLength == 0 ||
-            proofEnd + FIXED_SESSION_REFUND_ENABLE_FIELDS_LENGTH >=
-            data.length - HCASignatureLib.SIGNATURE_LENGTH
-        ) {
-            revert InvalidSessionData();
-        }
-
-        SessionEnableProof memory proof =
-            abi.decode(data[FIXED_SESSION_ENABLE_PREFIX_LENGTH:proofEnd], (SessionEnableProof));
-        address accountOwner = _validateSessionEnableProof(permissionId, proof);
-        (bytes calldata operationData, GasRefund memory gasRefund) =
+        address accountOwner =
+            _validateSessionEnableProof(permissionId, proof, packedSessions, ownerSignature);
+        (HCAOperationHashLib.DecodedOperation memory operation, GasRefund memory gasRefund) =
             _validateFixedRefundSessionEnablePayload(hash, data, proofEnd, proof);
-        _checkInitialRegistrationPolicy(
-            msg.sender,
-            accountOwner,
-            permissionId,
-            proof,
-            operationData,
-            gasRefund
-        );
+        _checkStatelessRegistrationPolicy(msg.sender, accountOwner, proof, operation, gasRefund);
     }
 
     /// @dev Validates the session signature, refund, and operation in a first same-chain use.
@@ -845,20 +456,21 @@ contract HCAOwnerAndSessionValidator is IValidator {
     )
         internal
         view
-        returns (bytes calldata operationData, GasRefund memory gasRefund)
+        returns (HCAOperationHashLib.DecodedOperation memory operation, GasRefund memory gasRefund)
     {
         uint256 operationOffset = proofEnd + FIXED_SESSION_REFUND_ENABLE_FIELDS_LENGTH;
         uint256 signatureOffset = data.length - HCASignatureLib.SIGNATURE_LENGTH;
-        gasRefund = GasRefund({token: address(bytes20(data[proofEnd + 32:proofEnd + 52])), exchangeRate: uint256(
-            bytes32(data[proofEnd + 52:proofEnd + 84])
-        ), overhead: uint256(bytes32(data[proofEnd + 84:operationOffset]))});
-        SessionConfig memory config =
-            SessionConfig({sessionKey: proof.sessionKey, validUntil: proof.validUntil, maxRefundGasOverhead: proof.maxRefundGasOverhead, resolver: proof.resolver, sessionNonce: proof.sessionNonce, refundToken: proof.refundToken, maxRefundExchangeRate: proof.maxRefundExchangeRate, maxRefundAmount: proof.maxRefundAmount});
-        _checkGasRefund(config, gasRefund);
+        uint256 refundAmount = uint96(bytes12(data[proofEnd + 64:proofEnd + 76]));
+        gasRefund = GasRefund({token: address(bytes20(data[proofEnd + 32:proofEnd + 52])), exchangeRate: uint96(
+            bytes12(data[proofEnd + 52:proofEnd + 64])
+        ), overhead: (refundAmount << 128) | uint48(bytes6(data[proofEnd + 76:operationOffset]))});
+        _checkGasRefund(proof, gasRefund);
 
-        operationData = data[operationOffset:signatureOffset];
+        bytes calldata operationData = data[operationOffset:signatureOffset];
+        bytes32 operationHash;
+        (operation, operationHash) = _decodeERC1271Operation(operationData);
         uint256 nonce = uint256(bytes32(data[proofEnd:proofEnd + 32]));
-        if (_singleChainDigest(msg.sender, nonce, operationData, gasRefund) != hash) {
+        if (_singleChainDigest(msg.sender, nonce, operationHash, gasRefund) != hash) {
             revert InvalidSessionData();
         }
         if (HCASignatureLib.recover(hash, data[signatureOffset:]) != proof.sessionKey) {
@@ -870,74 +482,27 @@ contract HCAOwnerAndSessionValidator is IValidator {
     function _validateMultiChainSessionAuthorization(
         address owner_,
         bytes32 expectedSessionDigest,
-        SessionEnableProof memory proof
+        uint256 selectedIndex,
+        bytes calldata packedSessions,
+        bytes calldata ownerSignature
     )
         internal
         view
     {
-        uint256 count = proof.hashesAndChainIds.length;
-        uint256 selectedIndex = proof.sessionToEnableIndex;
-        if (count == 0 || selectedIndex >= count) {
-            revert InvalidSessionData();
-        }
-
-        HashAndChainId memory selected = proof.hashesAndChainIds[selectedIndex];
-        if (selected.chainId != block.chainid || selected.sessionDigest != expectedSessionDigest) {
-            revert InvalidSessionData();
-        }
-
-        bytes32[] memory chainSessionHashes = new bytes32[](count);
-        for (uint256 i; i < count; ++i) {
-            HashAndChainId memory item = proof.hashesAndChainIds[i];
-            chainSessionHashes[i] = HCASmartSessionLib.chainSessionHash(
-                item.chainId,
-                item.sessionDigest
+        HCASmartSessionLib.AuthorizationStatus status =
+            HCASmartSessionLib.validateMultiChainAuthorization(
+                owner_,
+                expectedSessionDigest,
+                selectedIndex,
+                packedSessions,
+                ownerSignature
             );
-        }
-        bytes32 digest = HCASmartSessionLib.multiChainDigest(chainSessionHashes);
-        if (HCASignatureLib.recover(digest, proof.ownerR, proof.ownerS, proof.ownerV) != owner_) {
-            revert InvalidSigner();
-        }
-    }
-
-    /// @dev Validates a cross-chain Permit2 intent and its destination operation preimage.
-    function _validateFixedPermit2Session(bytes32 hash, bytes calldata data) internal view {
-        if (
-            data.length <= FIXED_SESSION_PERMIT2_OPERATION_OFFSET + HCASignatureLib.SIGNATURE_LENGTH
-        ) {
+        if (status == HCASmartSessionLib.AuthorizationStatus.InvalidSelection) {
             revert InvalidSessionData();
         }
-
-        bytes32 permissionId = bytes32(data[1:33]);
-        SessionConfig memory config = _sessions[msg.sender][permissionId];
-        if (config.sessionKey == address(0)) {
+        if (status != HCASmartSessionLib.AuthorizationStatus.Valid) {
             revert InvalidSigner();
         }
-        if (block.timestamp > config.validUntil) {
-            revert SessionExpired();
-        }
-        (, uint96 sessionNonce) = _ownerAndSessionNonce(msg.sender);
-        if (sessionNonce != config.sessionNonce) {
-            revert InvalidSigner();
-        }
-
-        uint256 sourceChainId = uint256(bytes32(data[33:65]));
-        bytes calldata claimData = data[65:FIXED_SESSION_PERMIT2_OPERATION_OFFSET];
-        uint256 signatureOffset = data.length - HCASignatureLib.SIGNATURE_LENGTH;
-        bytes calldata operationData = data[FIXED_SESSION_PERMIT2_OPERATION_OFFSET:signatureOffset];
-        if (HCASignatureLib.recover(hash, data[signatureOffset:]) != config.sessionKey) {
-            revert InvalidSigner();
-        }
-        _validatePermit2Destination(hash, sourceChainId, claimData, operationData);
-
-        (address owner_, ) = _ownerAndSessionNonce(msg.sender);
-        _checkRegistrationPolicy(
-            msg.sender,
-            owner_,
-            config.resolver,
-            operationData,
-            GasRefund(address(0), 0, 0)
-        );
     }
 
     /// @dev Binds the destination operation to the signed Permit2 mandate.
@@ -949,6 +514,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
     )
         internal
         view
+        returns (HCAOperationHashLib.DecodedOperation memory operation)
     {
         if (
             sourceChainId == 0 ||
@@ -967,76 +533,34 @@ contract HCAOwnerAndSessionValidator is IValidator {
             claim.targetChainId != block.chainid ||
             claim.fillExpiry < block.timestamp ||
             claim.tokenOut == address(0) ||
-            claim.amountOut == 0 ||
-            !_isBatchRegistrarPaymentToken(operationData, claim.tokenOut)
+            claim.amountOut == 0
         ) {
             revert PolicyRuleFailed();
         }
+        if (operationData.length < 32) {
+            revert PolicyRuleFailed();
+        }
+        bytes32 operationHash;
+        (operation, operationHash) = HCAOperationHashLib.decodeAndHash(operationData);
+        if (!HCAOperationHashLib.isERC1271Mode(operation.mode)) {
+            revert InvalidOperationEncoding();
+        }
+        if (!HCARegistrarPolicyLib.isBatchPaymentToken(operation.executions, claim.tokenOut)) {
+            revert PolicyRuleFailed();
+        }
         if (
-            _operationHash(operationData) != bytes32(claimData[346:378]) ||
+            operationHash != bytes32(claimData[346:378]) ||
             HCAPermit2Lib.digest(claimData, claim, sourceChainId, PERMIT2) != expectedDigest
         ) {
             revert InvalidSessionData();
         }
     }
 
-    /// @dev Validates the common fixed-session fields after decoding its refund mode.
-    function _validateFixedSessionPayload(
-        bytes32 hash,
-        bytes calldata data,
-        uint256 operationOffset,
-        GasRefund memory gasRefund
-    )
-        internal
-        view
-    {
-        bytes32 permissionId = bytes32(data[1:33]);
-        SessionConfig memory config = _sessions[msg.sender][permissionId];
-        if (config.sessionKey == address(0)) {
-            revert InvalidSigner();
-        }
-        if (block.timestamp > config.validUntil) {
-            revert SessionExpired();
-        }
-
-        (address owner_, uint96 sessionNonce) = _ownerAndSessionNonce(msg.sender);
-        if (sessionNonce != config.sessionNonce) {
-            revert InvalidSigner();
-        }
-        _checkGasRefund(config, gasRefund);
-        bytes calldata operationData =
-            _validateFixedSessionSignature(hash, data, operationOffset, gasRefund, config.sessionKey);
-        _checkRegistrationPolicy(msg.sender, owner_, config.resolver, operationData, gasRefund);
-    }
-
-    /// @dev Binds the operation and refund preimages to the session signature.
-    function _validateFixedSessionSignature(
-        bytes32 hash,
-        bytes calldata data,
-        uint256 operationOffset,
-        GasRefund memory gasRefund,
-        address sessionKey
-    )
-        internal
-        view
-        returns (bytes calldata operationData)
-    {
-        uint256 signatureOffset = data.length - HCASignatureLib.SIGNATURE_LENGTH;
-        operationData = data[operationOffset:signatureOffset];
-        uint256 nonce = uint256(bytes32(data[33:65]));
-        if (_singleChainDigest(msg.sender, nonce, operationData, gasRefund) != hash) {
-            revert InvalidSessionData();
-        }
-        if (HCASignatureLib.recover(hash, data[signatureOffset:]) != sessionKey) {
-            revert InvalidSigner();
-        }
-    }
-
-    /// @dev Reconstructs the production IntentExecutor digest for a single-chain intent.
+    /// @dev Reconstructs the production IntentExecutor digest from a decoded operation.
     function _singleChainDigest(
         address account,
         uint256 nonce,
-        bytes calldata operationData,
+        bytes32 operationHash,
         GasRefund memory gasRefund
     )
         internal
@@ -1057,13 +581,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
         );
         bytes32 structHash =
             keccak256(
-                abi.encode(
-                    SINGLE_CHAIN_OPS_TYPEHASH,
-                    account,
-                    nonce,
-                    _operationHash(operationData),
-                    gasRefundHash
-                )
+                abi.encode(SINGLE_CHAIN_OPS_TYPEHASH, account, nonce, operationHash, gasRefundHash)
             );
         bytes32 domainSeparator =
             keccak256(
@@ -1078,120 +596,29 @@ contract HCAOwnerAndSessionValidator is IValidator {
         return MessageHashUtils.toTypedDataHash(domainSeparator, structHash);
     }
 
-    /// @notice Validates every execution against the hardcoded registration and name-management action set.
-    /// @dev Checks target, selector, value, and selected ABI arguments for each execution.
-    ///      A default reverse name may be updated when the policy has a nonzero resolver and the
-    ///      named account is the HCA owner. The owner's `addr.reverse` node may be claimed with a
-    ///      zero resolver or the session's bound resolver; the latter counts as resolver use.
-    /// @param account The HCA that executes the operation.
-    /// @param owner The owner recorded for the HCA.
-    /// @param allowedResolver The resolver bound to the enabled session.
-    /// @param operationData The encoded ERC-7579 operation payload.
-    function _checkRegistrationPolicy(
+    /// @dev Validates a decoded ERC-1271 operation carrying a reusable session proof.
+    function _checkStatelessRegistrationPolicy(
         address account,
         address owner,
-        address allowedResolver,
-        bytes calldata operationData
+        SessionEnableProof memory proof,
+        HCAOperationHashLib.DecodedOperation memory operation,
+        GasRefund memory gasRefund
     )
         internal
         view
     {
-        _checkRegistrationPolicy(
+        if (operation.executions.length == 0) {
+            revert PolicyRuleFailed();
+        }
+        _checkRegistrationExecutions(
             account,
             owner,
-            allowedResolver,
-            operationData,
-            GasRefund(address(0), 0, 0)
+            proof.resolver,
+            operation.executions,
+            gasRefund,
+            proof.refundToken,
+            true
         );
-    }
-
-    /// @dev Applies the registration policy and any executor reimbursement constraints.
-    function _checkRegistrationPolicy(
-        address account,
-        address owner,
-        address allowedResolver,
-        bytes calldata operationData,
-        GasRefund memory gasRefund
-    )
-        internal
-        view
-    {
-        if (operationData.length < 32) {
-            revert InvalidOperationEncoding();
-        }
-        bytes32 operationMode = bytes32(operationData[:32]);
-        if (!HCAOperationHashLib.isSupportedMode(operationMode)) {
-            revert InvalidOperationEncoding();
-        }
-
-        Execution[] memory executions = abi.decode(operationData[32:], (Execution[]));
-        _checkRegistrationExecutions(account, owner, allowedResolver, executions, gasRefund);
-    }
-
-    /// @dev Allows one exact session-enable call in the first policy-checked batch.
-    function _checkInitialRegistrationPolicy(
-        address account,
-        address owner,
-        bytes32 permissionId,
-        SessionEnableProof memory proof,
-        bytes calldata operationData,
-        GasRefund memory gasRefund
-    )
-        internal
-        view
-    {
-        if (
-            operationData.length < 32 ||
-            !HCAOperationHashLib.isERC1271Mode(bytes32(operationData[:32]))
-        ) {
-            revert InvalidOperationEncoding();
-        }
-        Execution[] memory executions = abi.decode(operationData[32:], (Execution[]));
-        if (executions.length < 2) {
-            revert PolicyRuleFailed();
-        }
-
-        bytes memory expectedCall =
-            abi.encodeWithSelector(
-                this.enableSessionWithRefund.selector,
-                permissionId,
-                proof.sessionKey,
-                proof.validUntil,
-                proof.resolver,
-                proof.refundToken,
-                proof.maxRefundExchangeRate,
-                proof.maxRefundGasOverhead,
-                proof.maxRefundAmount
-            );
-        uint256 enableIndex = type(uint256).max;
-        for (uint256 i; i < executions.length; ++i) {
-            if (executions[i].target != address(this)) {
-                continue;
-            }
-            if (
-                enableIndex != type(uint256).max ||
-                executions[i].value != 0 ||
-                keccak256(executions[i].callData) != keccak256(expectedCall)
-            ) {
-                revert PolicyRuleFailed();
-            }
-            enableIndex = i;
-        }
-        if (enableIndex == type(uint256).max) {
-            revert PolicyRuleFailed();
-        }
-
-        (uint256 permitIndex, uint256 transferIndex) =
-            _fundingCallIndexes(executions, account, owner, proof.refundToken);
-        uint256 fundingCallCount = permitIndex == type(uint256).max ? 0 : 2;
-        Execution[] memory remaining = new Execution[](executions.length - 1 - fundingCallCount);
-        uint256 next;
-        for (uint256 i; i < executions.length; ++i) {
-            if (i != enableIndex && i != permitIndex && i != transferIndex) {
-                remaining[next++] = executions[i];
-            }
-        }
-        _checkRegistrationExecutions(account, owner, proof.resolver, remaining, gasRefund);
     }
 
     /// @dev Applies the fixed ENS policy to a decoded execution array.
@@ -1200,13 +627,17 @@ contract HCAOwnerAndSessionValidator is IValidator {
         address owner,
         address allowedResolver,
         Execution[] memory executions,
-        GasRefund memory gasRefund
+        GasRefund memory gasRefund,
+        address fundingToken,
+        bool requireAction
     )
         internal
         view
     {
-        (address policyResolver, ) = _registrationResolver(executions, owner, allowedResolver);
         RegistrationPolicyState memory state;
+        FundingPolicyState memory funding =
+            FundingPolicyState({account: account, owner: owner, enabled: fundingToken != address(0), permitted: false, transferred: false, permitIndex: 0, permittedAmount: 0});
+        uint256 actionCount;
 
         for (uint256 i; i < executions.length; ++i) {
             Execution memory execution = executions[i];
@@ -1216,28 +647,45 @@ contract HCAOwnerAndSessionValidator is IValidator {
 
             bytes4 selector = _selector(execution.callData);
 
+            if (
+                funding.enabled &&
+                execution.target == fundingToken &&
+                (selector == IERC20Permit.permit.selector ||
+                    selector == IERC20.transferFrom.selector)
+            ) {
+                _checkFundingCall(execution, selector, i, funding);
+                continue;
+            }
+            ++actionCount;
+
             if (selector == IETHRegistrar.commit.selector) {
-                if (!_isAuthorizedRegistrar(execution.target)) {
+                if (!_isAuthorizedRegistrar(execution.target, state)) {
                     revert ActionNotAllowed(execution.target, selector);
                 }
                 continue;
             }
 
             if (selector == IETHRegistrar.register.selector) {
-                // The preceding registration scan verifies the target's live registrar role.
+                if (!_isAuthorizedRegistrar(execution.target, state)) {
+                    revert ActionNotAllowed(execution.target, selector);
+                }
+                (address registrant, address resolver) = _registerFields(execution.callData);
+                if (registrant != owner || resolver != allowedResolver) {
+                    revert PolicyRuleFailed();
+                }
                 state.usesResolver = true;
-                if (policyResolver.code.length == 0 && !state.deploysResolver) {
+                if (allowedResolver.code.length == 0 && !state.deploysResolver) {
                     revert PolicyRuleFailed();
                 }
                 continue;
             }
 
-            if (policyResolver != address(0) && execution.target == policyResolver) {
+            if (allowedResolver != address(0) && execution.target == allowedResolver) {
                 state.usesResolver = true;
-                if (policyResolver.code.length == 0 && !state.deploysResolver) {
+                if (allowedResolver.code.length == 0 && !state.deploysResolver) {
                     revert PolicyRuleFailed();
                 }
-                _checkResolverCall(execution.callData, owner);
+                _checkResolverCall(execution.callData);
                 continue;
             }
 
@@ -1245,7 +693,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
                 if (selector != IDefaultReverseRegistrarAdapter.setNameWithHCA.selector) {
                     revert ActionNotAllowed(execution.target, selector);
                 }
-                if (policyResolver == address(0)) {
+                if (allowedResolver == address(0)) {
                     revert PolicyRuleFailed();
                 }
                 address namedAccount = _readAddress(execution.callData, 4);
@@ -1265,7 +713,7 @@ contract HCAOwnerAndSessionValidator is IValidator {
                 }
                 address claimResolver = _readAddress(execution.callData, 4 + 32);
                 if (claimResolver != address(0)) {
-                    if (claimResolver != policyResolver) {
+                    if (claimResolver != allowedResolver) {
                         revert PolicyRuleFailed();
                     }
                     state.usesResolver = true;
@@ -1280,65 +728,23 @@ contract HCAOwnerAndSessionValidator is IValidator {
                 if (state.deploysResolver) {
                     revert PolicyRuleFailed();
                 }
-                _checkResolverDeployment(account, owner, policyResolver, execution.callData);
+                _checkResolverDeployment(account, owner, allowedResolver, execution.callData);
                 state.usesResolver = true;
                 state.deploysResolver = true;
                 continue;
             }
 
             if (selector == IERC20.approve.selector) {
-                _checkPaymentTokenApproval(execution.target, execution.callData, gasRefund);
+                _checkPaymentTokenApproval(execution.target, execution.callData, gasRefund, state);
                 continue;
             }
 
             revert ActionNotAllowed(execution.target, selector);
         }
-        _checkResolverBinding(policyResolver, state);
-    }
-
-    /// @dev Finds the resolver used by every registration in a batch.
-    /// @param executions The decoded operation batch.
-    /// @param owner The owner that must receive each registration.
-    /// @param allowedResolver The resolver bound to the enabled session.
-    /// @return policyResolver The resolver that the policy permits for the batch.
-    /// @return seenRegister Whether the batch contains a registration.
-    function _registrationResolver(
-        Execution[] memory executions,
-        address owner,
-        address allowedResolver
-    )
-        internal
-        view
-        returns (address policyResolver, bool seenRegister)
-    {
-        for (uint256 i; i < executions.length; ++i) {
-            Execution memory execution = executions[i];
-            if (_selector(execution.callData) != IETHRegistrar.register.selector) {
-                continue;
-            }
-            if (!_isAuthorizedRegistrar(execution.target)) {
-                revert ActionNotAllowed(execution.target, IETHRegistrar.register.selector);
-            }
-
-            (address registrant, address resolver) = _registerFields(execution.callData);
-            if (registrant != owner) {
-                revert PolicyRuleFailed();
-            }
-            if (!seenRegister) {
-                seenRegister = true;
-                policyResolver = resolver;
-            } else if (policyResolver != resolver) {
-                revert PolicyRuleFailed();
-            }
+        if (funding.permitted != funding.transferred || (requireAction && actionCount == 0)) {
+            revert PolicyRuleFailed();
         }
-
-        if (seenRegister) {
-            if (allowedResolver != policyResolver) {
-                revert PolicyRuleFailed();
-            }
-        } else {
-            policyResolver = allowedResolver;
-        }
+        _checkResolverBinding(allowedResolver, state);
     }
 
     /// @dev Validates an exact deployment of the resolver bound to the session.
@@ -1387,13 +793,17 @@ contract HCAOwnerAndSessionValidator is IValidator {
     function _checkPaymentTokenApproval(
         address token,
         bytes memory callData,
-        GasRefund memory gasRefund
+        GasRefund memory gasRefund,
+        RegistrationPolicyState memory state
     )
         internal
         view
     {
         address spender = _readAddress(callData, 4);
-        if (_isAuthorizedRegistrar(spender) && _isRegistrarPaymentToken(spender, token)) {
+        if (
+            _isAuthorizedRegistrar(spender, state) &&
+            HCARegistrarPolicyLib.isPaymentToken(spender, token)
+        ) {
             return;
         }
         if (
@@ -1406,100 +816,112 @@ contract HCAOwnerAndSessionValidator is IValidator {
     }
 
     /// @dev Returns whether the pinned registry currently authorizes an account to register names.
+    ///      Reuses a successful lookup within the same operation batch.
     /// @param account The prospective registrar.
+    /// @param state The policy state caching one authorized registrar.
     /// @return authorized Whether the account holds the root registrar role.
-    function _isAuthorizedRegistrar(address account) internal view returns (bool authorized) {
-        return HCARegistrarPolicyLib.isAuthorized(ETH_REGISTRY, account);
-    }
-
-    /// @dev Returns whether a registrar's current rent price oracle accepts a payment token.
-    ///      Fails closed when the registrar or its oracle does not answer as expected.
-    /// @param registrar The registrar whose oracle decides payment-token support.
-    /// @param token The candidate payment token.
-    /// @return supported Whether the registrar's oracle accepts the token.
-    function _isRegistrarPaymentToken(address registrar, address token)
+    function _isAuthorizedRegistrar(address account, RegistrationPolicyState memory state)
         internal
         view
-        returns (bool supported)
+        returns (bool authorized)
     {
-        return HCARegistrarPolicyLib.isPaymentToken(registrar, token);
+        if (account != address(0) && state.authorizedRegistrar == account) {
+            return true;
+        }
+        authorized = HCARegistrarPolicyLib.isAuthorized(ETH_REGISTRY, account);
+        if (authorized) {
+            state.authorizedRegistrar = account;
+        }
     }
 
-    /// @dev Returns whether every registration in a batch uses a registrar whose oracle accepts
-    ///      the token. Batches without a registration bind the token to the signed intent only.
-    /// @param operationData The encoded ERC-7579 operation payload.
-    /// @param token The token delivered to the account by the signed intent.
-    /// @return supported Whether every used registrar accepts the token.
-    function _isBatchRegistrarPaymentToken(bytes calldata operationData, address token)
+    /// @dev Decodes the packed fixed fields and locates the multi-chain owner authorization.
+    ///      Returns a zero proof end when the envelope cannot contain the required tail.
+    function _decodeSessionEnableProof(bytes calldata data, uint256 tailLength)
         internal
-        view
-        returns (bool supported)
+        pure
+        returns (
+            bytes32 permissionId,
+            SessionEnableProof memory proof,
+            bytes calldata packedSessions,
+            bytes calldata ownerSignature,
+            uint256 proofEnd
+        )
     {
-        return HCARegistrarPolicyLib.isBatchPaymentToken(operationData, token);
+        packedSessions = data[0:0];
+        ownerSignature = data[0:0];
+        uint256 proofOffset = HCASmartSessionLib.ENABLE_PREFIX_LENGTH;
+        if (data.length <= proofOffset + _SESSION_PROOF_BASE_LENGTH + tailLength) {
+            return (permissionId, proof, packedSessions, ownerSignature, 0);
+        }
+
+        permissionId = bytes32(data[1:proofOffset]);
+        uint256 chainCount = uint8(data[proofOffset + _SESSION_PROOF_HEADER_LENGTH - 1]);
+        if (chainCount == 0) {
+            return (permissionId, proof, packedSessions, ownerSignature, 0);
+        }
+
+        uint256 sessionsOffset = proofOffset + _SESSION_PROOF_HEADER_LENGTH;
+        uint256 signatureOffset =
+            sessionsOffset + chainCount * HCASmartSessionLib.AUTHORIZATION_ENTRY_LENGTH;
+        proofEnd = signatureOffset + HCASignatureLib.SIGNATURE_LENGTH;
+        if (proofEnd + tailLength >= data.length) {
+            return (permissionId, proof, packedSessions, ownerSignature, 0);
+        }
+
+        proof = SessionEnableProof({sessionKey: address(bytes20(data[proofOffset:proofOffset + 20])), validUntil: uint48(
+            bytes6(data[proofOffset + 20:proofOffset + 26])
+        ), sessionNonce: uint96(bytes12(data[proofOffset + 26:proofOffset + 38])), resolver: address(
+            bytes20(data[proofOffset + 38:proofOffset + 58])
+        ), refundToken: address(bytes20(data[proofOffset + 58:proofOffset + 78])), maxRefundExchangeRate: uint96(
+            bytes12(data[proofOffset + 78:proofOffset + 90])
+        ), maxRefundGasOverhead: uint48(bytes6(data[proofOffset + 90:proofOffset + 96])), maxRefundAmount: uint96(
+            bytes12(data[proofOffset + 96:proofOffset + 108])
+        ), sessionToEnableIndex: uint8(data[proofOffset + 108])});
+        packedSessions = data[sessionsOffset:signatureOffset];
+        ownerSignature = data[signatureOffset:proofEnd];
     }
 
-    /// @dev Finds and checks an optional EIP-2612 funding pull into the HCA.
+    /// @dev Validates one leg of an optional EIP-2612 funding pull into the HCA.
     ///      The permit and transfer must be adjacent, use the same amount, and consume the full
     ///      allowance that the owner gave to this HCA.
-    function _fundingCallIndexes(
-        Execution[] memory executions,
-        address account,
-        address owner,
-        address token
+    function _checkFundingCall(
+        Execution memory execution,
+        bytes4 selector,
+        uint256 index,
+        FundingPolicyState memory state
     )
         internal
         pure
-        returns (uint256 permitIndex, uint256 transferIndex)
     {
-        permitIndex = type(uint256).max;
-        transferIndex = type(uint256).max;
-        uint256 permittedAmount;
-        uint256 transferredAmount;
-
-        for (uint256 i; i < executions.length; ++i) {
-            Execution memory execution = executions[i];
-            if (execution.target != token) {
-                continue;
+        if (selector == IERC20Permit.permit.selector) {
+            if (state.permitted || execution.callData.length != 4 + 7 * 32) {
+                revert PolicyRuleFailed();
             }
-            bytes4 selector = _selector(execution.callData);
-            if (selector == IERC20Permit.permit.selector) {
-                if (
-                    permitIndex != type(uint256).max ||
-                    execution.value != 0 ||
-                    execution.callData.length != 4 + 7 * 32
-                ) {
-                    revert PolicyRuleFailed();
-                }
-                _requireArgAddress(execution.callData, 4, owner);
-                _requireArgAddress(execution.callData, 4 + 32, account);
-                permittedAmount = _readUint(execution.callData, 4 + 2 * 32);
-                permitIndex = i;
-            } else if (selector == IERC20.transferFrom.selector) {
-                if (
-                    transferIndex != type(uint256).max ||
-                    execution.value != 0 ||
-                    execution.callData.length != 4 + 3 * 32
-                ) {
-                    revert PolicyRuleFailed();
-                }
-                _requireArgAddress(execution.callData, 4, owner);
-                _requireArgAddress(execution.callData, 4 + 32, account);
-                transferredAmount = _readUint(execution.callData, 4 + 2 * 32);
-                transferIndex = i;
+            _requireArgAddress(execution.callData, 4, state.owner);
+            _requireArgAddress(execution.callData, 4 + 32, state.account);
+            state.permittedAmount = _readUint(execution.callData, 4 + 2 * 32);
+            if (state.permittedAmount == 0) {
+                revert PolicyRuleFailed();
             }
+            state.permitted = true;
+            state.permitIndex = index;
+            return;
         }
 
-        if (permitIndex == type(uint256).max && transferIndex == type(uint256).max) {
-            return (permitIndex, transferIndex);
-        }
         if (
-            permitIndex == type(uint256).max ||
-            transferIndex != permitIndex + 1 ||
-            permittedAmount == 0 ||
-            transferredAmount != permittedAmount
+            !state.permitted ||
+            state.transferred ||
+            index != state.permitIndex + 1 ||
+            execution.callData.length != 4 + 3 * 32
         ) {
             revert PolicyRuleFailed();
         }
+        _requireArgAddress(execution.callData, 4, state.owner);
+        _requireArgAddress(execution.callData, 4 + 32, state.account);
+        if (_readUint(execution.callData, 4 + 2 * 32) != state.permittedAmount) {
+            revert PolicyRuleFailed();
+        }
+        state.transferred = true;
     }
 
     /// @dev Hashes the fixed HCA fields stored in the standard Smart Session salt.
@@ -1523,7 +945,10 @@ contract HCAOwnerAndSessionValidator is IValidator {
     }
 
     /// @dev Checks an executor reimbursement against the limits approved for a session.
-    function _checkGasRefund(SessionConfig memory config, GasRefund memory gasRefund) internal pure {
+    function _checkGasRefund(SessionEnableProof memory proof, GasRefund memory gasRefund)
+        internal
+        pure
+    {
         if (gasRefund.token == address(0)) {
             if (gasRefund.exchangeRate != 0 || gasRefund.overhead != 0) {
                 revert GasRefundNotAllowed();
@@ -1533,29 +958,27 @@ contract HCAOwnerAndSessionValidator is IValidator {
         uint256 refundAmount = gasRefund.overhead >> 128;
         uint256 gasOverhead = uint128(gasRefund.overhead);
         if (
-            gasRefund.token != config.refundToken ||
+            gasRefund.token != proof.refundToken ||
             gasRefund.exchangeRate == 0 ||
-            gasRefund.exchangeRate > config.maxRefundExchangeRate ||
+            gasRefund.exchangeRate > proof.maxRefundExchangeRate ||
             refundAmount == 0 ||
-            refundAmount > config.maxRefundAmount ||
-            gasOverhead > config.maxRefundGasOverhead
+            refundAmount > proof.maxRefundAmount ||
+            gasOverhead > proof.maxRefundGasOverhead
         ) {
             revert GasRefundNotAllowed();
         }
     }
 
-    /// @dev Hashes the encoded ERC-7579 operation exactly as IntentExecutor does.
-    function _operationHash(bytes calldata operationData) internal pure returns (bytes32) {
-        if (operationData.length < 32) {
+    /// @dev Decodes an operation after checking that its mode uses ERC-1271 authorization.
+    function _decodeERC1271Operation(bytes calldata operationData)
+        internal
+        pure
+        returns (HCAOperationHashLib.DecodedOperation memory operation, bytes32 operationHash)
+    {
+        (operation, operationHash) = HCAOperationHashLib.decodeAndHash(operationData);
+        if (!HCAOperationHashLib.isERC1271Mode(operation.mode)) {
             revert InvalidOperationEncoding();
         }
-
-        bytes32 operationMode = bytes32(operationData[:32]);
-        if (!HCAOperationHashLib.isERC1271Mode(operationMode)) {
-            revert InvalidOperationEncoding();
-        }
-
-        return HCAOperationHashLib.hash(operationData);
     }
 
     /// @notice Reads a function selector from calldata.
@@ -1569,9 +992,8 @@ contract HCAOwnerAndSessionValidator is IValidator {
     /// @notice Validates resolver record writes on the owner-authorized resolver.
     /// @dev Allows known resolver setters directly or recursively through supported multicalls.
     /// @param callData ABI-encoded resolver call data.
-    /// @param owner The owner recorded for the HCA.
-    function _checkResolverCall(bytes memory callData, address owner) internal pure {
-        HCAResolverPolicyLib.checkCall(callData, owner);
+    function _checkResolverCall(bytes memory callData) internal pure {
+        HCAResolverPolicyLib.checkCall(callData);
     }
 
     /// @notice Reads the fields relevant to the registration policy from a register call.
@@ -1585,14 +1007,6 @@ contract HCAOwnerAndSessionValidator is IValidator {
         returns (address registrant, address resolver)
     {
         return HCARegistrarPolicyLib.registrationFields(callData);
-    }
-
-    /// @notice Copies function arguments out of ABI calldata bytes.
-    /// @dev Drops the four-byte function selector and returns ABI-encoded arguments.
-    /// @param callData ABI-encoded call data with a function selector prefix.
-    /// @return args ABI-encoded function arguments.
-    function _callArgs(bytes memory callData) internal pure returns (bytes memory args) {
-        return HCAExecutionLib.callArgs(callData);
     }
 
     /// @notice Reads an ABI-encoded address argument from calldata.
@@ -1633,17 +1047,5 @@ contract HCAOwnerAndSessionValidator is IValidator {
         returns (uint256 result)
     {
         return HCAExecutionLib.readUint(callData, offset);
-    }
-
-    /// @dev Recovers a Rhinestone signature and maps malformed signatures to `InvalidSigner`.
-    function _recover(bytes32 digest, bytes calldata signature)
-        internal
-        pure
-        returns (address signer)
-    {
-        signer = HCASignatureLib.recover(digest, signature);
-        if (signer == address(0)) {
-            revert InvalidSigner();
-        }
     }
 }

--- a/contracts/src/hca/HCAOwnerAndSessionValidator.sol
+++ b/contracts/src/hca/HCAOwnerAndSessionValidator.sol
@@ -815,18 +815,21 @@ contract HCAOwnerAndSessionValidator is HCAValidatorBase {
         }
     }
 
-    /// @dev Returns whether the pinned registry currently authorizes an account to register names.
-    ///      Reuses a successful lookup within the same operation batch.
+    /// @dev Selects the first authorized registrar used by an operation batch and requires every
+    ///      later registrar action to use the same account.
     /// @param account The prospective registrar.
-    /// @param state The policy state caching one authorized registrar.
-    /// @return authorized Whether the account holds the root registrar role.
+    /// @param state The policy state containing the registrar selected by the batch.
+    /// @return authorized Whether the account is the batch's selected registry-authorized registrar.
     function _isAuthorizedRegistrar(address account, RegistrationPolicyState memory state)
         internal
         view
         returns (bool authorized)
     {
-        if (account != address(0) && state.authorizedRegistrar == account) {
-            return true;
+        if (account == address(0)) {
+            return false;
+        }
+        if (state.authorizedRegistrar != address(0)) {
+            return state.authorizedRegistrar == account;
         }
         authorized = HCARegistrarPolicyLib.isAuthorized(ETH_REGISTRY, account);
         if (authorized) {

--- a/contracts/src/hca/HCAValidatorBase.sol
+++ b/contracts/src/hca/HCAValidatorBase.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.27;
+
+import {IValidator} from "nexus/interfaces/modules/IValidator.sol";
+import {MODULE_TYPE_VALIDATOR} from "nexus/types/Constants.sol";
+
+/// @title HCA Validator Base
+/// @notice Shares the stateless ERC-7579 module surface used by fixed HCA validators.
+/// @dev Concrete validators provide their signature and operation-policy implementations.
+abstract contract HCAValidatorBase is IValidator {
+    /// @notice Reports permissions as disabled so reusable proofs remain attached to operations.
+    /// @param account Unused account address.
+    /// @param permissionId Unused session permission identifier.
+    /// @return Always false because the authorization is supplied with each operation.
+    function isPermissionEnabled(address account, bytes32 permissionId)
+        external
+        pure
+        returns (bool)
+    {
+        account;
+        permissionId;
+        return false;
+    }
+
+    /// @notice Returns whether this module is an ERC-7579 validator.
+    /// @param moduleTypeId The module type to inspect.
+    /// @return True only for the validator module type.
+    function isModuleType(uint256 moduleTypeId) external pure returns (bool) {
+        return moduleTypeId == MODULE_TYPE_VALIDATOR;
+    }
+}

--- a/contracts/src/hca/StandaloneHCAFactory.sol
+++ b/contracts/src/hca/StandaloneHCAFactory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
+import {IUUPSProxy} from "@ensdomains/verifiable-factory/IUUPSProxy.sol";
 import {IVerifiableFactory} from "@ensdomains/verifiable-factory/IVerifiableFactory.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
@@ -130,10 +131,12 @@ contract StandaloneHCAFactory is IStandaloneHCAFactory, Ownable {
             initData
         );
 
-        address deployedImplementation = VERIFIABLE_FACTORY.verifyContract(hca);
+        (, address deployedImplementation) = IUUPSProxy(hca).getVerifiableProxyData();
         if (deployedImplementation != hcaImplementation) {
             revert UnexpectedHCAImplementation(hcaImplementation, deployedImplementation);
         }
+
+        hcaOwners[hca] = owner;
 
         address deployedOwner;
         try IStandaloneHCAOwner(hca).owner() returns (address owner_) {
@@ -145,7 +148,6 @@ contract StandaloneHCAFactory is IStandaloneHCAFactory, Ownable {
             revert UnexpectedHCAOwner(owner, deployedOwner);
         }
 
-        hcaOwners[hca] = owner;
         emit HCADeployed(hca, owner, hcaImplementation, userSalt);
     }
 

--- a/contracts/src/hca/StandaloneSingleOwnerHCA.sol
+++ b/contracts/src/hca/StandaloneSingleOwnerHCA.sol
@@ -2,8 +2,9 @@
 pragma solidity 0.8.27;
 
 import {IProxyAuthorization} from "@ensdomains/verifiable-factory/IProxyAuthorization.sol";
+import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import {PackedUserOperation} from "account-abstraction/interfaces/PackedUserOperation.sol";
-import {IModule} from "nexus/interfaces/modules/IModule.sol";
 import {IValidator} from "nexus/interfaces/modules/IValidator.sol";
 import {
     CALLTYPE_BATCH,
@@ -23,6 +24,8 @@ import {Execution} from "nexus/types/DataTypes.sol";
 
 import {IAddressSet} from "../utils/interfaces/IAddressSet.sol";
 
+import {IStandaloneHCAFactory} from "./interfaces/IStandaloneHCAFactory.sol";
+
 /// @title Standalone Single Owner HCA
 /// @notice Nexus account whose owner is set once during account initialization.
 /// @dev Module changes are disabled after initialization and the configured default validator
@@ -33,20 +36,8 @@ contract StandaloneSingleOwnerHCA is Nexus, IProxyAuthorization {
     using NonceLib for uint256;
 
     ////////////////////////////////////////////////////////////////////////
-    // Constants & Immutables
+    // Immutables
     ////////////////////////////////////////////////////////////////////////
-
-    /// @notice Selector for ERC-721 token receipt.
-    /// @dev Returned by `onERC721Received`.
-    bytes4 internal constant ERC721_RECEIVED_SELECTOR = 0x150b7a02;
-
-    /// @notice Selector for single ERC-1155 token receipt.
-    /// @dev Returned by `onERC1155Received`.
-    bytes4 internal constant ERC1155_RECEIVED_SELECTOR = 0xf23a6e61;
-
-    /// @notice Selector for batched ERC-1155 token receipt.
-    /// @dev Returned by `onERC1155BatchReceived`.
-    bytes4 internal constant ERC1155_BATCH_RECEIVED_SELECTOR = 0xbc197c81;
 
     /// @notice The allowlist of upgrade target implementations permitted from this implementation.
     IAddressSet public immutable UPGRADE_SET;
@@ -55,12 +46,19 @@ contract StandaloneSingleOwnerHCA is Nexus, IProxyAuthorization {
     /// @dev The initial trusted implementation uses the zero address and rejects all predecessors.
     IAddressSet public immutable PREDECESSOR_UPGRADE_SET;
 
+    /// @notice The factory that stores immutable owner certifications for production HCAs.
+    /// @dev A zero address retains direct-deployment behavior for isolated account deployments.
+    IStandaloneHCAFactory public immutable OWNER_REGISTRY;
+
+    /// @dev The VerifiableFactory allowed to invoke production proxy initialization.
+    address private immutable _ACCOUNT_DEPLOYER;
+
     ////////////////////////////////////////////////////////////////////////
     // Storage
     ////////////////////////////////////////////////////////////////////////
 
-    /// @notice The initialized account owner.
-    /// @dev Set once during `initializeAccount`.
+    /// @dev Legacy owner storage retained at its original offset for upgrade compatibility.
+    ///      New factory deployments read the canonical owner from `OWNER_REGISTRY`.
     address private _owner;
 
     /// @notice The nonce bound to every enabled fixed session.
@@ -108,7 +106,7 @@ contract StandaloneSingleOwnerHCA is Nexus, IProxyAuthorization {
 
     /// @dev Restricts a function to the initialized account owner.
     modifier onlyOwner() {
-        if (msg.sender != _owner) {
+        if (msg.sender != _accountOwner()) {
             revert CallerNotOwner();
         }
         _;
@@ -137,38 +135,50 @@ contract StandaloneSingleOwnerHCA is Nexus, IProxyAuthorization {
     /// @param validatorInitData_ Initialization data passed to the default validator.
     /// @param upgradeSet_ The allowlist of permitted upgrade target implementations.
     /// @param predecessorUpgradeSet_ The predecessor allowlist; zero rejects every predecessor.
+    /// @param ownerRegistry_ The factory containing immutable HCA owner certifications.
     constructor(
         address entryPoint_,
         address defaultValidator_,
         address intentExecutor_,
         bytes memory validatorInitData_,
         IAddressSet upgradeSet_,
-        IAddressSet predecessorUpgradeSet_
+        IAddressSet predecessorUpgradeSet_,
+        IStandaloneHCAFactory ownerRegistry_
     )
         Nexus(entryPoint_, defaultValidator_, intentExecutor_, validatorInitData_, "")
     {
         UPGRADE_SET = upgradeSet_;
         PREDECESSOR_UPGRADE_SET = predecessorUpgradeSet_;
+        OWNER_REGISTRY = ownerRegistry_;
+        _ACCOUNT_DEPLOYER =
+            address(ownerRegistry_) == address(0)
+                ? address(0)
+                : address(ownerRegistry_.VERIFIABLE_FACTORY());
     }
 
     ////////////////////////////////////////////////////////////////////////
     // Implementation
     ////////////////////////////////////////////////////////////////////////
 
-    /// @notice Initializes the account owner.
+    /// @notice Initializes a direct account or validates a factory account's proposed owner.
+    /// @dev The immutable default executor is authorized directly by Nexus and does not require
+    ///      per-account module initialization.
     /// @param initData ABI-encoded owner address.
     function initializeAccount(bytes calldata initData) external payable override {
-        if (_owner != address(0)) {
-            revert StandaloneHCAAlreadyInitialized();
-        }
-
         address initialOwner = abi.decode(initData, (address));
         if (initialOwner == address(0)) {
             revert OwnerCannotBeZero();
         }
 
-        _owner = initialOwner;
-        IModule(_DEFAULT_EXECUTOR).onInstall("");
+        IStandaloneHCAFactory ownerRegistry = OWNER_REGISTRY;
+        if (address(ownerRegistry) == address(0)) {
+            if (_owner != address(0)) {
+                revert StandaloneHCAAlreadyInitialized();
+            }
+            _owner = initialOwner;
+        } else if (msg.sender != _ACCOUNT_DEPLOYER) {
+            revert StandaloneHCAAlreadyInitialized();
+        }
     }
 
     /// @notice Disables module installation.
@@ -246,16 +256,49 @@ contract StandaloneSingleOwnerHCA is Nexus, IProxyAuthorization {
         return IValidator(_DEFAULT_VALIDATOR).validateUserOp(userOp, userOpHash);
     }
 
+    /// @notice Validates a signature through the account's fixed default validator.
+    /// @dev Preserves Nexus's zero-address default-validator prefix and ERC-7739 detection while
+    ///      omitting dynamic validator and pre-validation-hook lookups that this account disables.
+    /// @param hash The digest to validate.
+    /// @param signature A zero-address validator prefix followed by validator-specific data.
+    /// @return magicValue The ERC-1271 success value, or the failure value when validation reverts.
+    function isValidSignature(bytes32 hash, bytes calldata signature)
+        external
+        view
+        override
+        returns (bytes4 magicValue)
+    {
+        if (signature.length == 0) {
+            if (uint256(hash) == (~signature.length / 0xffff) * 0x7739) {
+                return checkERC7739Support(hash, signature);
+            }
+        }
+
+        address validator = address(bytes20(signature[:20]));
+        if (validator != address(0)) {
+            revert ValidatorNotInstalled(validator);
+        }
+        try IValidator(_DEFAULT_VALIDATOR).isValidSignatureWithSender(
+            msg.sender,
+            hash,
+            signature[20:]
+        ) returns (bytes4 result) {
+            return result;
+        } catch {
+            return bytes4(0xffffffff);
+        }
+    }
+
     /// @notice Returns the account owner.
     function owner() external view returns (address) {
-        return _owner;
+        return _accountOwner();
     }
 
     /// @notice Returns the account owner and current session nonce.
     /// @return owner_ The account owner.
     /// @return sessionNonce_ The current session nonce.
     function ownerAndSessionNonce() external view returns (address owner_, uint96 sessionNonce_) {
-        return (_owner, _sessionNonce);
+        return (_accountOwner(), _sessionNonce);
     }
 
     /// @notice Returns whether a predecessor may upgrade into this implementation.
@@ -300,18 +343,27 @@ contract StandaloneSingleOwnerHCA is Nexus, IProxyAuthorization {
     function _fallback(bytes calldata callData) internal override {
         if (callData.length >= 4) {
             bytes4 selector = bytes4(callData[0:4]);
-            if (selector == ERC721_RECEIVED_SELECTOR) {
+            if (selector == IERC721Receiver.onERC721Received.selector) {
                 revert NoNFTAllowed();
             }
-            if (selector == ERC1155_RECEIVED_SELECTOR) {
+            if (selector == IERC1155Receiver.onERC1155Received.selector) {
                 revert NoNFTAllowed();
             }
-            if (selector == ERC1155_BATCH_RECEIVED_SELECTOR) {
+            if (selector == IERC1155Receiver.onERC1155BatchReceived.selector) {
                 revert NoNFTAllowed();
             }
         }
 
         super._fallback(callData);
+    }
+
+    /// @dev Returns the factory-certified owner or the directly initialized legacy owner.
+    function _accountOwner() internal view returns (address owner_) {
+        IStandaloneHCAFactory ownerRegistry = OWNER_REGISTRY;
+        return
+            address(ownerRegistry) == address(0)
+                ? _owner
+                : ownerRegistry.hcaOwners(address(this));
     }
 
     /// @dev Requires the owner as caller and allowlist approval for the target implementation.

--- a/contracts/src/hca/libraries/HCAExecutionLib.sol
+++ b/contracts/src/hca/libraries/HCAExecutionLib.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
+import {Bytes} from "@openzeppelin/contracts/utils/Bytes.sol";
+
 /// @title HCA Execution Library
 /// @notice Reads selectors and ABI words from policy-controlled execution calldata.
 /// @dev Preserves one policy-specific error for malformed execution encodings.
@@ -17,9 +19,7 @@ library HCAExecutionLib {
         if (callData.length < 4) {
             revert InvalidOperationEncoding();
         }
-        assembly ("memory-safe") {
-            callSelector := mload(add(callData, 0x20))
-        }
+        return bytes4(callData);
     }
 
     /// @notice Copies function arguments out of encoded call data.
@@ -30,10 +30,7 @@ library HCAExecutionLib {
         if (callData.length < 4) {
             revert InvalidOperationEncoding();
         }
-        args = new bytes(callData.length - 4);
-        for (uint256 i; i < args.length; ++i) {
-            args[i] = callData[i + 4];
-        }
+        return Bytes.slice(callData, 4);
     }
 
     /// @notice Reads an ABI-encoded address argument from call data.

--- a/contracts/src/hca/libraries/HCAOperationHashLib.sol
+++ b/contracts/src/hca/libraries/HCAOperationHashLib.sol
@@ -109,19 +109,19 @@ library HCAOperationHashLib {
                 revert(0, 4)
             }
 
-            let inputLength := operationData.length
-            if lt(inputLength, _PACKED_OPERATION_PREFIX_LENGTH) { fail() }
-            let inputOffset := operationData.offset
-            let firstWord := calldataload(inputOffset)
-            let mode := shl(240, shr(240, firstWord))
-            let count := byte(2, firstWord)
+            if lt(operationData.length, _PACKED_OPERATION_PREFIX_LENGTH) { fail() }
 
-            operation := mload(0x40)
-            mstore(operation, mode)
-            let executions := add(operation, 0x40)
-            mstore(add(operation, 0x20), executions)
-            mstore(executions, count)
-            let executionCursor := add(executions, 0x20)
+            let count
+            {
+                let firstWord := calldataload(operationData.offset)
+                count := byte(2, firstWord)
+                operation := mload(0x40)
+                mstore(operation, shl(240, shr(240, firstWord)))
+            }
+
+            mstore(add(operation, 0x20), add(operation, 0x40))
+            mstore(add(operation, 0x40), count)
+            let executionCursor := add(operation, 0x60)
             let hashes := add(executionCursor, shl(5, count))
             mstore(hashes, count)
             let hashCursor := add(hashes, 0x20)
@@ -129,24 +129,25 @@ library HCAOperationHashLib {
             let cursor := _PACKED_OPERATION_PREFIX_LENGTH
 
             for { let i := 0 } lt(i, count) { i := add(i, 1) } {
-                if gt(add(cursor, _PACKED_EXECUTION_PREFIX_LENGTH), inputLength) { fail() }
-                let target := shr(96, calldataload(add(inputOffset, cursor)))
+                if gt(add(cursor, _PACKED_EXECUTION_PREFIX_LENGTH), operationData.length) {
+                    fail()
+                }
+                let target := shr(96, calldataload(add(operationData.offset, cursor)))
                 let callDataLength :=
-                    shr(232, calldataload(add(add(inputOffset, cursor), 20)))
+                    shr(232, calldataload(add(add(operationData.offset, cursor), 20)))
                 cursor := add(cursor, _PACKED_EXECUTION_PREFIX_LENGTH)
-                let callDataEnd := add(cursor, callDataLength)
-                if gt(callDataEnd, inputLength) { fail() }
+                if gt(add(cursor, callDataLength), operationData.length) { fail() }
 
                 mstore(executionCursor, free)
-                let execution := free
-                free := add(free, 0x60)
-                mstore(execution, target)
-                mstore(add(execution, 0x20), 0)
-                mstore(add(execution, 0x40), free)
-                mstore(free, callDataLength)
-                let callDataPointer := add(free, 0x20)
+                mstore(free, target)
+                mstore(add(free, 0x20), 0)
+                mstore(add(free, 0x40), add(free, 0x60))
+                mstore(add(free, 0x60), callDataLength)
+                let callDataPointer := add(free, 0x80)
                 mstore(add(callDataPointer, callDataLength), 0)
-                calldatacopy(callDataPointer, add(inputOffset, cursor), callDataLength)
+                calldatacopy(
+                    callDataPointer, add(operationData.offset, cursor), callDataLength
+                )
                 free := and(add(add(callDataPointer, callDataLength), 0x1f), not(0x1f))
 
                 mstore(
@@ -160,16 +161,16 @@ library HCAOperationHashLib {
 
                 executionCursor := add(executionCursor, 0x20)
                 hashCursor := add(hashCursor, 0x20)
-                cursor := callDataEnd
+                cursor := add(cursor, callDataLength)
             }
-            if iszero(eq(cursor, inputLength)) { fail() }
+            if iszero(eq(cursor, operationData.length)) { fail() }
 
             let executionArrayHash := keccak256(add(hashes, 0x20), shl(5, count))
             mstore(
                 free,
                 0xdbc520cb50a8aaf3fa06ea43dc3d59d248e52ae638476e3268a1e6e36bffe196
             )
-            mstore(add(free, 0x20), mode)
+            mstore(add(free, 0x20), mload(operation))
             mstore(add(free, 0x40), executionArrayHash)
             operationHash := keccak256(free, 0x60)
             mstore(0x40, add(free, 0x80))

--- a/contracts/src/hca/libraries/HCAOperationHashLib.sol
+++ b/contracts/src/hca/libraries/HCAOperationHashLib.sol
@@ -5,8 +5,18 @@ import {Execution} from "nexus/types/DataTypes.sol";
 
 /// @title HCA Operation Hash Library
 /// @notice Reconstructs the operation hashes used by Rhinestone intents.
-/// @dev Decodes the operation tuple shared by the HCA validation policies.
+/// @dev Uses the canonical Nexus execution tuple when decoding operation batches.
 library HCAOperationHashLib {
+    ////////////////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Decoded ERC-7579 operation reused across hashing and policy validation.
+    struct DecodedOperation {
+        bytes32 mode;
+        Execution[] executions;
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // Constants
     ////////////////////////////////////////////////////////////////////////
@@ -32,6 +42,20 @@ library HCAOperationHashLib {
     bytes32 internal constant ERC7579_ERC1271_EMISSARY_EXECUTION_MODE =
         bytes32(uint256(0x0206) << 240);
 
+    /// @dev Bytes preceding the packed execution entries: two mode bytes and one count byte.
+    uint256 private constant _PACKED_OPERATION_PREFIX_LENGTH = 3;
+
+    /// @dev Bytes preceding each packed execution's calldata: target and three-byte length.
+    uint256 private constant _PACKED_EXECUTION_PREFIX_LENGTH = 23;
+
+    ////////////////////////////////////////////////////////////////////////
+    // Errors
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice A packed operation is malformed.
+    /// @dev Error selector: `0xf679d4db`
+    error InvalidOperationEncoding();
+
     ////////////////////////////////////////////////////////////////////////
     // Implementation
     ////////////////////////////////////////////////////////////////////////
@@ -55,29 +79,100 @@ library HCAOperationHashLib {
         return mode == ERC7579_ERC1271_MODE || mode == ERC7579_ERC1271_EMISSARY_EXECUTION_MODE;
     }
 
-    /// @notice Hashes an encoded ERC-7579 operation as the IntentExecutor does.
-    /// @dev The caller must validate the operation mode and ensure that `operationData` contains
-    ///      its leading mode word before calling this function.
-    /// @param operationData The operation mode followed by an ABI-encoded execution array.
+    /// @notice Decodes a packed zero-value ERC-7579 operation for reuse across validation stages.
+    /// @dev The encoding is two mode bytes, a one-byte execution count, then entries containing
+    ///      a 20-byte target, three-byte calldata length, and raw calldata. Values are omitted
+    ///      because every HCA policy rejects nonzero-value executions.
+    /// @param operationData The packed operation.
+    /// @return operation The decoded mode and execution array.
+    function decode(bytes calldata operationData)
+        internal
+        pure
+        returns (DecodedOperation memory operation)
+    {
+        (operation, ) = decodeAndHash(operationData);
+    }
+
+    /// @notice Decodes and hashes a packed zero-value ERC-7579 operation in one pass.
+    /// @dev Reverts unless the execution count and every calldata length consume the input exactly.
+    /// @param operationData The packed operation.
+    /// @return operation The decoded mode and execution array.
     /// @return operationHash The EIP-712 operation struct hash.
-    function hash(bytes calldata operationData) internal pure returns (bytes32 operationHash) {
-        bytes32 mode = bytes32(operationData[:32]);
-        Execution[] memory executions = abi.decode(operationData[32:], (Execution[]));
-        bytes32[] memory executionHashes = new bytes32[](executions.length);
-        for (uint256 i; i < executions.length; ++i) {
-            Execution memory execution = executions[i];
-            executionHashes[i] = keccak256(
-                abi.encode(
-                    EXECUTION_TYPEHASH,
-                    execution.target,
-                    execution.value,
-                    keccak256(execution.callData)
+    function decodeAndHash(bytes calldata operationData)
+        internal
+        pure
+        returns (DecodedOperation memory operation, bytes32 operationHash)
+    {
+        assembly ("memory-safe") {
+            function fail() {
+                mstore(0, shl(224, 0xf679d4db))
+                revert(0, 4)
+            }
+
+            let inputLength := operationData.length
+            if lt(inputLength, _PACKED_OPERATION_PREFIX_LENGTH) { fail() }
+            let inputOffset := operationData.offset
+            let firstWord := calldataload(inputOffset)
+            let mode := shl(240, shr(240, firstWord))
+            let count := byte(2, firstWord)
+
+            operation := mload(0x40)
+            mstore(operation, mode)
+            let executions := add(operation, 0x40)
+            mstore(add(operation, 0x20), executions)
+            mstore(executions, count)
+            let executionCursor := add(executions, 0x20)
+            let hashes := add(executionCursor, shl(5, count))
+            mstore(hashes, count)
+            let hashCursor := add(hashes, 0x20)
+            let free := add(hashCursor, shl(5, count))
+            let cursor := _PACKED_OPERATION_PREFIX_LENGTH
+
+            for { let i := 0 } lt(i, count) { i := add(i, 1) } {
+                if gt(add(cursor, _PACKED_EXECUTION_PREFIX_LENGTH), inputLength) { fail() }
+                let target := shr(96, calldataload(add(inputOffset, cursor)))
+                let callDataLength :=
+                    shr(232, calldataload(add(add(inputOffset, cursor), 20)))
+                cursor := add(cursor, _PACKED_EXECUTION_PREFIX_LENGTH)
+                let callDataEnd := add(cursor, callDataLength)
+                if gt(callDataEnd, inputLength) { fail() }
+
+                mstore(executionCursor, free)
+                let execution := free
+                free := add(free, 0x60)
+                mstore(execution, target)
+                mstore(add(execution, 0x20), 0)
+                mstore(add(execution, 0x40), free)
+                mstore(free, callDataLength)
+                let callDataPointer := add(free, 0x20)
+                mstore(add(callDataPointer, callDataLength), 0)
+                calldatacopy(callDataPointer, add(inputOffset, cursor), callDataLength)
+                free := and(add(add(callDataPointer, callDataLength), 0x1f), not(0x1f))
+
+                mstore(
+                    free,
+                    0x09b0a32e9842b65559835c235891737e06927d59e48a6f0e0512e136a513a9e4
                 )
-            );
+                mstore(add(free, 0x20), target)
+                mstore(add(free, 0x40), 0)
+                mstore(add(free, 0x60), keccak256(callDataPointer, callDataLength))
+                mstore(hashCursor, keccak256(free, 0x80))
+
+                executionCursor := add(executionCursor, 0x20)
+                hashCursor := add(hashCursor, 0x20)
+                cursor := callDataEnd
+            }
+            if iszero(eq(cursor, inputLength)) { fail() }
+
+            let executionArrayHash := keccak256(add(hashes, 0x20), shl(5, count))
+            mstore(
+                free,
+                0xdbc520cb50a8aaf3fa06ea43dc3d59d248e52ae638476e3268a1e6e36bffe196
+            )
+            mstore(add(free, 0x20), mode)
+            mstore(add(free, 0x40), executionArrayHash)
+            operationHash := keccak256(free, 0x60)
+            mstore(0x40, add(free, 0x80))
         }
-        return
-            keccak256(
-                abi.encode(OPERATION_TYPEHASH, mode, keccak256(abi.encodePacked(executionHashes)))
-            );
     }
 }

--- a/contracts/src/hca/libraries/HCAPermit2Lib.sol
+++ b/contracts/src/hca/libraries/HCAPermit2Lib.sol
@@ -97,19 +97,13 @@ library HCAPermit2Lib {
         returns (bytes32 result)
     {
         bytes32 tokenPermissionsHash =
-            keccak256(
-                abi.encodePacked(
-                    keccak256(
-                        abi.encode(TOKEN_PERMISSIONS_TYPEHASH, claim.sourceToken, claim.sourceAmount)
-                    )
+            _hashElement(
+                keccak256(
+                    abi.encode(TOKEN_PERMISSIONS_TYPEHASH, claim.sourceToken, claim.sourceAmount)
                 )
             );
         bytes32 tokenOutHash =
-            keccak256(
-                abi.encodePacked(
-                    keccak256(abi.encode(TOKEN_TYPEHASH, claim.tokenOut, claim.amountOut))
-                )
-            );
+            _hashElement(keccak256(abi.encode(TOKEN_TYPEHASH, claim.tokenOut, claim.amountOut)));
         bytes32 targetHash =
             keccak256(
                 abi.encode(
@@ -145,5 +139,17 @@ library HCAPermit2Lib {
         bytes32 domainSeparator =
             keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, PERMIT2_NAME_HASH, sourceChainId, permit2));
         return MessageHashUtils.toTypedDataHash(domainSeparator, permitHash);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Private Functions
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Hashes the packed encoding of a single EIP-712 array element.
+    function _hashElement(bytes32 elementHash) private pure returns (bytes32 result) {
+        assembly ("memory-safe") {
+            mstore(0, elementHash)
+            result := keccak256(0, 0x20)
+        }
     }
 }

--- a/contracts/src/hca/libraries/HCARegistrarPolicyLib.sol
+++ b/contracts/src/hca/libraries/HCARegistrarPolicyLib.sol
@@ -57,25 +57,31 @@ library HCARegistrarPolicyLib {
         }
     }
 
-    /// @notice Returns whether every registration in a batch accepts a payment token.
-    /// @dev Reuses the execution array decoded by the calling validator.
+    /// @notice Returns whether a registration batch uses one registrar that accepts a payment token.
+    /// @dev Reuses the execution array decoded by the calling validator and queries the selected
+    ///      registrar's oracle once. Batches without a registration return true.
     /// @param executions The decoded operation batch.
     /// @param token The token delivered to the account by the signed intent.
-    /// @return supported Whether every used registrar accepts the token.
+    /// @return supported Whether the batch uses at most one registrar and it accepts the token.
     function isBatchPaymentToken(Execution[] memory executions, address token)
         internal
         view
         returns (bool supported)
     {
+        address registrar;
+        bool seenRegistration;
         for (uint256 i; i < executions.length; ++i) {
             if (HCAExecutionLib.selector(executions[i].callData) != IETHRegistrar.register.selector) {
                 continue;
             }
-            if (!isPaymentToken(executions[i].target, token)) {
+            if (!seenRegistration) {
+                registrar = executions[i].target;
+                seenRegistration = true;
+            } else if (executions[i].target != registrar) {
                 return false;
             }
         }
-        return true;
+        return !seenRegistration || isPaymentToken(registrar, token);
     }
 
     /// @notice Reads the registrant and resolver from an encoded registration call.

--- a/contracts/src/hca/libraries/HCARegistrarPolicyLib.sol
+++ b/contracts/src/hca/libraries/HCARegistrarPolicyLib.sol
@@ -58,19 +58,15 @@ library HCARegistrarPolicyLib {
     }
 
     /// @notice Returns whether every registration in a batch accepts a payment token.
-    /// @dev Decodes the operation payload before checking every registration target.
-    /// @param operationData The encoded ERC-7579 operation payload.
+    /// @dev Reuses the execution array decoded by the calling validator.
+    /// @param executions The decoded operation batch.
     /// @param token The token delivered to the account by the signed intent.
     /// @return supported Whether every used registrar accepts the token.
-    function isBatchPaymentToken(bytes calldata operationData, address token)
+    function isBatchPaymentToken(Execution[] memory executions, address token)
         internal
         view
         returns (bool supported)
     {
-        if (operationData.length < 32) {
-            return false;
-        }
-        Execution[] memory executions = abi.decode(operationData[32:], (Execution[]));
         for (uint256 i; i < executions.length; ++i) {
             if (HCAExecutionLib.selector(executions[i].callData) != IETHRegistrar.register.selector) {
                 continue;
@@ -83,7 +79,7 @@ library HCARegistrarPolicyLib {
     }
 
     /// @notice Reads the registrant and resolver from an encoded registration call.
-    /// @dev Reads only the ABI head words required by the registration policy.
+    /// @dev Reads fixed ABI head words without decoding the dynamic label argument.
     /// @param callData ABI-encoded registrar call data.
     /// @return registrant The owner argument of the registration.
     /// @return resolver The resolver argument of the registration.

--- a/contracts/src/hca/libraries/HCAResolverPolicyLib.sol
+++ b/contracts/src/hca/libraries/HCAResolverPolicyLib.sol
@@ -91,19 +91,21 @@ library HCAResolverPolicyLib {
     /// @notice Validates one direct or nested resolver call.
     /// @dev Recurses through the standard resolver multicall and rejects unknown selectors.
     /// @param callData ABI-encoded resolver call data.
-    /// @param owner The owner recorded for the HCA.
-    function checkCall(bytes memory callData, address owner) internal pure {
+    function checkCall(bytes memory callData) internal pure {
         bytes4 callSelector = HCAExecutionLib.selector(callData);
         if (callSelector == IMulticallable.multicall.selector) {
-            _checkCalls(abi.decode(HCAExecutionLib.callArgs(callData), (bytes[])), owner);
-        } else if (!_isRecordSelector(callSelector)) {
+            _checkCalls(abi.decode(HCAExecutionLib.callArgs(callData), (bytes[])));
+            return;
+        }
+        if (!_isRecordSelector(callSelector)) {
             revert ActionNotAllowed(address(0), callSelector);
         }
     }
 
     /// @notice Validates an exact deployment of the resolver bound to a session.
-    /// @dev Requires full resolver access for both the HCA and its owner at initialization.
-    /// @param account The HCA that calls the factory and receives resolver access.
+    /// @dev Requires full resolver access for both the HCA and its owner at initialization and
+    ///      permits only supported resolver record setters in the initializer multicall.
+    /// @param account The HCA that calls the factory.
     /// @param owner The HCA owner that receives resolver access.
     /// @param resolver The resolver address bound to the session.
     /// @param callData ABI-encoded factory call data.
@@ -122,11 +124,29 @@ library HCAResolverPolicyLib {
         internal
         pure
     {
-        uint256 salt = HCAExecutionLib.readUint(callData, 4 + 32);
-        Grant[] memory grants = new Grant[](2);
-        grants[0] = Grant({account: account, roleBitmap: EACBaseRolesLib.ALL_ROLES});
-        grants[1] = Grant({account: owner, roleBitmap: EACBaseRolesLib.ALL_ROLES});
-        bytes[] memory calls = new bytes[](0);
+        (address callImplementation, uint256 salt, bytes memory initData) =
+            abi.decode(HCAExecutionLib.callArgs(callData), (address, uint256, bytes));
+        if (
+            callImplementation != implementation ||
+            HCAExecutionLib.selector(initData) !=
+            IPermissionedResolverInitializable.initialize.selector
+        ) {
+            revert PolicyRuleFailed();
+        }
+
+        (Grant[] memory grants, bytes[] memory calls) =
+            abi.decode(HCAExecutionLib.callArgs(initData), (Grant[], bytes[]));
+        if (
+            grants.length != 2 ||
+            grants[0].account != account ||
+            grants[0].roleBitmap != EACBaseRolesLib.ALL_ROLES ||
+            grants[1].account != owner ||
+            grants[1].roleBitmap != EACBaseRolesLib.ALL_ROLES
+        ) {
+            revert PolicyRuleFailed();
+        }
+        _checkCalls(calls);
+
         bytes memory expectedInitData =
             abi.encodeCall(IPermissionedResolverInitializable.initialize, (grants, calls));
         bytes memory expectedCallData =
@@ -162,9 +182,9 @@ library HCAResolverPolicyLib {
     }
 
     /// @dev Validates nested resolver calls.
-    function _checkCalls(bytes[] memory calls, address owner) private pure {
+    function _checkCalls(bytes[] memory calls) private pure {
         for (uint256 i; i < calls.length; ++i) {
-            checkCall(calls[i], owner);
+            checkCall(calls[i]);
         }
     }
 

--- a/contracts/src/hca/libraries/HCASignatureLib.sol
+++ b/contracts/src/hca/libraries/HCASignatureLib.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 /// @title HCA Signature Library
@@ -14,6 +13,10 @@ library HCASignatureLib {
 
     /// @dev Length of one ECDSA signature.
     uint256 internal constant SIGNATURE_LENGTH = 65;
+
+    /// @dev Highest canonical secp256k1 `s` value accepted by EIP-2.
+    uint256 private constant _HALF_CURVE_ORDER =
+        0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0;
 
     ////////////////////////////////////////////////////////////////////////
     // Implementation
@@ -46,7 +49,7 @@ library HCASignatureLib {
     }
 
     /// @notice Recovers a signer from separate Rhinestone-compatible signature fields.
-    /// @dev Normalizes compact recovery identifiers and rejects non-canonical signatures.
+    /// @dev Normalizes compact recovery identifiers and rejects non-canonical `s` values.
     /// @param digest The digest represented by the signature.
     /// @param r The ECDSA `r` value.
     /// @param s The ECDSA `s` value.
@@ -66,11 +69,10 @@ library HCASignatureLib {
         if (v != 27 && v != 28) {
             return address(0);
         }
-        ECDSA.RecoverError error;
-        (signer, error, ) = ECDSA.tryRecover(digest, v, r, s);
-        if (error != ECDSA.RecoverError.NoError) {
+        if (uint256(s) > _HALF_CURVE_ORDER) {
             return address(0);
         }
+        return ecrecover(digest, v, r, s);
     }
 
     /// @notice Checks the raw and EIP-191 UserOperation signatures accepted by the Nexus validator.
@@ -106,22 +108,19 @@ library HCASignatureLib {
         if (v != 27 && v != 28) {
             return false;
         }
+        if (uint256(s) > _HALF_CURVE_ORDER) {
+            return false;
+        }
 
         address signer;
-        ECDSA.RecoverError error;
         if (!explicitEthSigned) {
-            (signer, error, ) = ECDSA.tryRecover(digest, v, r, s);
-            if (error == ECDSA.RecoverError.NoError && signer == expectedSigner) {
+            signer = ecrecover(digest, v, r, s);
+            if (signer != address(0) && signer == expectedSigner) {
                 return true;
             }
         }
 
-        (signer, error, ) = ECDSA.tryRecover(
-            MessageHashUtils.toEthSignedMessageHash(digest),
-            v,
-            r,
-            s
-        );
-        return error == ECDSA.RecoverError.NoError && signer == expectedSigner;
+        signer = ecrecover(MessageHashUtils.toEthSignedMessageHash(digest), v, r, s);
+        return signer != address(0) && signer == expectedSigner;
     }
 }

--- a/contracts/src/hca/libraries/HCASmartSessionLib.sol
+++ b/contracts/src/hca/libraries/HCASmartSessionLib.sol
@@ -3,13 +3,38 @@ pragma solidity 0.8.27;
 
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
+import {HCASignatureLib} from "./HCASignatureLib.sol";
+
 /// @title HCA Smart Session Library
 /// @notice Reconstructs the authorization hashes used by Rhinestone Smart Sessions.
-/// @dev Shares the Smart Session hashing rules used by the HCA validators.
+/// @dev Shares proof validation between the destination and source HCA session validators.
 library HCASmartSessionLib {
+    ////////////////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @notice Result of validating one multi-chain owner authorization.
+    enum AuthorizationStatus {
+        InvalidSelection,
+        InvalidSigner,
+        Valid
+    }
+
+    /// @notice One chain and session digest from a multi-chain authorization.
+    struct HashAndChainId {
+        uint64 chainId;
+        bytes32 sessionDigest;
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // Constants
     ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Size of the mode and permission ID preceding a packed authorization proof.
+    uint256 internal constant ENABLE_PREFIX_LENGTH = 33;
+
+    /// @dev Size of one packed chain identifier and session digest.
+    uint256 internal constant AUTHORIZATION_ENTRY_LENGTH = 40;
 
     /// @dev Canonical Smart Session emissary.
     address private constant SMART_SESSION_EMISSARY = 0xad568B3F825A8d5FFc06DD3253526B64D810Ae89;
@@ -17,17 +42,9 @@ library HCASmartSessionLib {
     /// @dev Canonical one-of-one session validator.
     address private constant OWNABLE_SESSION_VALIDATOR = 0x000000000013fdB5234E4E3162a810F54d9f7E98;
 
-    /// @dev Smart Session EIP-712 domain type hash.
-    bytes32 private constant SMART_SESSION_DOMAIN_TYPEHASH =
-        0xb03948446334eb9b2196d5eb166f69b9d49403eb4a12f36de8d3f9f3cb8e15c3;
-
-    /// @dev Smart Session EIP-712 name hash.
-    bytes32 private constant SMART_SESSION_NAME_HASH =
-        0x909aaff4c04d02fd420ef163a6d750c002b0a00dc41a031ba039e3fdb4732133;
-
-    /// @dev Smart Session EIP-712 version hash.
-    bytes32 private constant SMART_SESSION_VERSION_HASH =
-        0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6;
+    /// @dev Smart Session EIP-712 domain separator.
+    bytes32 private constant SMART_SESSION_DOMAIN_SEPARATOR =
+        0xe4b7e03cf1e8e7a6af0eec6f72a68d532e03fdaad0b8326461731cb31803a084;
 
     /// @dev Signed-session type hash.
     bytes32 private constant SIGNED_SESSION_TYPEHASH =
@@ -49,6 +66,57 @@ library HCASmartSessionLib {
     // Implementation
     ////////////////////////////////////////////////////////////////////////
 
+    /// @notice Validates the selected chain session and its multi-chain owner signature.
+    /// @dev Reconstructs the Smart Session digest before recovering the authorizing signer.
+    /// @param expectedOwner The owner that authorized the session set.
+    /// @param expectedSessionDigest The session digest authorized for the current chain.
+    /// @param selectedIndex The current chain's index in `hashesAndChainIds`.
+    /// @param packedSessions Packed chain identifiers and session digests covered by the signature.
+    /// @param ownerSignature The owner's ECDSA signature over the multi-chain authorization.
+    /// @return status Whether selection and signer validation succeeded.
+    function validateMultiChainAuthorization(
+        address expectedOwner,
+        bytes32 expectedSessionDigest,
+        uint256 selectedIndex,
+        bytes calldata packedSessions,
+        bytes calldata ownerSignature
+    )
+        internal
+        view
+        returns (AuthorizationStatus status)
+    {
+        uint256 packedLength = packedSessions.length;
+        uint256 count = packedLength / AUTHORIZATION_ENTRY_LENGTH;
+        if (
+            count == 0 ||
+            packedLength != count * AUTHORIZATION_ENTRY_LENGTH ||
+            selectedIndex >= count
+        ) {
+            return AuthorizationStatus.InvalidSelection;
+        }
+
+        uint256 selectedOffset = selectedIndex * AUTHORIZATION_ENTRY_LENGTH;
+        uint64 selectedChainId = uint64(bytes8(packedSessions[selectedOffset:selectedOffset + 8]));
+        bytes32 selectedSessionDigest =
+            bytes32(packedSessions[selectedOffset + 8:selectedOffset + AUTHORIZATION_ENTRY_LENGTH]);
+        if (selectedChainId != block.chainid || selectedSessionDigest != expectedSessionDigest) {
+            return AuthorizationStatus.InvalidSelection;
+        }
+
+        bytes32[] memory chainSessionHashes = new bytes32[](count);
+        for (uint256 i; i < count; ++i) {
+            uint256 offset = i * AUTHORIZATION_ENTRY_LENGTH;
+            chainSessionHashes[i] = chainSessionHash(
+                uint64(bytes8(packedSessions[offset:offset + 8])),
+                bytes32(packedSessions[offset + 8:offset + AUTHORIZATION_ENTRY_LENGTH])
+            );
+        }
+        address signer =
+            HCASignatureLib.recover(multiChainDigest(chainSessionHashes), ownerSignature);
+        return
+            signer == expectedOwner ? AuthorizationStatus.Valid : AuthorizationStatus.InvalidSigner;
+    }
+
     /// @notice Derives the hashes that bind a one-of-one key to an account and policy.
     /// @dev Matches the permission and session hashing used by Rhinestone Smart Sessions.
     /// @param account The account authorized on the selected chain.
@@ -61,21 +129,36 @@ library HCASmartSessionLib {
         pure
         returns (bytes32 permissionId, bytes32 sessionDigest)
     {
-        bytes memory validatorInitData = _validatorInitData(sessionKey);
-        permissionId = keccak256(abi.encode(OWNABLE_SESSION_VALIDATOR, validatorInitData, salt));
-        sessionDigest = keccak256(
-            abi.encode(
-                SIGNED_SESSION_TYPEHASH,
-                account,
-                type(uint256).max,
-                uint256(0),
-                DEFAULT_SIGNED_PERMISSIONS_HASH,
-                salt,
-                OWNABLE_SESSION_VALIDATOR,
-                keccak256(validatorInitData),
-                SMART_SESSION_EMISSARY
-            )
-        );
+        bytes32 validatorInitDataHash;
+        assembly ("memory-safe") {
+            let ptr := mload(0x40)
+
+            // Hash the canonical ABI encoding of the validator, its dynamic init data, and salt.
+            mstore(ptr, OWNABLE_SESSION_VALIDATOR)
+            mstore(add(ptr, 0x20), 0x60)
+            mstore(add(ptr, 0x40), salt)
+            mstore(add(ptr, 0x60), 0x80)
+            mstore(add(ptr, 0x80), 1)
+            mstore(add(ptr, 0xa0), 0x40)
+            mstore(add(ptr, 0xc0), 1)
+            mstore(add(ptr, 0xe0), sessionKey)
+            validatorInitDataHash := keccak256(add(ptr, 0x80), 0x80)
+            permissionId := keccak256(ptr, 0x100)
+
+            // Reuse the buffer for the fixed-width signed-session struct.
+            mstore(ptr, SIGNED_SESSION_TYPEHASH)
+            mstore(add(ptr, 0x20), account)
+            mstore(add(ptr, 0x40), not(0))
+            mstore(add(ptr, 0x60), 0)
+            mstore(add(ptr, 0x80), DEFAULT_SIGNED_PERMISSIONS_HASH)
+            mstore(add(ptr, 0xa0), salt)
+            mstore(add(ptr, 0xc0), OWNABLE_SESSION_VALIDATOR)
+            mstore(add(ptr, 0xe0), validatorInitDataHash)
+            mstore(add(ptr, 0x100), SMART_SESSION_EMISSARY)
+            sessionDigest := keccak256(ptr, 0x120)
+
+            mstore(0x40, add(ptr, 0x120))
+        }
     }
 
     /// @notice Hashes a chain identifier and its signed-session digest.
@@ -100,28 +183,12 @@ library HCASmartSessionLib {
         pure
         returns (bytes32 result)
     {
-        bytes32 structHash =
-            keccak256(
-                abi.encode(
-                    MULTI_CHAIN_SESSION_TYPEHASH,
-                    keccak256(abi.encodePacked(chainSessionHashes))
-                )
-            );
-        bytes32 domainSeparator =
-            keccak256(
-                abi.encode(
-                    SMART_SESSION_DOMAIN_TYPEHASH,
-                    SMART_SESSION_NAME_HASH,
-                    SMART_SESSION_VERSION_HASH
-                )
-            );
-        return MessageHashUtils.toTypedDataHash(domainSeparator, structHash);
-    }
-
-    /// @dev Returns the standard one-of-one Ownable validator initialization data.
-    function _validatorInitData(address sessionKey) private pure returns (bytes memory) {
-        address[] memory owners = new address[](1);
-        owners[0] = sessionKey;
-        return abi.encode(uint256(1), owners);
+        bytes32 chainSessionsHash;
+        assembly ("memory-safe") {
+            chainSessionsHash :=
+                keccak256(add(chainSessionHashes, 0x20), shl(5, mload(chainSessionHashes)))
+        }
+        bytes32 structHash = keccak256(abi.encode(MULTI_CHAIN_SESSION_TYPEHASH, chainSessionsHash));
+        return MessageHashUtils.toTypedDataHash(SMART_SESSION_DOMAIN_SEPARATOR, structHash);
     }
 }

--- a/contracts/test/e2e/hca.test.ts
+++ b/contracts/test/e2e/hca.test.ts
@@ -1183,6 +1183,38 @@ describe("Standalone HCA", () => {
     expectVar({ recovered }).toEqualAddress(owner.address);
   });
 
+  it("rejects standalone HCA cross-chain session sources", async () => {
+    const owner = env.namedAccounts.user;
+    const account = await createRhinestoneAccount({
+      ...sdkConfig(),
+      ...(await standaloneConfig(owner)),
+      endpointUrl: MOCK_ORCHESTRATOR_URL,
+    });
+    const sessionKey = privateKeyToAccount(BURNER_SESSION_SIGNER_KEY);
+    const session: Session = {
+      chain: env.client.chain,
+      account: account.getAddress(),
+      owners: { type: "ecdsa", accounts: [sessionKey] },
+    };
+    const targetChain = {
+      ...env.client.chain,
+      id: env.client.chain.id + 1,
+    };
+
+    await expect(
+      account.prepareTransaction({
+        sourceChains: [env.client.chain],
+        targetChain,
+        calls: [],
+        signers: {
+          type: "experimental_session",
+          session,
+          verifyExecutions: true,
+        },
+      }),
+    ).rejects.toThrow("Standalone HCA cross-chain sessions are not supported");
+  });
+
   it("prepares and signs a fresh standalone HCA UserOperation", async () => {
     const owner = env.namedAccounts.user;
     const config = await standaloneConfig(owner);

--- a/contracts/test/e2e/hca.test.ts
+++ b/contracts/test/e2e/hca.test.ts
@@ -46,8 +46,7 @@ const HCA_USER_SALT = 0n;
 const ERC7579_ERC1271_MODE = `0x0201${"00".repeat(30)}` as Hex;
 const MOCK_ORCHESTRATOR_URL = "https://hca-orchestrator.invalid";
 const MOCK_BUNDLER_URL = "https://hca-bundler.invalid";
-const SMART_SESSION_EMISSARY =
-  "0xad568B3F825A8d5FFc06DD3253526B64D810Ae89";
+const SMART_SESSION_EMISSARY = "0xad568B3F825A8d5FFc06DD3253526B64D810Ae89";
 
 type HCAExecution = {
   target: Address;
@@ -701,11 +700,7 @@ describe("Standalone HCA", () => {
               callData: encodeFunctionData({
                 abi: artifacts.PermissionedResolver.abi,
                 functionName: "setText",
-                args: [
-                  dnsEncodeName(name),
-                  "avatar",
-                  `https://euc.li/${name}`,
-                ],
+                args: [dnsEncodeName(name), "avatar", `https://euc.li/${name}`],
               }),
             },
           ]

--- a/contracts/test/e2e/hca.test.ts
+++ b/contracts/test/e2e/hca.test.ts
@@ -2,20 +2,24 @@ import { describe, it } from "bun:test";
 import {
   createRhinestoneAccount,
   type RhinestoneAccountConfig,
+  type Session,
 } from "@rhinestone/sdk";
 import { getPermissionId } from "@rhinestone/sdk/smart-sessions";
 import {
   type Account,
   type Address,
+  concat,
   encodeAbiParameters,
   encodeFunctionData,
   encodePacked,
   keccak256,
   parseAbiParameters,
+  parseSignature,
   recoverMessageAddress,
   recoverTypedDataAddress,
   size,
   slice,
+  toHex,
   type Hex,
   zeroAddress,
   zeroHash,
@@ -42,6 +46,8 @@ const HCA_USER_SALT = 0n;
 const ERC7579_ERC1271_MODE = `0x0201${"00".repeat(30)}` as Hex;
 const MOCK_ORCHESTRATOR_URL = "https://hca-orchestrator.invalid";
 const MOCK_BUNDLER_URL = "https://hca-bundler.invalid";
+const SMART_SESSION_EMISSARY =
+  "0xad568B3F825A8d5FFc06DD3253526B64D810Ae89";
 
 type HCAExecution = {
   target: Address;
@@ -66,7 +72,6 @@ type MockIntentInput = {
 
 type MockRouteOptions = {
   arbiter: Address;
-  enabledSessionValidator?: Address;
   fundingMethod: "NO_FUNDING" | "PERMIT2";
   settlementLayer: "INTENT_EXECUTOR" | "ACROSS";
   sourceToken?: Address;
@@ -178,23 +183,6 @@ async function withMockedIntentRoute<T>(
     const body = init?.body ? JSON.parse(String(init.body)) : undefined;
     if (url === `${MOCK_ORCHESTRATOR_URL}/intents/route`) {
       return Response.json(mockIntentRoute(body as MockIntentInput, options));
-    }
-    if (
-      options.enabledSessionValidator &&
-      (body as JsonRpcRequest | undefined)?.method === "eth_call"
-    ) {
-      const request = body as JsonRpcRequest;
-      const call = request.params?.[0] as { to?: Address } | undefined;
-      if (
-        call?.to?.toLowerCase() ===
-        options.enabledSessionValidator.toLowerCase()
-      ) {
-        return Response.json({
-          jsonrpc: "2.0",
-          id: request.id,
-          result: `0x${"00".repeat(31)}01`,
-        });
-      }
     }
     return originalFetch(input, init);
   }) as typeof globalThis.fetch;
@@ -313,13 +301,13 @@ describe("Standalone HCA", () => {
   async function buildSessionSignature({
     hca,
     nonce,
-    permissionId,
+    authorization,
     sessionKey,
     executions,
   }: {
     hca: Address;
     nonce: bigint;
-    permissionId: Hex;
+    authorization: { permissionId: Hex; proof: Hex };
     sessionKey: Account;
     executions: HCAExecution[];
   }): Promise<Hex> {
@@ -331,16 +319,187 @@ describe("Standalone HCA", () => {
       args: [hca, nonce, executions],
     })) as Hex;
     return encodePacked(
-      ["address", "bytes1", "bytes32", "uint256", "bytes", "bytes"],
+      [
+        "address",
+        "bytes1",
+        "bytes32",
+        "bytes",
+        "uint256",
+        "address",
+        "uint96",
+        "uint96",
+        "uint48",
+        "bytes",
+        "bytes",
+      ],
       [
         zeroAddress,
-        "0x01",
-        permissionId,
+        "0x05",
+        authorization.permissionId,
+        authorization.proof,
         nonce,
+        zeroAddress,
+        0n,
+        0n,
+        0,
         data,
         await signRhinestoneMessage(sessionKey, digest),
       ],
     );
+  }
+
+  async function createSessionAuthorization({
+    hca,
+    owner,
+    sessionKey,
+    validUntil,
+    resolver,
+    refundToken = env.erc20.MockUSDC.address,
+    maxRefundExchangeRate = 1n,
+    maxRefundGasOverhead = 0,
+    maxRefundAmount = 1n,
+  }: {
+    hca: Address;
+    owner: Account;
+    sessionKey: Account;
+    validUntil: number;
+    resolver: Address;
+    refundToken?: Address;
+    maxRefundExchangeRate?: bigint;
+    maxRefundGasOverhead?: number;
+    maxRefundAmount?: bigint;
+  }) {
+    const code = await env.client.getCode({ address: hca });
+    const sessionNonce =
+      code && code !== "0x"
+        ? (
+            (await env.client.readContract({
+              address: hca,
+              abi: stack.hcaImplementation.abi,
+              functionName: "ownerAndSessionNonce",
+            })) as readonly [Address, bigint]
+          )[1]
+        : 0n;
+    const salt = keccak256(
+      encodeAbiParameters(
+        [
+          { type: "uint96" },
+          { type: "uint48" },
+          { type: "address" },
+          { type: "address" },
+          { type: "uint96" },
+          { type: "uint48" },
+          { type: "uint96" },
+        ],
+        [
+          sessionNonce,
+          validUntil,
+          resolver,
+          refundToken,
+          maxRefundExchangeRate,
+          maxRefundGasOverhead,
+          maxRefundAmount,
+        ],
+      ),
+    );
+    const session: Session = {
+      chain: env.client.chain,
+      account: hca,
+      salt,
+      owners: { type: "ecdsa", accounts: [sessionKey] },
+    };
+    const account = await createRhinestoneAccount({
+      ...sdkConfig(),
+      ...(await standaloneConfig(owner)),
+      ...(code && code !== "0x" && { initData: { address: hca } }),
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input, init) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      if ((body as JsonRpcRequest | undefined)?.method === "eth_call") {
+        const request = body as JsonRpcRequest;
+        const call = request.params?.[0] as { to?: Address } | undefined;
+        if (call?.to?.toLowerCase() === SMART_SESSION_EMISSARY.toLowerCase()) {
+          return Response.json({
+            jsonrpc: "2.0",
+            id: request.id,
+            result: zeroHash,
+          });
+        }
+      }
+      return originalFetch(input, init);
+    }) as typeof globalThis.fetch;
+    let details;
+    try {
+      details = await account.experimental_getSessionDetails([session]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    const userSignature = await account.experimental_signEnableSession(details);
+    if (
+      size(userSignature) !== 85 ||
+      slice(userSignature, 0, 20).toLowerCase() !== zeroAddress.toLowerCase()
+    ) {
+      throw new Error("unexpected HCA owner session authorization");
+    }
+    const parsed = parseSignature(slice(userSignature, 20));
+    const ownerV = parsed.v ?? BigInt(27 + (parsed.yParity ?? 0));
+    const packedSessions = details.hashesAndChainIds.map(
+      ({ chainId, sessionDigest }) =>
+        encodePacked(["uint64", "bytes32"], [BigInt(chainId), sessionDigest]),
+    );
+    const proof = concat([
+      encodePacked(
+        [
+          "address",
+          "uint48",
+          "uint96",
+          "address",
+          "address",
+          "uint96",
+          "uint48",
+          "uint96",
+          "uint8",
+          "uint8",
+        ],
+        [
+          sessionKey.address,
+          validUntil,
+          sessionNonce,
+          resolver,
+          refundToken,
+          maxRefundExchangeRate,
+          maxRefundGasOverhead,
+          maxRefundAmount,
+          0,
+          details.hashesAndChainIds.length,
+        ],
+      ),
+      ...packedSessions,
+      parsed.r,
+      parsed.s,
+      toHex(ownerV, { size: 1 }),
+    ]);
+    return {
+      permissionId: getPermissionId(session),
+      proof,
+      session,
+      enableData: {
+        userSignature,
+        hashesAndChainIds: details.hashesAndChainIds,
+        sessionToEnableIndex: 0,
+        hcaSessionNonce: sessionNonce,
+        hcaSessionConfig: {
+          sessionKey: sessionKey.address,
+          validUntil,
+          resolver,
+          refundToken,
+          maxRefundExchangeRate,
+          maxRefundGasOverhead,
+          maxRefundAmount,
+        },
+      },
+    };
   }
 
   async function executeOwnerIntent({
@@ -360,38 +519,6 @@ describe("Standalone HCA", () => {
     await env.waitFor(
       stack.executor.write.execute([hca, executions, signature]),
     );
-  }
-
-  async function enableSession({
-    hca,
-    owner,
-    permissionId,
-    sessionKey,
-    validUntil,
-    resolver,
-  }: {
-    hca: Address;
-    owner: Account;
-    permissionId: Hex;
-    sessionKey: Account;
-    validUntil: number;
-    resolver: Address;
-  }) {
-    await executeOwnerIntent({
-      hca,
-      owner,
-      executions: [
-        {
-          target: stack.validator.address,
-          value: 0n,
-          callData: encodeFunctionData({
-            abi: stack.validator.abi,
-            functionName: "enableSession",
-            args: [permissionId, sessionKey.address, validUntil, resolver],
-          }),
-        },
-      ],
-    });
   }
 
   // Local E2E deploys separately. A sponsored production route can put deployment and
@@ -489,7 +616,21 @@ describe("Standalone HCA", () => {
     const executions: HCAExecution[] = [];
 
     const resolverCode = await env.client.getCode({ address: resolver });
-    if (!resolverCode || resolverCode === "0x") {
+    const deploysResolver = !resolverCode || resolverCode === "0x";
+    if (deploysResolver) {
+      const encodedName = dnsEncodeName(name);
+      const resolverCalls = [
+        encodeFunctionData({
+          abi: artifacts.PermissionedResolver.abi,
+          functionName: "setAddress",
+          args: [encodedName, COIN_TYPE_ETH, owner.address],
+        }),
+        encodeFunctionData({
+          abi: artifacts.PermissionedResolver.abi,
+          functionName: "setText",
+          args: [encodedName, "avatar", `https://euc.li/${name}`],
+        }),
+      ];
       executions.push({
         target: env.v2.VerifiableFactory.address,
         value: 0n,
@@ -505,12 +646,9 @@ describe("Standalone HCA", () => {
               args: [
                 [
                   { account: hca, roleBitmap: ROLES.ALL },
-                  // Make the owner co-admin of its resolver ("0x00" = DNS-encoded root, i.e. root
-                  // resource) so record management never depends on the disposable HCA. The policy
-                  // only permits this grant when the grantee is the owner.
                   { account: owner.address, roleBitmap: ROLES.ALL },
                 ],
-                [],
+                resolverCalls,
               ],
             }),
           ],
@@ -546,33 +684,32 @@ describe("Standalone HCA", () => {
           ],
         }),
       },
-      {
-        target: resolver,
-        value: 0n,
-        callData: encodeFunctionData({
-          abi: artifacts.PermissionedResolver.abi,
-          functionName: "setAddress",
-          args: [dnsEncodeName(name), COIN_TYPE_ETH, owner.address],
-        }),
-      },
-      {
-        target: resolver,
-        value: 0n,
-        callData: encodeFunctionData({
-          abi: artifacts.PermissionedResolver.abi,
-          functionName: "setText",
-          args: [dnsEncodeName(name), "url", `https://example.com/${label}`],
-        }),
-      },
-      {
-        target: resolver,
-        value: 0n,
-        callData: encodeFunctionData({
-          abi: artifacts.PermissionedResolver.abi,
-          functionName: "setName",
-          args: [dnsEncodeName(getReverseName(owner.address)), name],
-        }),
-      },
+      ...(!deploysResolver
+        ? [
+            {
+              target: resolver,
+              value: 0n,
+              callData: encodeFunctionData({
+                abi: artifacts.PermissionedResolver.abi,
+                functionName: "setAddress",
+                args: [dnsEncodeName(name), COIN_TYPE_ETH, owner.address],
+              }),
+            },
+            {
+              target: resolver,
+              value: 0n,
+              callData: encodeFunctionData({
+                abi: artifacts.PermissionedResolver.abi,
+                functionName: "setText",
+                args: [
+                  dnsEncodeName(name),
+                  "avatar",
+                  `https://euc.li/${name}`,
+                ],
+              }),
+            },
+          ]
+        : []),
       {
         target: env.shared.DefaultReverseRegistrarAdapter.address,
         value: 0n,
@@ -691,6 +828,23 @@ describe("Standalone HCA", () => {
       env.v2.PermissionedResolverImpl.address,
     );
 
+    const [rootRecordId, nameRecordId] = await Promise.all([
+      env.client.readContract({
+        address: resolver,
+        abi: artifacts.PermissionedResolver.abi,
+        functionName: "getRecordId",
+        args: [zeroHash],
+      }),
+      env.client.readContract({
+        address: resolver,
+        abi: artifacts.PermissionedResolver.abi,
+        functionName: "getRecordId",
+        args: [namehash(name)],
+      }),
+    ]);
+    expectVar({ rootRecordId }).toStrictEqual(0n);
+    expectVar({ nameRecordId }).toBeGreaterThan(0n);
+
     const hcaBalance = await env.erc20.MockUSDC.read.balanceOf([hca]);
     expectVar({ hcaBalance }).toStrictEqual(0n);
     expectVar({ price }).toBeGreaterThan(0n);
@@ -699,7 +853,7 @@ describe("Standalone HCA", () => {
       makeResolutions({
         name,
         addresses: [{ coinType: COIN_TYPE_ETH, value: owner.address }],
-        texts: [{ key: "url", value: `https://example.com/${label}` }],
+        texts: [{ key: "avatar", value: `https://euc.li/${name}` }],
       }),
     );
     const [result] = await env.v2.UniversalResolver.read.resolve([
@@ -770,12 +924,6 @@ describe("Standalone HCA", () => {
       ...config,
     });
     const hca = computeHcaAddress(owner.address);
-    const sessionKey = privateKeyToAccount(BURNER_SESSION_SIGNER_KEY);
-    const sdkSession = {
-      chain: env.client.chain,
-      owners: { type: "ecdsa" as const, accounts: [sessionKey] },
-    };
-    const permissionId = getPermissionId(sdkSession);
 
     expectVar({ configuredAdapter }).toEqualAddress(
       env.shared.DefaultReverseRegistrarAdapter.address,
@@ -797,19 +945,6 @@ describe("Standalone HCA", () => {
         HCA_USER_SALT,
       ]),
     );
-    const currentBlock = await env.client.getBlock();
-    await enableSession({
-      hca,
-      owner,
-      permissionId,
-      sessionKey,
-      validUntil: Number(currentBlock.timestamp + 3600n),
-      resolver: zeroAddress,
-    });
-    expectVar({
-      sdkSessionEnabled:
-        await account.experimental_isSessionEnabled(sdkSession),
-    }).toStrictEqual(true);
     const signature = await account.signTypedData(
       {
         domain: {
@@ -847,17 +982,24 @@ describe("Standalone HCA", () => {
       endpointUrl: MOCK_ORCHESTRATOR_URL,
     });
     const sessionKey = privateKeyToAccount(BURNER_SESSION_SIGNER_KEY);
-    const session = {
-      chain: env.client.chain,
-      owners: { type: "ecdsa" as const, accounts: [sessionKey] },
-    };
-    const permissionId = getPermissionId(session);
     const refundToken = env.erc20.MockUSDC.address;
     const refundPaymaster = await stack.validator.read.GAS_REFUND_PAYMASTER();
     const maxExchangeRate = 10_000_000_000n;
     const maxGasOverhead = 100_000;
     const maxRefundAmount = 25_000_000n;
     const packedOverhead = (maxRefundAmount << 128n) | BigInt(maxGasOverhead);
+    const currentBlock = await env.client.getBlock();
+    const authorization = await createSessionAuthorization({
+      hca: account.getAddress(),
+      owner,
+      sessionKey,
+      validUntil: Number(currentBlock.timestamp + 3600n),
+      resolver: zeroAddress,
+      refundToken,
+      maxRefundExchangeRate: maxExchangeRate,
+      maxRefundGasOverhead: maxGasOverhead,
+      maxRefundAmount,
+    });
     const calls: HCAExecution[] = [
       {
         target: refundToken,
@@ -882,7 +1024,6 @@ describe("Standalone HCA", () => {
     const signed = await withMockedIntentRoute(
       {
         arbiter: stack.executor.address,
-        enabledSessionValidator: stack.validator.address,
         fundingMethod: "NO_FUNDING",
         settlementLayer: "INTENT_EXECUTOR",
         gasRefund: {
@@ -904,7 +1045,8 @@ describe("Standalone HCA", () => {
           sponsored: false,
           signers: {
             type: "experimental_session",
-            session,
+            session: authorization.session,
+            enableData: authorization.enableData,
             verifyExecutions: true,
           },
         });
@@ -920,20 +1062,24 @@ describe("Standalone HCA", () => {
         "address",
         "bytes1",
         "bytes32",
+        "bytes",
         "uint256",
         "address",
-        "uint256",
-        "uint256",
+        "uint96",
+        "uint96",
+        "uint48",
         "bytes",
       ],
       [
         zeroAddress,
-        "0x02",
-        permissionId,
+        "0x05",
+        authorization.permissionId,
+        authorization.proof,
         targetExecutionNonce,
         refundToken,
         maxExchangeRate,
-        packedOverhead,
+        maxRefundAmount,
+        maxGasOverhead,
         operation,
       ],
     );
@@ -1210,7 +1356,7 @@ describe("Standalone HCA", () => {
     });
   });
 
-  it("reuses one owner-enabled session for registration and a later primary change", async () => {
+  it("reuses one owner-authorized session for registration and a later primary change", async () => {
     const owner = env.namedAccounts.user;
     const sessionKey = privateKeyToAccount(BURNER_SESSION_SIGNER_KEY);
     const label = "hcasessionkey";
@@ -1219,16 +1365,11 @@ describe("Standalone HCA", () => {
       owner,
     );
     const currentBlock = await env.client.getBlock();
-    const validUntil = Number(currentBlock.timestamp + 3600n);
-    const permissionId = keccak256(
-      encodePacked(["address", "address"], [hca, sessionKey.address]),
-    );
-    await enableSession({
+    const authorization = await createSessionAuthorization({
       hca,
       owner,
-      permissionId,
       sessionKey,
-      validUntil,
+      validUntil: Number(currentBlock.timestamp + 3600n),
       resolver,
     });
 
@@ -1250,7 +1391,7 @@ describe("Standalone HCA", () => {
     const blockedSignature = await buildSessionSignature({
       hca,
       nonce: 1n,
-      permissionId,
+      authorization,
       sessionKey,
       executions: blockedExecutions,
     });
@@ -1266,7 +1407,7 @@ describe("Standalone HCA", () => {
     const signature = await buildSessionSignature({
       hca,
       nonce: 2n,
-      permissionId,
+      authorization,
       sessionKey,
       executions,
     });
@@ -1288,7 +1429,7 @@ describe("Standalone HCA", () => {
     const laterSignature = await buildSessionSignature({
       hca,
       nonce: 3n,
-      permissionId,
+      authorization,
       sessionKey,
       executions: laterExecutions,
     });
@@ -1315,16 +1456,11 @@ describe("Standalone HCA", () => {
       owner,
     );
     const currentBlock = await env.client.getBlock();
-    const validUntil = Number(currentBlock.timestamp + 3600n);
-    const permissionId = keccak256(
-      encodePacked(["address", "address"], [hca, sessionKey.address]),
-    );
-    await enableSession({
+    const authorization = await createSessionAuthorization({
       hca,
       owner,
-      permissionId,
       sessionKey,
-      validUntil,
+      validUntil: Number(currentBlock.timestamp + 3600n),
       resolver,
     });
 
@@ -1340,7 +1476,7 @@ describe("Standalone HCA", () => {
     const signature = await buildSessionSignature({
       hca,
       nonce: 1n,
-      permissionId,
+      authorization,
       sessionKey,
       executions,
     });

--- a/contracts/test/integration/HardhatCompilerIsolation.test.ts
+++ b/contracts/test/integration/HardhatCompilerIsolation.test.ts
@@ -44,6 +44,10 @@ const hcaProfile: CompilerProfile = {
   evmVersion: "cancun",
   optimizerRuns: 1000,
 };
+const hcaHotRuntimeProfile: CompilerProfile = {
+  ...hcaProfile,
+  optimizerRuns: 23_000,
+};
 const wrapperRegistryProfile: CompilerProfile = {
   solcVersion: "0.8.25",
   solcLongVersion: "0.8.25+commit.b61c2a91",
@@ -57,6 +61,7 @@ const nameWrapperProfile: CompilerProfile = {
   optimizerRuns: 1200,
 };
 const hcaSources = new Set([
+  "src/hca/HCAValidatorBase.sol",
   "src/hca/HCAFundingSessionValidator.sol",
   "src/hca/HCAOwnerAndSessionValidator.sol",
   "src/hca/StandaloneHCAFactory.sol",
@@ -154,6 +159,9 @@ async function expectExactSourcePragma(
 }
 
 function expectedFirstPartyProfile(sourceName: string): CompilerProfile {
+  if (sourceName === "src/hca/HCAOwnerAndSessionValidator.sol") {
+    return hcaHotRuntimeProfile;
+  }
   if (hcaSources.has(sourceName)) return hcaProfile;
   if (sourceName === "src/registry/WrapperRegistry.sol") {
     return wrapperRegistryProfile;

--- a/contracts/test/mocks/MockRegistrationIntentExecutor.sol
+++ b/contracts/test/mocks/MockRegistrationIntentExecutor.sol
@@ -132,7 +132,7 @@ contract MockRegistrationIntentExecutor is IExecutor {
         return abi.encodePacked(ERC7579_ERC1271_MODE, abi.encode(executions));
     }
 
-    /// @notice Encodes an ERC-7579 pure-emissary execution operation.
+    /// @notice Encodes a compact zero-value ERC-7579 session operation.
     /// @param executions The executions to encode.
     /// @return The encoded operation payload consumed by the validator.
     function encodeSessionOperation(Execution[] calldata executions)
@@ -140,7 +140,23 @@ contract MockRegistrationIntentExecutor is IExecutor {
         pure
         returns (bytes memory)
     {
-        return encodeOperation(executions);
+        bytes memory packed =
+            abi.encodePacked(bytes2(ERC7579_ERC1271_MODE), uint8(executions.length));
+        for (uint256 i; i < executions.length; ++i) {
+            Execution calldata execution = executions[i];
+            if (execution.value != 0 || execution.callData.length > type(uint24).max) {
+                revert InvalidSignature();
+            }
+            packed = bytes.concat(
+                packed,
+                abi.encodePacked(
+                    execution.target,
+                    uint24(execution.callData.length),
+                    execution.callData
+                )
+            );
+        }
+        return packed;
     }
 
     /// @notice Reproduces the production IntentExecutor's no-refund SingleChainOps digest.

--- a/contracts/test/mocks/MockStandaloneHCAStack.sol
+++ b/contracts/test/mocks/MockStandaloneHCAStack.sol
@@ -95,13 +95,20 @@ contract MockValidatorModule is IValidator {
 
 
 /// @title Mock Executor Module
-/// @notice Test-only ERC-7579 executor with no behavior.
+/// @notice Test-only ERC-7579 executor that records module initialization.
 contract MockExecutorModule is IExecutor {
-    /// @notice No-op install hook.
-    function onInstall(bytes calldata) external pure {}
+    /// @notice Whether an account invoked the install hook.
+    mapping(address account => bool initialized) public initialized;
 
-    /// @notice No-op uninstall hook.
-    function onUninstall(bytes calldata) external pure {}
+    /// @notice Records the calling account as initialized.
+    function onInstall(bytes calldata) external {
+        initialized[msg.sender] = true;
+    }
+
+    /// @notice Clears the calling account's initialization marker.
+    function onUninstall(bytes calldata) external {
+        initialized[msg.sender] = false;
+    }
 
     /// @notice Reports the executor module type.
     function isModuleType(uint256 moduleTypeId) external pure returns (bool) {
@@ -111,8 +118,10 @@ contract MockExecutorModule is IExecutor {
     /// @notice Unused module-type encoding.
     function getModuleTypes() external pure returns (EncodedModuleTypes) {}
 
-    /// @notice Always reports initialized.
-    function isInitialized(address) external pure returns (bool) {
-        return true;
+    /// @notice Returns whether an account invoked the install hook.
+    /// @param account The account to inspect.
+    /// @return Whether the account is initialized.
+    function isInitialized(address account) external view returns (bool) {
+        return initialized[account];
     }
 }

--- a/contracts/test/unit/hca/HCAFundingSessionValidator.t.sol
+++ b/contracts/test/unit/hca/HCAFundingSessionValidator.t.sol
@@ -6,13 +6,19 @@ pragma solidity ^0.8.27;
 import {Test} from "forge-std/Test.sol";
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {PackedUserOperation} from "account-abstraction/interfaces/PackedUserOperation.sol";
+import {ERC1271_MAGICVALUE} from "nexus/types/Constants.sol";
+import {Execution} from "nexus/types/DataTypes.sol";
 
 import {
     HCAFundingSessionValidator,
     IRhinestoneClaimRouter
 } from "~src/hca/HCAFundingSessionValidator.sol";
+import {HCAOperationHashLib} from "~src/hca/libraries/HCAOperationHashLib.sol";
+import {HCASignatureLib} from "~src/hca/libraries/HCASignatureLib.sol";
+import {HCASmartSessionLib} from "~src/hca/libraries/HCASmartSessionLib.sol";
 
 contract HCAFundingSessionValidatorTest is Test {
     struct ClaimFixture {
@@ -26,10 +32,6 @@ contract HCAFundingSessionValidatorTest is Test {
         bytes32 destinationOpsHash;
         bytes32 qualifierHash;
     }
-
-    bytes4 constant ERC1271_MAGICVALUE = 0x1626ba7e;
-    bytes4 constant PERMIT_SELECTOR =
-        bytes4(keccak256("permit(address,address,uint256,uint256,uint8,bytes32,bytes32)"));
 
     bytes32 constant DOMAIN_TYPEHASH =
         keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
@@ -157,14 +159,14 @@ contract HCAFundingSessionValidatorTest is Test {
             abi.encodePacked(
                 bytes1(uint8(4)),
                 config.permissionId,
-                bytes4(0),
+                bytes2(0),
                 new bytes(65 + 410 + 1)
             );
         vm.expectRevert(HCAFundingSessionValidator.InvalidSession.selector);
         _validate(bytes32(0), zeroLengthProofEnvelope);
 
         HCAFundingSessionValidator.FundingAuthorizationProof memory proof = _ownerProof(config);
-        proof.hashesAndChainIds = new HCAFundingSessionValidator.HashAndChainId[](0);
+        proof.hashesAndChainIds = new HCASmartSessionLib.HashAndChainId[](0);
         bytes memory operation = _fundingOperation(COMMIT_SOURCE_COST, true);
         (bytes memory claim, bytes32 digest) = _claim(operation, COMMIT_SOURCE_COST, 100_000, 1);
         vm.expectRevert(HCAFundingSessionValidator.InvalidSession.selector);
@@ -205,7 +207,7 @@ contract HCAFundingSessionValidatorTest is Test {
         bytes memory operation = _fundingOperation(COMMIT_SOURCE_COST, true);
         (bytes memory claim, bytes32 digest) = _claim(operation, COMMIT_SOURCE_COST, 100_000, 1);
         bytes memory envelope = _envelope(proof, digest, claim, operation);
-        envelope[37 + abi.encode(proof).length] ^= 0x01;
+        envelope[33 + _packAuthorization(proof).length] ^= 0x01;
 
         vm.expectRevert(HCAFundingSessionValidator.InvalidSession.selector);
         _validate(digest, envelope);
@@ -260,14 +262,13 @@ contract HCAFundingSessionValidatorTest is Test {
     function test_rejectsInvalidFundingCalls() public {
         HCAFundingSessionValidator.FundingAuthorizationProof memory proof = _ownerProof(config);
 
-        HCAFundingSessionValidator.Execution[] memory executions =
-            new HCAFundingSessionValidator.Execution[](1);
-        executions[0] = HCAFundingSessionValidator.Execution({target: sourceToken, value: 0, callData: abi.encodeCall(
+        Execution[] memory executions = new Execution[](1);
+        executions[0] = Execution({target: sourceToken, value: 0, callData: abi.encodeCall(
             IERC20.transferFrom,
             (owner, makeAddr("wrong-nexus"), COMMIT_SOURCE_COST)
         )});
         bytes memory wrongRecipientOperation =
-            abi.encodePacked(validator.ERC7579_ERC1271_MODE(), abi.encode(executions));
+            _packOperation(HCAOperationHashLib.ERC7579_ERC1271_MODE, executions);
         (bytes memory claim, bytes32 digest) =
             _claim(wrongRecipientOperation, COMMIT_SOURCE_COST, 100_000, 1);
         vm.expectRevert(HCAFundingSessionValidator.FundingPolicyFailed.selector);
@@ -275,7 +276,7 @@ contract HCAFundingSessionValidatorTest is Test {
 
         executions[0].callData = hex"deadbeef";
         bytes memory unknownCallOperation =
-            abi.encodePacked(validator.ERC7579_ERC1271_MODE(), abi.encode(executions));
+            _packOperation(HCAOperationHashLib.ERC7579_ERC1271_MODE, executions);
         (claim, digest) = _claim(unknownCallOperation, COMMIT_SOURCE_COST, 100_000, 2);
         vm.expectRevert(HCAFundingSessionValidator.FundingPolicyFailed.selector);
         _validate(digest, _envelope(proof, digest, claim, unknownCallOperation));
@@ -295,24 +296,23 @@ contract HCAFundingSessionValidatorTest is Test {
         vm.expectRevert(HCAFundingSessionValidator.InvalidOperation.selector);
         _validate(digest, _envelope(proof, digest, claim, hex"00"));
 
-        HCAFundingSessionValidator.Execution[] memory executions =
-            new HCAFundingSessionValidator.Execution[](1);
-        executions[0] = HCAFundingSessionValidator.Execution({target: sourceToken, value: 0, callData: hex"dead"});
+        Execution[] memory executions = new Execution[](1);
+        executions[0] = Execution({target: sourceToken, value: 0, callData: hex"dead"});
         bytes memory shortSelectorOperation =
-            abi.encodePacked(validator.ERC7579_ERC1271_MODE(), abi.encode(executions));
+            _packOperation(HCAOperationHashLib.ERC7579_ERC1271_MODE, executions);
         (claim, digest) = _claim(shortSelectorOperation, COMMIT_SOURCE_COST, 100_000, 2);
         vm.expectRevert(HCAFundingSessionValidator.InvalidOperation.selector);
         _validate(digest, _envelope(proof, digest, claim, shortSelectorOperation));
 
         executions[0].callData = abi.encodePacked(IERC20.transferFrom.selector);
         bytes memory shortArgumentsOperation =
-            abi.encodePacked(validator.ERC7579_ERC1271_MODE(), abi.encode(executions));
+            _packOperation(HCAOperationHashLib.ERC7579_ERC1271_MODE, executions);
         (claim, digest) = _claim(shortArgumentsOperation, COMMIT_SOURCE_COST, 100_000, 3);
         vm.expectRevert(HCAFundingSessionValidator.InvalidOperation.selector);
         _validate(digest, _envelope(proof, digest, claim, shortArgumentsOperation));
 
         executions[0].callData = abi.encodeWithSelector(
-            PERMIT_SELECTOR,
+            IERC20Permit.permit.selector,
             makeAddr("wrong-owner"),
             nexus,
             TOTAL_SOURCE_BUDGET,
@@ -322,7 +322,7 @@ contract HCAFundingSessionValidatorTest is Test {
             bytes32(uint256(2))
         );
         bytes memory invalidPermitOperation =
-            abi.encodePacked(validator.ERC7579_ERC1271_MODE(), abi.encode(executions));
+            _packOperation(HCAOperationHashLib.ERC7579_ERC1271_MODE, executions);
         (claim, digest) = _claim(invalidPermitOperation, COMMIT_SOURCE_COST, 100_000, 4);
         vm.expectRevert(HCAFundingSessionValidator.FundingPolicyFailed.selector);
         _validate(digest, _envelope(proof, digest, claim, invalidPermitOperation));
@@ -504,7 +504,7 @@ contract HCAFundingSessionValidatorTest is Test {
                 true,
                 sourceToken,
                 PERMIT2,
-                validator.ERC7579_ERC1271_EMISSARY_EXECUTION_MODE()
+                HCAOperationHashLib.ERC7579_ERC1271_EMISSARY_EXECUTION_MODE
             );
         (bytes memory claim, bytes32 digest) = _claim(operation, COMMIT_SOURCE_COST, 100_000, 1);
 
@@ -680,7 +680,7 @@ contract HCAFundingSessionValidatorTest is Test {
                 includePermit,
                 target,
                 approvalSpender,
-                validator.ERC7579_ERC1271_MODE()
+                HCAOperationHashLib.ERC7579_ERC1271_MODE
             );
     }
 
@@ -695,12 +695,11 @@ contract HCAFundingSessionValidatorTest is Test {
         view
         returns (bytes memory)
     {
-        HCAFundingSessionValidator.Execution[] memory executions =
-            new HCAFundingSessionValidator.Execution[](includePermit ? 3 : 1);
+        Execution[] memory executions = new Execution[](includePermit ? 3 : 1);
         uint256 offset;
         if (includePermit) {
-            executions[offset++] = HCAFundingSessionValidator.Execution({target: target, value: 0, callData: abi.encodeWithSelector(
-                PERMIT_SELECTOR,
+            executions[offset++] = Execution({target: target, value: 0, callData: abi.encodeWithSelector(
+                IERC20Permit.permit.selector,
                 owner,
                 nexus,
                 TOTAL_SOURCE_BUDGET,
@@ -709,16 +708,16 @@ contract HCAFundingSessionValidatorTest is Test {
                 bytes32(uint256(1)),
                 bytes32(uint256(2))
             )});
-            executions[offset++] = HCAFundingSessionValidator.Execution({target: target, value: 0, callData: abi.encodeCall(
+            executions[offset++] = Execution({target: target, value: 0, callData: abi.encodeCall(
                 IERC20.approve,
                 (approvalSpender, type(uint256).max)
             )});
         }
-        executions[offset++] = HCAFundingSessionValidator.Execution({target: target, value: 0, callData: abi.encodeCall(
+        executions[offset++] = Execution({target: target, value: 0, callData: abi.encodeCall(
             IERC20.transferFrom,
             (owner, nexus, pullAmount)
         )});
-        return abi.encodePacked(mode, abi.encode(executions));
+        return _packOperation(mode, executions);
     }
 
     function _claim(
@@ -836,16 +835,16 @@ contract HCAFundingSessionValidatorTest is Test {
         bytes32 arbitrumSessionDigest = _signedSessionHash(arbitrumConfig);
 
         proof.sessionToEnableIndex = 1;
-        proof.hashesAndChainIds = new HCAFundingSessionValidator.HashAndChainId[](3);
-        proof.hashesAndChainIds[0] = HCAFundingSessionValidator.HashAndChainId({chainId: uint64(
+        proof.hashesAndChainIds = new HCASmartSessionLib.HashAndChainId[](3);
+        proof.hashesAndChainIds[0] = HCASmartSessionLib.HashAndChainId({chainId: uint64(
             baseConfig.destinationChainId
         ), sessionDigest: keccak256("destination-session")});
-        proof.hashesAndChainIds[1] = HCAFundingSessionValidator.HashAndChainId({chainId: BASE_SEPOLIA_CHAIN_ID, sessionDigest: baseSessionDigest});
-        proof.hashesAndChainIds[2] = HCAFundingSessionValidator.HashAndChainId({chainId: ARBITRUM_SEPOLIA_CHAIN_ID, sessionDigest: arbitrumSessionDigest});
+        proof.hashesAndChainIds[1] = HCASmartSessionLib.HashAndChainId({chainId: BASE_SEPOLIA_CHAIN_ID, sessionDigest: baseSessionDigest});
+        proof.hashesAndChainIds[2] = HCASmartSessionLib.HashAndChainId({chainId: ARBITRUM_SEPOLIA_CHAIN_ID, sessionDigest: arbitrumSessionDigest});
 
         bytes32[] memory chainSessionHashes = new bytes32[](proof.hashesAndChainIds.length);
         for (uint256 i; i < proof.hashesAndChainIds.length; ++i) {
-            HCAFundingSessionValidator.HashAndChainId memory item = proof.hashesAndChainIds[i];
+            HCASmartSessionLib.HashAndChainId memory item = proof.hashesAndChainIds[i];
             chainSessionHashes[i] = keccak256(
                 abi.encode(CHAIN_SESSION_TYPEHASH, item.chainId, item.sessionDigest)
             );
@@ -901,17 +900,29 @@ contract HCAFundingSessionValidatorTest is Test {
         view
         returns (bytes memory)
     {
-        bytes memory proofData = abi.encode(proof);
+        bytes memory proofData = _packAuthorization(proof);
         return
             abi.encodePacked(
                 bytes1(uint8(4)),
                 config.permissionId,
-                bytes4(uint32(proofData.length)),
                 proofData,
                 _sessionSignature(permit2Digest),
                 claimData,
                 operationData
             );
+    }
+
+    function _packAuthorization(HCAFundingSessionValidator.FundingAuthorizationProof memory proof)
+        internal
+        pure
+        returns (bytes memory packed)
+    {
+        packed = abi.encodePacked(proof.sessionToEnableIndex, uint8(proof.hashesAndChainIds.length));
+        for (uint256 i; i < proof.hashesAndChainIds.length; ++i) {
+            HCASmartSessionLib.HashAndChainId memory item = proof.hashesAndChainIds[i];
+            packed = bytes.concat(packed, abi.encodePacked(item.chainId, item.sessionDigest));
+        }
+        return bytes.concat(packed, abi.encodePacked(proof.ownerR, proof.ownerS, proof.ownerV));
     }
 
     function _sessionSignature(bytes32 permit2Digest) internal view returns (bytes memory) {
@@ -965,33 +976,69 @@ contract HCAFundingSessionValidatorTest is Test {
         return abi.encode(uint256(1), owners);
     }
 
-    function _operationHash(bytes memory operationData) internal pure returns (bytes32) {
-        bytes32 mode;
-        assembly ("memory-safe") {
-            mode := mload(add(operationData, 0x20))
-        }
-        HCAFundingSessionValidator.Execution[] memory executions =
-            abi.decode(_slice(operationData, 32), (HCAFundingSessionValidator.Execution[]));
-        bytes32[] memory executionHashes = new bytes32[](executions.length);
+    function _packOperation(bytes32 mode, Execution[] memory executions)
+        internal
+        pure
+        returns (bytes memory packed)
+    {
+        packed = abi.encodePacked(bytes2(mode), uint8(executions.length));
         for (uint256 i; i < executions.length; ++i) {
-            executionHashes[i] = keccak256(
-                abi.encode(
-                    OPS_TYPEHASH,
-                    executions[i].target,
-                    executions[i].value,
-                    keccak256(executions[i].callData)
+            Execution memory execution = executions[i];
+            assertEq(execution.value, 0);
+            assertLe(execution.callData.length, type(uint24).max);
+            packed = bytes.concat(
+                packed,
+                abi.encodePacked(
+                    execution.target,
+                    uint24(execution.callData.length),
+                    execution.callData
                 )
             );
         }
-        return
-            keccak256(abi.encode(OP_TYPEHASH, mode, keccak256(abi.encodePacked(executionHashes))));
     }
 
-    function _slice(bytes memory data, uint256 start) internal pure returns (bytes memory result) {
-        result = new bytes(data.length - start);
-        for (uint256 i; i < result.length; ++i) {
-            result[i] = data[start + i];
+    function _operationHash(bytes memory operationData) internal pure returns (bytes32) {
+        if (operationData.length < 3) {
+            revert HCAOperationHashLib.InvalidOperationEncoding();
         }
+        bytes2 modePrefix;
+        assembly ("memory-safe") {
+            modePrefix := mload(add(operationData, 0x20))
+        }
+        bytes32 mode = bytes32(modePrefix);
+        uint256 count = uint8(operationData[2]);
+        bytes32[] memory executionHashes = new bytes32[](count);
+        uint256 cursor = 3;
+        for (uint256 i; i < count; ++i) {
+            if (operationData.length < cursor + 23) {
+                revert HCAOperationHashLib.InvalidOperationEncoding();
+            }
+            address target;
+            assembly ("memory-safe") {
+                target := shr(96, mload(add(add(operationData, 0x20), cursor)))
+            }
+            uint256 callDataLength =
+                (uint256(uint8(operationData[cursor + 20])) << 16) |
+                (uint256(uint8(operationData[cursor + 21])) << 8) |
+                uint256(uint8(operationData[cursor + 22]));
+            cursor += 23;
+            if (operationData.length < cursor + callDataLength) {
+                revert HCAOperationHashLib.InvalidOperationEncoding();
+            }
+            bytes32 callDataHash;
+            assembly ("memory-safe") {
+                callDataHash := keccak256(add(add(operationData, 0x20), cursor), callDataLength)
+            }
+            executionHashes[i] = keccak256(
+                abi.encode(OPS_TYPEHASH, target, uint256(0), callDataHash)
+            );
+            cursor += callDataLength;
+        }
+        if (cursor != operationData.length) {
+            revert HCAOperationHashLib.InvalidOperationEncoding();
+        }
+        return
+            keccak256(abi.encode(OP_TYPEHASH, mode, keccak256(abi.encodePacked(executionHashes))));
     }
 }
 
@@ -1010,7 +1057,15 @@ contract HCAFundingSessionValidatorHarness is HCAFundingSessionValidator {
         view
         returns (uint256)
     {
-        return _validateFundingOperation(account, _sessions[configAccount], operationData);
+        if (operationData.length < 3) {
+            revert InvalidOperation();
+        }
+        HCAOperationHashLib.DecodedOperation memory operation =
+            HCAOperationHashLib.decode(operationData);
+        if (!HCAOperationHashLib.isSupportedMode(operation.mode)) {
+            revert InvalidOperation();
+        }
+        return _validateFundingOperation(account, _sessions[configAccount], operation);
     }
 
     function validatePermit2ClaimHarness(bytes32 digest, bytes calldata data, address configAccount)
@@ -1030,6 +1085,10 @@ contract HCAFundingSessionValidatorHarness is HCAFundingSessionValidator {
         pure
         returns (address)
     {
-        return _recover(digest, signature);
+        address signer = HCASignatureLib.recover(digest, signature);
+        if (signer == address(0)) {
+            revert InvalidSession();
+        }
+        return signer;
     }
 }

--- a/contracts/test/unit/hca/HCAOwnerAndSessionValidator.t.sol
+++ b/contracts/test/unit/hca/HCAOwnerAndSessionValidator.t.sol
@@ -6,8 +6,15 @@ pragma solidity ^0.8.27;
 import {Test} from "forge-std/Test.sol";
 
 import {VerifiableFactory} from "@ensdomains/verifiable-factory/VerifiableFactory.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+import {ERC1271_MAGICVALUE} from "nexus/types/Constants.sol";
+import {Execution} from "nexus/types/DataTypes.sol";
 
 import {HCAOwnerAndSessionValidator} from "~src/hca/HCAOwnerAndSessionValidator.sol";
+import {HCAOperationHashLib} from "~src/hca/libraries/HCAOperationHashLib.sol";
+import {HCASmartSessionLib} from "~src/hca/libraries/HCASmartSessionLib.sol";
+import {IETHRegistrar} from "~src/registrar/interfaces/IETHRegistrar.sol";
 import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
 
@@ -33,8 +40,21 @@ contract HCAOwnerAndSessionValidatorTest is Test {
         bytes32 qualifierHash;
     }
 
-    bytes4 constant ERC1271_MAGICVALUE = 0x1626ba7e;
-    bytes4 constant COMMIT_SELECTOR = 0xf14fcbc8;
+    struct SessionEnableProofFixture {
+        address sessionKey;
+        uint48 validUntil;
+        uint96 sessionNonce;
+        address resolver;
+        address refundToken;
+        uint96 maxRefundExchangeRate;
+        uint48 maxRefundGasOverhead;
+        uint96 maxRefundAmount;
+        uint8 sessionToEnableIndex;
+        HCASmartSessionLib.HashAndChainId[] hashesAndChainIds;
+        bytes32 ownerR;
+        bytes32 ownerS;
+        uint8 ownerV;
+    }
 
     address constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
 
@@ -127,58 +147,19 @@ contract HCAOwnerAndSessionValidatorTest is Test {
         validator.checkResolverCallHarness(abi.encodeWithSelector(selector), owner);
     }
 
-    function test_validator_acceptsPermit2SessionForExactDestinationOperation() public {
-        bytes32 permissionId = _enableSession();
-        bytes memory operationData = _withHybridMode(_commitOperation(bytes32("commitment")));
-        (bytes memory claimData, bytes32 digest) =
-            _claim(operationData, address(hca), block.chainid);
-
-        assertEq(
-            hca.validate(
-                validator,
-                digest,
-                _envelope(permissionId, claimData, operationData, digest)
-            ),
-            ERC1271_MAGICVALUE
-        );
-    }
-
-    function test_validator_rejectsOperationThatDiffersFromPermit2Mandate() public {
-        bytes32 permissionId = _enableSession();
-        bytes memory operationData = _commitOperation(bytes32("commitment"));
-        (bytes memory claimData, bytes32 digest) =
-            _claim(operationData, address(hca), block.chainid);
-        bytes memory changedOperation = _commitOperation(bytes32("different"));
-
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSessionData.selector);
-        hca.validate(validator, digest, _envelope(permissionId, claimData, changedOperation, digest));
-    }
-
-    function test_validator_rejectsPermit2MandateForAnotherDestination() public {
-        bytes32 permissionId = _enableSession();
-        bytes memory operationData = _commitOperation(bytes32("commitment"));
-        (bytes memory claimData, bytes32 digest) =
-            _claim(operationData, makeAddr("another-account"), block.chainid);
-
-        vm.expectRevert(HCAOwnerAndSessionValidator.PolicyRuleFailed.selector);
-        hca.validate(validator, digest, _envelope(permissionId, claimData, operationData, digest));
-    }
-
     function test_validator_acceptsFirstPermit2RouteWithMultiChainSessionAuthorization()
         public
         view
     {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
         bytes memory operationData = _withHybridMode(_initialCommitOperation(permissionId, proof));
         (bytes memory claimData, bytes32 digest) =
             _claim(operationData, address(hca), block.chainid);
-        bytes memory proofData = abi.encode(proof);
+        bytes memory proofData = _packProof(proof);
         bytes memory envelope =
             abi.encodePacked(
                 bytes1(uint8(4)),
                 permissionId,
-                bytes4(uint32(proofData.length)),
                 proofData,
                 SOURCE_CHAIN_ID,
                 claimData,
@@ -216,8 +197,7 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     }
 
     function test_validator_rejectsInvalidFirstUseProofAndSessionSignature() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
         bytes memory operationData = _initialCommitOperation(permissionId, proof);
         (bytes memory claimData, bytes32 digest) =
             _claim(operationData, address(hca), block.chainid);
@@ -229,7 +209,7 @@ contract HCAOwnerAndSessionValidatorTest is Test {
             _initialEnvelope(keccak256("wrong-permission"), proof, claimData, operationData, digest)
         );
 
-        proof.hashesAndChainIds = new HCAOwnerAndSessionValidator.HashAndChainId[](0);
+        proof.hashesAndChainIds = new HCASmartSessionLib.HashAndChainId[](0);
         vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSessionData.selector);
         hca.validate(
             validator,
@@ -248,8 +228,7 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     }
 
     function test_validator_rejectsFirstPermit2RouteWithInvalidOwnerAuthorization() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
         proof.ownerR = bytes32(uint256(proof.ownerR) + 1);
         bytes memory operationData = _initialCommitOperation(permissionId, proof);
         (bytes memory claimData, bytes32 digest) =
@@ -264,8 +243,7 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     }
 
     function test_validator_rejectsFirstPermit2RouteForAnotherSelectedChain() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
         proof.hashesAndChainIds[proof.sessionToEnableIndex].chainId = uint64(SOURCE_CHAIN_ID);
         bytes memory operationData = _initialCommitOperation(permissionId, proof);
         (bytes memory claimData, bytes32 digest) =
@@ -280,8 +258,7 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     }
 
     function test_validator_rejectsFirstPermit2RouteWithStaleSessionNonce() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
         hca.setSessionNonce(1);
         bytes memory operationData = _initialCommitOperation(permissionId, proof);
         (bytes memory claimData, bytes32 digest) =
@@ -295,28 +272,11 @@ contract HCAOwnerAndSessionValidatorTest is Test {
         );
     }
 
-    function test_validator_rejectsFirstPermit2RouteWithMismatchedEnableCall() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
-        bytes memory operationData =
-            _initialCommitOperation(permissionId, proof, proof.validUntil - 1);
-        (bytes memory claimData, bytes32 digest) =
-            _claim(operationData, address(hca), block.chainid);
-
-        vm.expectRevert(HCAOwnerAndSessionValidator.PolicyRuleFailed.selector);
-        hca.validate(
-            validator,
-            digest,
-            _initialEnvelope(permissionId, proof, claimData, operationData, digest)
-        );
-    }
-
     function test_validator_acceptsFirstSameChainRouteWithMultiChainSessionAuthorization()
         public
         view
     {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
         HCAOwnerAndSessionValidator.GasRefund memory gasRefund =
             HCAOwnerAndSessionValidator.GasRefund({token: proof.refundToken, exchangeRate: proof.maxRefundExchangeRate, overhead: (uint256(
                     proof.maxRefundAmount
@@ -344,8 +304,7 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     }
 
     function test_validator_rejectsInvalidFirstSameChainDigestAndSignature() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
         HCAOwnerAndSessionValidator.GasRefund memory gasRefund =
             HCAOwnerAndSessionValidator.GasRefund({token: proof.refundToken, exchangeRate: proof.maxRefundExchangeRate, overhead: (uint256(
                     proof.maxRefundAmount
@@ -372,41 +331,8 @@ contract HCAOwnerAndSessionValidatorTest is Test {
         hca.validate(validator, digest, envelope);
     }
 
-    function test_validator_rejectsInvalidEnabledPermit2Session() public {
-        bytes memory operationData = _commitOperation(bytes32("commitment"));
-        (bytes memory claimData, bytes32 digest) =
-            _claim(operationData, address(hca), block.chainid);
-
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSigner.selector);
-        hca.validate(
-            validator,
-            digest,
-            _envelope(keccak256("missing-session"), claimData, operationData, digest)
-        );
-
-        bytes32 permissionId = _enableSession();
-        hca.setSessionNonce(1);
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSigner.selector);
-        hca.validate(validator, digest, _envelope(permissionId, claimData, operationData, digest));
-
-        hca.setSessionNonce(0);
-        bytes memory envelope = _envelope(permissionId, claimData, operationData, digest);
-        _replaceSignature(envelope, _signRhinestoneMessage(0xBAD, digest));
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSigner.selector);
-        hca.validate(validator, digest, envelope);
-
-        claimData[84] = 0x02;
-        vm.expectRevert(HCAOwnerAndSessionValidator.PolicyRuleFailed.selector);
-        hca.validate(validator, digest, _envelope(permissionId, claimData, operationData, digest));
-
-        vm.warp(block.timestamp + 2 days);
-        vm.expectRevert(HCAOwnerAndSessionValidator.SessionExpired.selector);
-        hca.validate(validator, digest, _envelope(permissionId, claimData, operationData, digest));
-    }
-
     function test_validator_rejectsFirstSameChainRouteAboveAuthorizedRefund() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
         HCAOwnerAndSessionValidator.GasRefund memory gasRefund =
             HCAOwnerAndSessionValidator.GasRefund({token: proof.refundToken, exchangeRate: proof.maxRefundExchangeRate, overhead: (uint256(
                     proof.maxRefundAmount + 1
@@ -432,8 +358,7 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     }
 
     function test_validator_rejectsFirstSameChainFundingPullToAnotherAccount() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
         HCAOwnerAndSessionValidator.GasRefund memory gasRefund =
             HCAOwnerAndSessionValidator.GasRefund({token: proof.refundToken, exchangeRate: proof.maxRefundExchangeRate, overhead: (uint256(
                     proof.maxRefundAmount
@@ -460,10 +385,8 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     }
 
     function test_validator_rejectsFirstSameChainFundingWithoutTransfer() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            _initialRefundExecutions(permissionId, proof);
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
+        Execution[] memory executions = _initialRefundExecutions(permissionId, proof);
 
         _assertInitialRefundPolicyFailure(
             permissionId,
@@ -474,11 +397,9 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     }
 
     function test_validator_rejectsFirstSameChainFundingWhenCallsAreNotAdjacent() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            _initialRefundExecutions(permissionId, proof);
-        HCAOwnerAndSessionValidator.Execution memory transfer = executions[1];
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
+        Execution[] memory executions = _initialRefundExecutions(permissionId, proof);
+        Execution memory transfer = executions[1];
         executions[1] = executions[2];
         executions[2] = transfer;
 
@@ -486,12 +407,10 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     }
 
     function test_validator_rejectsFirstSameChainFundingWithMismatchedAmounts() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            _initialRefundExecutions(permissionId, proof);
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
+        Execution[] memory executions = _initialRefundExecutions(permissionId, proof);
         executions[1].callData = abi.encodeWithSelector(
-            validator.TRANSFER_FROM_SELECTOR(),
+            IERC20.transferFrom.selector,
             owner,
             address(hca),
             19_000_000
@@ -501,12 +420,10 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     }
 
     function test_validator_rejectsFirstSameChainFundingWithZeroAmount() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            _initialRefundExecutions(permissionId, proof);
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
+        Execution[] memory executions = _initialRefundExecutions(permissionId, proof);
         executions[0].callData = abi.encodeWithSelector(
-            validator.PERMIT_SELECTOR(),
+            IERC20Permit.permit.selector,
             owner,
             address(hca),
             0,
@@ -516,7 +433,7 @@ contract HCAOwnerAndSessionValidatorTest is Test {
             bytes32(uint256(2))
         );
         executions[1].callData = abi.encodeWithSelector(
-            validator.TRANSFER_FROM_SELECTOR(),
+            IERC20.transferFrom.selector,
             owner,
             address(hca),
             0
@@ -526,12 +443,9 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     }
 
     function test_validator_rejectsFirstSameChainFundingWithDuplicatePermit() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            _initialRefundExecutions(permissionId, proof);
-        HCAOwnerAndSessionValidator.Execution[] memory duplicated =
-            new HCAOwnerAndSessionValidator.Execution[](executions.length + 1);
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
+        Execution[] memory executions = _initialRefundExecutions(permissionId, proof);
+        Execution[] memory duplicated = new Execution[](executions.length + 1);
         duplicated[0] = executions[0];
         for (uint256 i; i < executions.length; ++i) {
             duplicated[i + 1] = executions[i];
@@ -541,12 +455,10 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     }
 
     function test_validator_rejectsFirstSameChainFundingFromAnotherOwner() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            _initialRefundExecutions(permissionId, proof);
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
+        Execution[] memory executions = _initialRefundExecutions(permissionId, proof);
         executions[0].callData = abi.encodeWithSelector(
-            validator.PERMIT_SELECTOR(),
+            IERC20Permit.permit.selector,
             makeAddr("another-owner"),
             address(hca),
             20_000_000,
@@ -560,12 +472,10 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     }
 
     function test_validator_rejectsFirstSameChainFundingForAnotherSpender() public {
-        (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId) =
-            _multiChainEnableProof();
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            _initialRefundExecutions(permissionId, proof);
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
+        Execution[] memory executions = _initialRefundExecutions(permissionId, proof);
         executions[0].callData = abi.encodeWithSelector(
-            validator.PERMIT_SELECTOR(),
+            IERC20Permit.permit.selector,
             owner,
             makeAddr("another-spender"),
             20_000_000,
@@ -578,72 +488,28 @@ contract HCAOwnerAndSessionValidatorTest is Test {
         _assertInitialRefundPolicyFailure(permissionId, proof, 80, _encodeExecutions(executions));
     }
 
-    function _enableSession() internal returns (bytes32 permissionId) {
-        permissionId = keccak256("cross-chain registration session");
-        vm.prank(address(hca));
-        validator.enableSession(
-            permissionId,
-            sessionSigner,
-            uint48(block.timestamp + 1 days),
-            address(0)
-        );
-    }
-
     function _commitOperation(bytes32 commitment) internal view returns (bytes memory) {
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](1);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(
-            COMMIT_SELECTOR,
+        Execution[] memory executions = new Execution[](1);
+        executions[0] = Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(
+            IETHRegistrar.commit.selector,
             commitment
         )});
-        return abi.encodePacked(validator.ERC7579_ERC1271_MODE(), abi.encode(executions));
+        return _encodeExecutions(executions);
     }
 
-    function _initialCommitOperation(
-        bytes32 permissionId,
-        HCAOwnerAndSessionValidator.SessionEnableProof memory proof
-    )
+    function _initialCommitOperation(bytes32 permissionId, SessionEnableProofFixture memory proof)
         internal
         view
         returns (bytes memory)
     {
-        return _initialCommitOperation(permissionId, proof, proof.validUntil);
-    }
-
-    function _initialCommitOperation(
-        bytes32 permissionId,
-        HCAOwnerAndSessionValidator.SessionEnableProof memory proof,
-        uint48 enabledUntil
-    )
-        internal
-        view
-        returns (bytes memory)
-    {
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](2);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: address(validator), value: 0, callData: abi.encodeCall(
-            validator.enableSessionWithRefund,
-            (
-                permissionId,
-                proof.sessionKey,
-                enabledUntil,
-                proof.resolver,
-                proof.refundToken,
-                proof.maxRefundExchangeRate,
-                proof.maxRefundGasOverhead,
-                proof.maxRefundAmount
-            )
-        )});
-        executions[1] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(
-            COMMIT_SELECTOR,
-            bytes32("commitment")
-        )});
-        return abi.encodePacked(validator.ERC7579_ERC1271_MODE(), abi.encode(executions));
+        permissionId;
+        proof;
+        return _commitOperation(bytes32("commitment"));
     }
 
     function _initialEnvelope(
         bytes32 permissionId,
-        HCAOwnerAndSessionValidator.SessionEnableProof memory proof,
+        SessionEnableProofFixture memory proof,
         bytes memory claimData,
         bytes memory operationData,
         bytes32 digest
@@ -652,12 +518,11 @@ contract HCAOwnerAndSessionValidatorTest is Test {
         pure
         returns (bytes memory)
     {
-        bytes memory proofData = abi.encode(proof);
+        bytes memory proofData = _packProof(proof);
         return
             abi.encodePacked(
                 bytes1(uint8(4)),
                 permissionId,
-                bytes4(uint32(proofData.length)),
                 proofData,
                 SOURCE_CHAIN_ID,
                 claimData,
@@ -668,7 +533,7 @@ contract HCAOwnerAndSessionValidatorTest is Test {
 
     function _initialRefundCommitOperation(
         bytes32 permissionId,
-        HCAOwnerAndSessionValidator.SessionEnableProof memory proof
+        SessionEnableProofFixture memory proof
     )
         internal
         view
@@ -679,17 +544,16 @@ contract HCAOwnerAndSessionValidatorTest is Test {
 
     function _initialRefundCommitOperation(
         bytes32 permissionId,
-        HCAOwnerAndSessionValidator.SessionEnableProof memory proof,
+        SessionEnableProofFixture memory proof,
         address fundingRecipient
     )
         internal
         view
         returns (bytes memory)
     {
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](5);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: paymentToken, value: 0, callData: abi.encodeWithSelector(
-            validator.PERMIT_SELECTOR(),
+        Execution[] memory executions = new Execution[](4);
+        executions[0] = Execution({target: paymentToken, value: 0, callData: abi.encodeWithSelector(
+            IERC20Permit.permit.selector,
             owner,
             address(hca),
             20_000_000,
@@ -698,40 +562,28 @@ contract HCAOwnerAndSessionValidatorTest is Test {
             bytes32(uint256(1)),
             bytes32(uint256(2))
         )});
-        executions[1] = HCAOwnerAndSessionValidator.Execution({target: paymentToken, value: 0, callData: abi.encodeWithSelector(
-            validator.TRANSFER_FROM_SELECTOR(),
+        executions[1] = Execution({target: paymentToken, value: 0, callData: abi.encodeWithSelector(
+            IERC20.transferFrom.selector,
             owner,
             fundingRecipient,
             20_000_000
         )});
-        executions[2] = HCAOwnerAndSessionValidator.Execution({target: paymentToken, value: 0, callData: abi.encodeWithSelector(
-            validator.APPROVE_SELECTOR(),
+        executions[2] = Execution({target: paymentToken, value: 0, callData: abi.encodeWithSelector(
+            IERC20.approve.selector,
             gasRefundPaymaster,
             proof.maxRefundAmount
         )});
-        executions[3] = HCAOwnerAndSessionValidator.Execution({target: address(validator), value: 0, callData: abi.encodeCall(
-            validator.enableSessionWithRefund,
-            (
-                permissionId,
-                proof.sessionKey,
-                proof.validUntil,
-                proof.resolver,
-                proof.refundToken,
-                proof.maxRefundExchangeRate,
-                proof.maxRefundGasOverhead,
-                proof.maxRefundAmount
-            )
-        )});
-        executions[4] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(
-            COMMIT_SELECTOR,
+        executions[3] = Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(
+            IETHRegistrar.commit.selector,
             bytes32("commitment")
         )});
-        return abi.encodePacked(validator.ERC7579_ERC1271_MODE(), abi.encode(executions));
+        permissionId;
+        return _encodeExecutions(executions);
     }
 
     function _initialRefundEnvelope(
         bytes32 permissionId,
-        HCAOwnerAndSessionValidator.SessionEnableProof memory proof,
+        SessionEnableProofFixture memory proof,
         uint256 nonce,
         HCAOwnerAndSessionValidator.GasRefund memory gasRefund,
         bytes memory operationData,
@@ -741,46 +593,38 @@ contract HCAOwnerAndSessionValidatorTest is Test {
         pure
         returns (bytes memory)
     {
-        bytes memory proofData = abi.encode(proof);
+        bytes memory proofData = _packProof(proof);
         return
             abi.encodePacked(
                 bytes1(uint8(5)),
                 permissionId,
-                bytes4(uint32(proofData.length)),
                 proofData,
                 nonce,
                 gasRefund.token,
-                gasRefund.exchangeRate,
-                gasRefund.overhead,
+                uint96(gasRefund.exchangeRate),
+                uint96(gasRefund.overhead >> 128),
+                uint48(uint128(gasRefund.overhead)),
                 operationData,
                 _signRhinestoneMessage(SESSION_KEY, digest)
             );
     }
 
-    function _initialRefundExecutions(
-        bytes32 permissionId,
-        HCAOwnerAndSessionValidator.SessionEnableProof memory proof
-    )
+    function _initialRefundExecutions(bytes32 permissionId, SessionEnableProofFixture memory proof)
         internal
         view
-        returns (HCAOwnerAndSessionValidator.Execution[] memory)
+        returns (Execution[] memory)
     {
-        return
-            abi.decode(
-                _slice(_initialRefundCommitOperation(permissionId, proof), 32),
-                (HCAOwnerAndSessionValidator.Execution[])
-            );
+        (, Execution[] memory executions) =
+            _decodeOperation(_initialRefundCommitOperation(permissionId, proof));
+        return executions;
     }
 
-    function _withoutExecution(
-        HCAOwnerAndSessionValidator.Execution[] memory executions,
-        uint256 removedIndex
-    )
+    function _withoutExecution(Execution[] memory executions, uint256 removedIndex)
         internal
         pure
-        returns (HCAOwnerAndSessionValidator.Execution[] memory remaining)
+        returns (Execution[] memory remaining)
     {
-        remaining = new HCAOwnerAndSessionValidator.Execution[](executions.length - 1);
+        remaining = new Execution[](executions.length - 1);
         uint256 next;
         for (uint256 i; i < executions.length; ++i) {
             if (i != removedIndex) {
@@ -789,17 +633,31 @@ contract HCAOwnerAndSessionValidatorTest is Test {
         }
     }
 
-    function _encodeExecutions(HCAOwnerAndSessionValidator.Execution[] memory executions)
-        internal
-        view
-        returns (bytes memory)
-    {
-        return abi.encodePacked(validator.ERC7579_ERC1271_MODE(), abi.encode(executions));
+    function _encodeExecutions(Execution[] memory executions) internal pure returns (bytes memory) {
+        bytes memory packed =
+            abi.encodePacked(
+                bytes2(HCAOperationHashLib.ERC7579_ERC1271_MODE),
+                uint8(executions.length)
+            );
+        for (uint256 i; i < executions.length; ++i) {
+            Execution memory execution = executions[i];
+            assertEq(execution.value, 0);
+            assertLe(execution.callData.length, type(uint24).max);
+            packed = bytes.concat(
+                packed,
+                abi.encodePacked(
+                    execution.target,
+                    uint24(execution.callData.length),
+                    execution.callData
+                )
+            );
+        }
+        return packed;
     }
 
     function _assertInitialRefundPolicyFailure(
         bytes32 permissionId,
-        HCAOwnerAndSessionValidator.SessionEnableProof memory proof,
+        SessionEnableProofFixture memory proof,
         uint256 nonce,
         bytes memory operationData
     )
@@ -835,7 +693,7 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     function _multiChainEnableProof()
         internal
         view
-        returns (HCAOwnerAndSessionValidator.SessionEnableProof memory proof, bytes32 permissionId)
+        returns (SessionEnableProofFixture memory proof, bytes32 permissionId)
     {
         proof.sessionKey = sessionSigner;
         proof.validUntil = uint48(block.timestamp + 1 days);
@@ -876,17 +734,17 @@ contract HCAOwnerAndSessionValidatorTest is Test {
                     SMART_SESSION_EMISSARY
                 )
             );
-        proof.hashesAndChainIds = new HCAOwnerAndSessionValidator.HashAndChainId[](2);
-        proof.hashesAndChainIds[0] = HCAOwnerAndSessionValidator.HashAndChainId({chainId: uint64(
+        proof.hashesAndChainIds = new HCASmartSessionLib.HashAndChainId[](2);
+        proof.hashesAndChainIds[0] = HCASmartSessionLib.HashAndChainId({chainId: uint64(
             SOURCE_CHAIN_ID
         ), sessionDigest: keccak256("source session")});
-        proof.hashesAndChainIds[1] = HCAOwnerAndSessionValidator.HashAndChainId({chainId: uint64(
+        proof.hashesAndChainIds[1] = HCASmartSessionLib.HashAndChainId({chainId: uint64(
             block.chainid
         ), sessionDigest: destinationSessionDigest});
 
         bytes32[] memory chainSessionHashes = new bytes32[](2);
         for (uint256 i; i < 2; ++i) {
-            HCAOwnerAndSessionValidator.HashAndChainId memory item = proof.hashesAndChainIds[i];
+            HCASmartSessionLib.HashAndChainId memory item = proof.hashesAndChainIds[i];
             chainSessionHashes[i] = keccak256(
                 abi.encode(CHAIN_SESSION_TYPEHASH, item.chainId, item.sessionDigest)
             );
@@ -908,6 +766,30 @@ contract HCAOwnerAndSessionValidatorTest is Test {
             );
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
         (proof.ownerV, proof.ownerR, proof.ownerS) = vm.sign(OWNER_KEY, digest);
+    }
+
+    function _packProof(SessionEnableProofFixture memory proof)
+        internal
+        pure
+        returns (bytes memory packed)
+    {
+        packed = abi.encodePacked(
+            proof.sessionKey,
+            proof.validUntil,
+            proof.sessionNonce,
+            proof.resolver,
+            proof.refundToken,
+            proof.maxRefundExchangeRate,
+            proof.maxRefundGasOverhead,
+            proof.maxRefundAmount,
+            proof.sessionToEnableIndex,
+            uint8(proof.hashesAndChainIds.length)
+        );
+        for (uint256 i; i < proof.hashesAndChainIds.length; ++i) {
+            HCASmartSessionLib.HashAndChainId memory item = proof.hashesAndChainIds[i];
+            packed = bytes.concat(packed, abi.encodePacked(item.chainId, item.sessionDigest));
+        }
+        return bytes.concat(packed, abi.encodePacked(proof.ownerR, proof.ownerS, proof.ownerV));
     }
 
     function _claim(bytes memory operationData, address recipient, uint256 targetChainId)
@@ -1005,12 +887,7 @@ contract HCAOwnerAndSessionValidatorTest is Test {
     }
 
     function _operationHash(bytes memory operationData) internal pure returns (bytes32) {
-        bytes32 mode;
-        assembly ("memory-safe") {
-            mode := mload(add(operationData, 0x20))
-        }
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            abi.decode(_slice(operationData, 32), (HCAOwnerAndSessionValidator.Execution[]));
+        (bytes32 mode, Execution[] memory executions) = _decodeOperation(operationData);
         bytes32[] memory executionHashes = new bytes32[](executions.length);
         for (uint256 i; i < executions.length; ++i) {
             executionHashes[i] = keccak256(
@@ -1024,6 +901,50 @@ contract HCAOwnerAndSessionValidatorTest is Test {
         }
         return
             keccak256(abi.encode(OP_TYPEHASH, mode, keccak256(abi.encodePacked(executionHashes))));
+    }
+
+    function _decodeOperation(bytes memory operationData)
+        internal
+        pure
+        returns (bytes32 mode, Execution[] memory executions)
+    {
+        if (operationData.length < 3) {
+            revert HCAOperationHashLib.InvalidOperationEncoding();
+        }
+        bytes2 modePrefix;
+        assembly ("memory-safe") {
+            modePrefix := mload(add(operationData, 0x20))
+        }
+        mode = bytes32(modePrefix);
+        uint256 count = uint8(operationData[2]);
+        executions = new Execution[](count);
+        uint256 cursor = 3;
+        for (uint256 i; i < count; ++i) {
+            if (operationData.length < cursor + 23) {
+                revert HCAOperationHashLib.InvalidOperationEncoding();
+            }
+            address target;
+            assembly ("memory-safe") {
+                target := shr(96, mload(add(add(operationData, 0x20), cursor)))
+            }
+            uint256 callDataLength =
+                (uint256(uint8(operationData[cursor + 20])) << 16) |
+                (uint256(uint8(operationData[cursor + 21])) << 8) |
+                uint256(uint8(operationData[cursor + 22]));
+            cursor += 23;
+            if (operationData.length < cursor + callDataLength) {
+                revert HCAOperationHashLib.InvalidOperationEncoding();
+            }
+            executions[i] = Execution({target: target, value: 0, callData: _slice(
+                operationData,
+                cursor,
+                callDataLength
+            )});
+            cursor += callDataLength;
+        }
+        if (cursor != operationData.length) {
+            revert HCAOperationHashLib.InvalidOperationEncoding();
+        }
     }
 
     function _envelope(
@@ -1047,8 +968,12 @@ contract HCAOwnerAndSessionValidatorTest is Test {
             );
     }
 
-    function _slice(bytes memory data, uint256 start) internal pure returns (bytes memory result) {
-        result = new bytes(data.length - start);
+    function _slice(bytes memory data, uint256 start, uint256 length)
+        internal
+        pure
+        returns (bytes memory result)
+    {
+        result = new bytes(length);
         for (uint256 i; i < result.length; ++i) {
             result[i] = data[start + i];
         }
@@ -1107,7 +1032,8 @@ contract HCAOwnerAndSessionValidatorEnableHarness is HCAOwnerAndSessionValidator
         view
         returns (bytes32)
     {
-        return _singleChainDigest(account, nonce, operationData, gasRefund);
+        (, bytes32 operationHash) = _decodeERC1271Operation(operationData);
+        return _singleChainDigest(account, nonce, operationHash, gasRefund);
     }
 
     /// @notice Exposes resolver call policy validation.

--- a/contracts/test/unit/hca/HCAOwnerAndSessionValidator.t.sol
+++ b/contracts/test/unit/hca/HCAOwnerAndSessionValidator.t.sol
@@ -144,7 +144,7 @@ contract HCAOwnerAndSessionValidatorTest is Test {
                 selector
             )
         );
-        validator.checkResolverCallHarness(abi.encodeWithSelector(selector), owner);
+        validator.checkResolverCallHarness(abi.encodeWithSelector(selector));
     }
 
     function test_validator_acceptsFirstPermit2RouteWithMultiChainSessionAuthorization()
@@ -1038,8 +1038,7 @@ contract HCAOwnerAndSessionValidatorEnableHarness is HCAOwnerAndSessionValidator
 
     /// @notice Exposes resolver call policy validation.
     /// @param callData ABI-encoded resolver call data.
-    /// @param expectedOwner The account owner expected by resolver setters.
-    function checkResolverCallHarness(bytes calldata callData, address expectedOwner) external pure {
-        _checkResolverCall(callData, expectedOwner);
+    function checkResolverCallHarness(bytes calldata callData) external pure {
+        _checkResolverCall(callData);
     }
 }

--- a/contracts/test/unit/hca/HCAOwnerAndSessionValidator.t.sol
+++ b/contracts/test/unit/hca/HCAOwnerAndSessionValidator.t.sol
@@ -170,6 +170,30 @@ contract HCAOwnerAndSessionValidatorTest is Test {
         assertEq(hca.validate(validator, digest, envelope), ERC1271_MAGICVALUE);
     }
 
+    function test_validator_rejectsInvalidFirstPermit2Operations() public {
+        _assertFirstPermit2OperationRevert(
+            abi.encodePacked(bytes2(HCAOperationHashLib.ERC7579_ERC1271_MODE), uint8(0)),
+            HCAOwnerAndSessionValidator.PolicyRuleFailed.selector
+        );
+
+        bytes memory operationData = _commitOperation(bytes32("commitment"));
+        operationData[1] = bytes1(uint8(4));
+        _assertFirstPermit2OperationRevert(
+            operationData,
+            HCAOwnerAndSessionValidator.InvalidOperationEncoding.selector
+        );
+
+        Execution[] memory executions = new Execution[](1);
+        executions[0] = Execution({target: ethRegistrar, value: 0, callData: abi.encodePacked(
+            IETHRegistrar.register.selector,
+            bytes2(0)
+        )});
+        _assertFirstPermit2OperationRevert(
+            _encodeExecutions(executions),
+            HCAOwnerAndSessionValidator.PolicyRuleFailed.selector
+        );
+    }
+
     function test_validator_rejectsMalformedFirstUseEnvelopes() public {
         bytes memory envelope = new bytes(130);
         envelope[0] = 0xFF;
@@ -194,6 +218,15 @@ contract HCAOwnerAndSessionValidatorTest is Test {
         envelope[0] = 0x05;
         vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSessionData.selector);
         hca.validate(validator, bytes32(0), envelope);
+
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
+        bytes memory operationData = _initialCommitOperation(permissionId, proof);
+        (bytes memory claimData, bytes32 digest) =
+            _claim(operationData, address(hca), block.chainid);
+        envelope = _initialEnvelope(permissionId, proof, claimData, operationData, digest);
+        envelope = _slice(envelope, 0, envelope.length - operationData.length);
+        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSessionData.selector);
+        hca.validate(validator, digest, envelope);
     }
 
     function test_validator_rejectsInvalidFirstUseProofAndSessionSignature() public {
@@ -217,6 +250,16 @@ contract HCAOwnerAndSessionValidatorTest is Test {
             _initialEnvelope(permissionId, proof, claimData, operationData, digest)
         );
 
+        (proof, permissionId) = _multiChainEnableProof();
+        proof.sessionToEnableIndex = uint8(proof.hashesAndChainIds.length);
+        operationData = _initialCommitOperation(permissionId, proof);
+        (claimData, digest) = _claim(operationData, address(hca), block.chainid);
+        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSessionData.selector);
+        hca.validate(
+            validator,
+            digest,
+            _initialEnvelope(permissionId, proof, claimData, operationData, digest)
+        );
         (proof, permissionId) = _multiChainEnableProof();
         operationData = _initialCommitOperation(permissionId, proof);
         (claimData, digest) = _claim(operationData, address(hca), block.chainid);
@@ -488,6 +531,20 @@ contract HCAOwnerAndSessionValidatorTest is Test {
         _assertInitialRefundPolicyFailure(permissionId, proof, 80, _encodeExecutions(executions));
     }
 
+    function _assertFirstPermit2OperationRevert(bytes memory operationData, bytes4 revertSelector)
+        internal
+    {
+        (SessionEnableProofFixture memory proof, bytes32 permissionId) = _multiChainEnableProof();
+        (bytes memory claimData, bytes32 digest) =
+            _claim(operationData, address(hca), block.chainid);
+
+        vm.expectRevert(revertSelector);
+        hca.validate(
+            validator,
+            digest,
+            _initialEnvelope(permissionId, proof, claimData, operationData, digest)
+        );
+    }
     function _commitOperation(bytes32 commitment) internal view returns (bytes memory) {
         Execution[] memory executions = new Execution[](1);
         executions[0] = Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(

--- a/contracts/test/unit/hca/StandaloneHCAFactory.t.sol
+++ b/contracts/test/unit/hca/StandaloneHCAFactory.t.sol
@@ -36,10 +36,10 @@ contract StandaloneHCAFactoryTest is Test {
 
     function setUp() public {
         verifiableFactory = new VerifiableFactory();
+        hcaFactory = new StandaloneHCAFactory(verifiableFactory, address(this));
         implementation = _newImplementation("entry-point");
         otherImplementation = _newImplementation("other-entry-point");
         unapprovedImplementation = _newImplementation("unapproved-entry-point");
-        hcaFactory = new StandaloneHCAFactory(verifiableFactory, address(this));
         hcaFactory.setImplementationApproval(address(implementation), true);
         hcaFactory.setImplementationApproval(address(otherImplementation), true);
     }
@@ -89,6 +89,10 @@ contract StandaloneHCAFactoryTest is Test {
         assertEq(hcaFactory.authorizedOwnerOf(hca), owner);
         assertEq(StandaloneSingleOwnerHCA(payable(hca)).owner(), owner);
         assertEq(verifiableFactory.verifyContract(hca), address(implementation));
+        assertEq(vm.load(hca, bytes32(0)), bytes32(0));
+
+        vm.expectRevert(StandaloneSingleOwnerHCA.StandaloneHCAAlreadyInitialized.selector);
+        StandaloneSingleOwnerHCA(payable(hca)).initializeAccount(abi.encode(otherOwner));
     }
 
     function test_allowsMultipleHCAsForOneOwner() public {
@@ -247,7 +251,8 @@ contract StandaloneHCAFactoryTest is Test {
                 address(new MockExecutorModule()),
                 "",
                 _deployPermissionedAddressSet(address(this)),
-                IAddressSet(address(0))
+                IAddressSet(address(0)),
+                hcaFactory
             );
     }
 

--- a/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
+++ b/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
@@ -438,6 +438,11 @@ contract StandaloneSingleOwnerHCATest is Test {
             bytes4(0xffffffff)
         );
 
+        bytes32 erc7739DetectionHash = bytes32((type(uint256).max / 0xffff) * 0x7739);
+        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSessionData.selector);
+        vm.prank(intentExecutor);
+        account.isValidSignature(erc7739DetectionHash, "");
+
         vm.expectRevert(
             abi.encodeWithSelector(
                 IModuleManagerEventsAndErrors.ValidatorNotInstalled.selector,
@@ -1327,6 +1332,13 @@ contract StandaloneSingleOwnerHCATest is Test {
 
         vm.expectRevert(HCAOwnerAndSessionValidator.InvalidOperationEncoding.selector);
         validatorHarness.singleChainDigestHarness(address(hca), 0, hex"");
+
+        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidOperationEncoding.selector);
+        validatorHarness.singleChainDigestHarness(
+            address(hca),
+            0,
+            abi.encodePacked(bytes2(HCAOperationHashLib.ERC7579_ERC1271_MODE), uint8(1))
+        );
     }
 
     function test_validator_moduleSurface() public view {
@@ -1361,6 +1373,14 @@ contract StandaloneSingleOwnerHCATest is Test {
         assertEq(validator.validateUserOp(userOp, userOpHash), 1);
 
         userOp.signature = abi.encodePacked(bytes32(0), bytes32(0), uint8(29));
+        vm.prank(address(hca));
+        assertEq(validator.validateUserOp(userOp, userOpHash), 1);
+
+        userOp.signature = abi.encodePacked(
+            bytes32(uint256(1)),
+            bytes32(type(uint256).max),
+            uint8(27)
+        );
         vm.prank(address(hca));
         assertEq(validator.validateUserOp(userOp, userOpHash), 1);
 

--- a/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
+++ b/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
@@ -830,11 +830,11 @@ contract StandaloneSingleOwnerHCATest is Test {
         );
     }
 
-    function test_validator_acceptsMultipleRegistryAuthorizedRegistrars() public {
+    function test_validator_rejectsMultipleRegistryAuthorizedRegistrars() public {
         address alternateRegistrar = _deployRegistrarWithOracle(_defaultPaymentTokens());
         ethRegistry.grantRootRoles(RegistryRolesLib.ROLE_REGISTRAR, alternateRegistrar);
 
-        Execution[] memory executions = new Execution[](3);
+        Execution[] memory executions = new Execution[](2);
         executions[0] = Execution({target: ethRegistrar, value: 0, callData: _registerCallDataForLabel(
             "alice",
             owner,
@@ -845,12 +845,38 @@ contract StandaloneSingleOwnerHCATest is Test {
             owner,
             resolver
         )});
-        executions[2] = Execution({target: usdc, value: 0, callData: abi.encodeWithSelector(
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                HCAOwnerAndSessionValidator.ActionNotAllowed.selector,
+                alternateRegistrar,
+                REGISTER_SELECTOR
+            )
+        );
+        validatorHarness.checkRegistrationPolicyHarness(
+            address(hca),
+            owner,
+            resolver,
+            _operationData(executions)
+        );
+    }
+
+    function test_validator_rejectsApprovalForAnotherRegistryAuthorizedRegistrar() public {
+        address alternateRegistrar = _deployRegistrarWithOracle(_defaultPaymentTokens());
+        ethRegistry.grantRootRoles(RegistryRolesLib.ROLE_REGISTRAR, alternateRegistrar);
+
+        Execution[] memory executions = new Execution[](2);
+        executions[0] = Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
+            owner,
+            resolver
+        )});
+        executions[1] = Execution({target: usdc, value: 0, callData: abi.encodeWithSelector(
             APPROVE_SELECTOR,
             alternateRegistrar,
             1 ether
         )});
 
+        vm.expectRevert(HCAOwnerAndSessionValidator.PolicyRuleFailed.selector);
         validatorHarness.checkRegistrationPolicyHarness(
             address(hca),
             owner,
@@ -1048,14 +1074,30 @@ contract StandaloneSingleOwnerHCATest is Test {
         );
     }
 
-    function test_validator_checksIntentTokenAgainstBatchRegistrarOracles() public {
-        bytes memory registerBatch = _registrationOperationData(owner, resolver);
-        assertTrue(validatorHarness.isBatchRegistrarPaymentTokenHarness(registerBatch, usdc));
+    function test_validator_checksIntentTokenAgainstSingleBatchRegistrarOracle() public {
+        Execution[] memory executions = new Execution[](2);
+        executions[0] = Execution({target: ethRegistrar, value: 0, callData: _registerCallDataForLabel(
+            "alice",
+            owner,
+            resolver
+        )});
+        executions[1] = Execution({target: ethRegistrar, value: 0, callData: _registerCallDataForLabel(
+            "bob",
+            owner,
+            resolver
+        )});
+        bytes memory registerBatch = _operationData(executions);
+        address rentPriceOracle = address(IRentPriceOracleProvider(ethRegistrar).rentPriceOracle());
         assertFalse(
             validatorHarness.isBatchRegistrarPaymentTokenHarness(
                 registerBatch,
                 makeAddr("junk-token")
             )
+        );
+
+        executions[1].target = _deployRegistrarWithOracle(_defaultPaymentTokens());
+        assertFalse(
+            validatorHarness.isBatchRegistrarPaymentTokenHarness(_operationData(executions), usdc)
         );
 
         bytes memory commitBatch =
@@ -1069,6 +1111,18 @@ contract StandaloneSingleOwnerHCATest is Test {
         );
 
         assertFalse(validatorHarness.isBatchRegistrarPaymentTokenHarness(hex"", usdc));
+
+        vm.expectCall(
+            ethRegistrar,
+            abi.encodeWithSelector(IRentPriceOracleProvider.rentPriceOracle.selector),
+            1
+        );
+        vm.expectCall(
+            rentPriceOracle,
+            abi.encodeWithSelector(IRentPriceOracle.isPaymentToken.selector, usdc),
+            1
+        );
+        assertTrue(validatorHarness.isBatchRegistrarPaymentTokenHarness(registerBatch, usdc));
     }
 
     function test_validator_treatsUnresponsiveRegistrarOracleAsUnsupported() public {

--- a/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
+++ b/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
@@ -26,6 +26,7 @@ import {
     ModePayload
 } from "nexus/lib/ModeLib.sol";
 import {Execution} from "nexus/types/DataTypes.sol";
+import {ERC1271_MAGICVALUE} from "nexus/types/Constants.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
 import {Test} from "forge-std/Test.sol";
@@ -39,8 +40,13 @@ import {
 import {Grant} from "~src/access-control/interfaces/IEACGrantInitializable.sol";
 import {EACBaseRolesLib} from "~src/access-control/libraries/EACBaseRolesLib.sol";
 import {HCAOwnerAndSessionValidator} from "~src/hca/HCAOwnerAndSessionValidator.sol";
+import {HCAExecutionLib} from "~src/hca/libraries/HCAExecutionLib.sol";
+import {HCAOperationHashLib} from "~src/hca/libraries/HCAOperationHashLib.sol";
+import {HCARegistrarPolicyLib} from "~src/hca/libraries/HCARegistrarPolicyLib.sol";
+import {HCASignatureLib} from "~src/hca/libraries/HCASignatureLib.sol";
 import {StandaloneHCAFactory} from "~src/hca/StandaloneHCAFactory.sol";
 import {StandaloneSingleOwnerHCA} from "~src/hca/StandaloneSingleOwnerHCA.sol";
+import {IStandaloneHCAFactory} from "~src/hca/interfaces/IStandaloneHCAFactory.sol";
 import {IStandaloneHCAOwner} from "~src/hca/interfaces/IStandaloneHCAOwner.sol";
 import {IRentPriceOracle} from "~src/registrar/interfaces/IRentPriceOracle.sol";
 import {IRentPriceOracleProvider} from "~src/registrar/interfaces/IRentPriceOracleProvider.sol";
@@ -80,8 +86,6 @@ contract StandaloneSingleOwnerHCATest is Test {
         uint128 denom;
     }
 
-    bytes4 constant ERC1271_MAGICVALUE = 0x1626ba7e;
-
     bytes4 constant COMMIT_SELECTOR = 0xf14fcbc8;
     bytes4 constant REGISTER_SELECTOR = 0xcff3e7c2;
     bytes4 constant RENEW_SELECTOR = 0x89d779c3;
@@ -91,7 +95,12 @@ contract StandaloneSingleOwnerHCATest is Test {
     bytes4 constant CLAIM_WITH_HCA_SELECTOR = 0xc90695df;
     bytes4 constant MULTICALL_SELECTOR = 0xac9650d8;
 
+    bytes32 constant EXECUTION_TYPEHASH = keccak256("Ops(address to,uint256 value,bytes data)");
+    bytes32 constant OPERATION_TYPEHASH =
+        keccak256("Op(bytes32 vt,Ops[] ops)Ops(address to,uint256 value,bytes data)");
+
     bytes NAME = "\x04test\x00";
+    bytes REGISTRATION_NAME = "\x05alice\x03eth\x00";
 
     uint256 ownerKey = 0xA11CE;
     uint256 sessionKey = 0x5E5510;
@@ -263,6 +272,46 @@ contract StandaloneSingleOwnerHCATest is Test {
         assertEq(StandaloneSingleOwnerHCA(payable(proxy)).owner(), owner);
     }
 
+    function test_standaloneSingleOwnerHCA_proxyUsesFixedExecutorWithoutInstallHook() public {
+        MockValidatorModule defaultValidator = new MockValidatorModule();
+        MockExecutorModule defaultExecutor = new MockExecutorModule();
+        StandaloneSingleOwnerHCA implementation =
+            new StandaloneSingleOwnerHCA(
+                entryPoint,
+                address(defaultValidator),
+                address(defaultExecutor),
+                "",
+                upgradeSet,
+                IAddressSet(address(0)),
+                IStandaloneHCAFactory(address(0))
+            );
+        VerifiableFactory factory = new VerifiableFactory();
+        StandaloneSingleOwnerHCA account =
+            StandaloneSingleOwnerHCA(
+                payable(
+                    factory.deployProxy(
+                        address(implementation),
+                        2,
+                        abi.encodeCall(
+                            StandaloneSingleOwnerHCA.initializeAccount,
+                            (abi.encode(owner))
+                        )
+                    )
+                )
+            );
+
+        assertFalse(defaultExecutor.isInitialized(address(account)));
+        assertTrue(account.isModuleInstalled(2, address(defaultExecutor), ""));
+
+        WalletPaidTarget target = new WalletPaidTarget();
+        vm.prank(address(defaultExecutor));
+        account.executeFromExecutor(
+            ModeLib.encodeSimpleSingle(),
+            ExecLib.encodeSingle(address(target), 0, abi.encodeCall(WalletPaidTarget.setValue, (7)))
+        );
+        assertEq(target.value(), 7);
+    }
+
     function test_standaloneSingleOwnerHCA_revokeSessionsBumpsNonce() public {
         StandaloneSingleOwnerHCA account = _newAccount();
         account.initializeAccount(abi.encode(owner));
@@ -363,6 +412,45 @@ contract StandaloneSingleOwnerHCATest is Test {
         assertEq(hca.validate(validator, digest, _signV01(ownerKey, digest)), ERC1271_MAGICVALUE);
     }
 
+    function test_standaloneSingleOwnerHCA_validatesThroughFixedDefaultValidator() public {
+        MockExecutorModule defaultExecutor = new MockExecutorModule();
+        StandaloneSingleOwnerHCA account =
+            new StandaloneSingleOwnerHCA(
+                entryPoint,
+                address(validator),
+                address(defaultExecutor),
+                "",
+                upgradeSet,
+                IAddressSet(address(0)),
+                IStandaloneHCAFactory(address(0))
+            );
+        account.initializeAccount(abi.encode(owner));
+
+        bytes32 digest = keccak256("standalone owner intent");
+        bytes memory signature = abi.encodePacked(address(0), _sign(ownerKey, digest));
+
+        vm.prank(intentExecutor);
+        assertEq(account.isValidSignature(digest, signature), ERC1271_MAGICVALUE);
+
+        vm.prank(intentExecutor);
+        assertEq(
+            account.isValidSignature(digest, abi.encodePacked(address(0), _sign(badKey, digest))),
+            bytes4(0xffffffff)
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IModuleManagerEventsAndErrors.ValidatorNotInstalled.selector,
+                address(validator)
+            )
+        );
+        vm.prank(intentExecutor);
+        account.isValidSignature(
+            digest,
+            abi.encodePacked(address(validator), _sign(ownerKey, digest))
+        );
+    }
+
     function test_validator_rejectsInvalidOwnerAuthorization() public {
         bytes32 digest = keccak256("owner intent");
 
@@ -386,314 +474,17 @@ contract StandaloneSingleOwnerHCATest is Test {
         hca.validate(validator, digest, abi.encodePacked(bytes32(0), bytes32(0), uint8(27)));
 
         vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSigner.selector);
+        hca.validate(
+            validator,
+            digest,
+            abi.encodePacked(bytes32(uint256(1)), bytes32(type(uint256).max), uint8(27))
+        );
+
+        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSigner.selector);
         validatorHarness.recoverHarness(digest, hex"1234");
 
         vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSessionData.selector);
         hca.validate(validator, digest, hex"1234");
-    }
-
-    function test_validator_usesPreEnabledRhinestoneSession() public {
-        bytes32 permissionId = keccak256("registration session");
-        uint48 validUntil = uint48(block.timestamp + 1 days);
-        vm.prank(address(hca));
-        validator.enableSession(permissionId, sessionSigner, validUntil, resolver);
-        assertTrue(validator.isPermissionEnabled(address(hca), permissionId));
-
-        bytes memory registrationData = _registrationOperationData(owner, resolver);
-        assertEq(
-            _verifySession(permissionId, sessionKey, registrationData),
-            validator.verifyExecution.selector
-        );
-
-        bytes memory laterData =
-            _singleOperationData(
-                defaultReverseRegistrarHCAAdapter,
-                0,
-                abi.encodeWithSelector(SET_NAME_WITH_HCA_SELECTOR, owner, "later.eth")
-            );
-        assertEq(
-            _verifySession(permissionId, sessionKey, laterData),
-            validator.verifyExecution.selector
-        );
-    }
-
-    function test_validator_usesPreEnabledSessionThroughERC1271() public {
-        bytes32 permissionId = keccak256("registration session");
-        uint48 validUntil = uint48(block.timestamp + 1 days);
-        vm.prank(address(hca));
-        validator.enableSession(permissionId, sessionSigner, validUntil, resolver);
-
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](1);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(
-            COMMIT_SELECTOR,
-            bytes32("commitment")
-        )});
-        bytes memory operationData = _erc1271OperationData(executions);
-        uint256 nonce = 123;
-        bytes32 digest =
-            validatorHarness.singleChainDigestHarness(address(hca), nonce, operationData);
-
-        assertEq(
-            hca.validate(
-                validator,
-                digest,
-                _fixedSessionEnvelope(permissionId, nonce, operationData, sessionKey, digest)
-            ),
-            ERC1271_MAGICVALUE
-        );
-
-        executions[0].callData = abi.encodeWithSelector(
-            COMMIT_SELECTOR,
-            bytes32("different commitment")
-        );
-        bytes memory differentOperation = _erc1271OperationData(executions);
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSessionData.selector);
-        hca.validate(
-            validator,
-            digest,
-            _fixedSessionEnvelope(permissionId, nonce, differentOperation, sessionKey, digest)
-        );
-    }
-
-    function test_validator_usesRefundAwareSessionThroughERC1271() public {
-        bytes32 permissionId = keccak256("refund registration session");
-        uint96 maxExchangeRate = 10_000_000_000;
-        uint48 maxGasOverhead = 100_000;
-        uint96 maxRefundAmount = 25_000_000;
-        vm.prank(address(hca));
-        validator.enableSessionWithRefund(
-            permissionId,
-            sessionSigner,
-            uint48(block.timestamp + 1 days),
-            resolver,
-            usdc,
-            maxExchangeRate,
-            maxGasOverhead,
-            maxRefundAmount
-        );
-
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](2);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: usdc, value: 0, callData: abi.encodeWithSelector(
-            APPROVE_SELECTOR,
-            gasRefundPaymaster,
-            maxRefundAmount
-        )});
-        executions[1] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(
-            COMMIT_SELECTOR,
-            bytes32("commitment")
-        )});
-        bytes memory operationData = _erc1271OperationData(executions);
-        uint256 packedOverhead = (uint256(maxRefundAmount) << 128) | maxGasOverhead;
-        HCAOwnerAndSessionValidator.GasRefund memory gasRefund =
-            HCAOwnerAndSessionValidator.GasRefund({token: usdc, exchangeRate: maxExchangeRate, overhead: packedOverhead});
-        uint256 nonce = 321;
-        bytes32 digest =
-            validatorHarness.singleChainDigestWithRefundHarness(
-                address(hca),
-                nonce,
-                operationData,
-                gasRefund
-            );
-
-        assertEq(
-            hca.validate(
-                validator,
-                digest,
-                _fixedSessionRefundEnvelope(
-                    permissionId,
-                    nonce,
-                    gasRefund,
-                    operationData,
-                    sessionKey,
-                    digest
-                )
-            ),
-            ERC1271_MAGICVALUE
-        );
-
-        executions[0].callData = abi.encodeWithSelector(
-            APPROVE_SELECTOR,
-            gasRefundPaymaster,
-            maxRefundAmount - 1
-        );
-        operationData = _erc1271OperationData(executions);
-        digest = validatorHarness.singleChainDigestWithRefundHarness(
-            address(hca),
-            nonce,
-            operationData,
-            gasRefund
-        );
-        vm.expectRevert(HCAOwnerAndSessionValidator.PolicyRuleFailed.selector);
-        hca.validate(
-            validator,
-            digest,
-            _fixedSessionRefundEnvelope(
-                permissionId,
-                nonce,
-                gasRefund,
-                operationData,
-                sessionKey,
-                digest
-            )
-        );
-
-        executions[0].callData = abi.encodeWithSelector(
-            APPROVE_SELECTOR,
-            gasRefundPaymaster,
-            maxRefundAmount
-        );
-        operationData = _erc1271OperationData(executions);
-
-        gasRefund.exchangeRate = maxExchangeRate + 1;
-        digest = validatorHarness.singleChainDigestWithRefundHarness(
-            address(hca),
-            nonce,
-            operationData,
-            gasRefund
-        );
-        vm.expectRevert(HCAOwnerAndSessionValidator.GasRefundNotAllowed.selector);
-        hca.validate(
-            validator,
-            digest,
-            _fixedSessionRefundEnvelope(
-                permissionId,
-                nonce,
-                gasRefund,
-                operationData,
-                sessionKey,
-                digest
-            )
-        );
-
-        gasRefund.exchangeRate = maxExchangeRate;
-        gasRefund.overhead = (uint256(maxRefundAmount + 1) << 128) | maxGasOverhead;
-        digest = validatorHarness.singleChainDigestWithRefundHarness(
-            address(hca),
-            nonce,
-            operationData,
-            gasRefund
-        );
-        vm.expectRevert(HCAOwnerAndSessionValidator.GasRefundNotAllowed.selector);
-        hca.validate(
-            validator,
-            digest,
-            _fixedSessionRefundEnvelope(
-                permissionId,
-                nonce,
-                gasRefund,
-                operationData,
-                sessionKey,
-                digest
-            )
-        );
-
-        gasRefund.overhead = (uint256(maxRefundAmount) << 128) | uint256(maxGasOverhead + 1);
-        digest = validatorHarness.singleChainDigestWithRefundHarness(
-            address(hca),
-            nonce,
-            operationData,
-            gasRefund
-        );
-        vm.expectRevert(HCAOwnerAndSessionValidator.GasRefundNotAllowed.selector);
-        hca.validate(
-            validator,
-            digest,
-            _fixedSessionRefundEnvelope(
-                permissionId,
-                nonce,
-                gasRefund,
-                operationData,
-                sessionKey,
-                digest
-            )
-        );
-
-        gasRefund = HCAOwnerAndSessionValidator.GasRefund({token: dai, exchangeRate: maxExchangeRate, overhead: packedOverhead});
-        digest = validatorHarness.singleChainDigestWithRefundHarness(
-            address(hca),
-            nonce,
-            operationData,
-            gasRefund
-        );
-        vm.expectRevert(HCAOwnerAndSessionValidator.GasRefundNotAllowed.selector);
-        hca.validate(
-            validator,
-            digest,
-            _fixedSessionRefundEnvelope(
-                permissionId,
-                nonce,
-                gasRefund,
-                operationData,
-                sessionKey,
-                digest
-            )
-        );
-    }
-
-    function test_validator_noRefundSessionRejectsExecutorRefund() public {
-        bytes32 permissionId = keccak256("no-refund registration session");
-        vm.prank(address(hca));
-        validator.enableSession(
-            permissionId,
-            sessionSigner,
-            uint48(block.timestamp + 1 days),
-            resolver
-        );
-
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](1);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(
-            COMMIT_SELECTOR,
-            bytes32("commitment")
-        )});
-        bytes memory operationData = _erc1271OperationData(executions);
-        HCAOwnerAndSessionValidator.GasRefund memory gasRefund =
-            HCAOwnerAndSessionValidator.GasRefund({token: usdc, exchangeRate: 1, overhead: 0});
-        uint256 nonce = 654;
-        bytes32 digest =
-            validatorHarness.singleChainDigestWithRefundHarness(
-                address(hca),
-                nonce,
-                operationData,
-                gasRefund
-            );
-
-        vm.expectRevert(HCAOwnerAndSessionValidator.GasRefundNotAllowed.selector);
-        hca.validate(
-            validator,
-            digest,
-            _fixedSessionRefundEnvelope(
-                permissionId,
-                nonce,
-                gasRefund,
-                operationData,
-                sessionKey,
-                digest
-            )
-        );
-
-        gasRefund = HCAOwnerAndSessionValidator.GasRefund({token: address(0), exchangeRate: 1, overhead: 0});
-        digest = validatorHarness.singleChainDigestWithRefundHarness(
-            address(hca),
-            nonce,
-            operationData,
-            gasRefund
-        );
-        vm.expectRevert(HCAOwnerAndSessionValidator.GasRefundNotAllowed.selector);
-        hca.validate(
-            validator,
-            digest,
-            _fixedSessionRefundEnvelope(
-                permissionId,
-                nonce,
-                gasRefund,
-                operationData,
-                sessionKey,
-                digest
-            )
-        );
     }
 
     function test_validator_matchesRhinestoneSingleChainDigest() public {
@@ -707,14 +498,12 @@ contract StandaloneSingleOwnerHCATest is Test {
                 address(0x5678),
                 gasRefundPaymaster
             );
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](1);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: address(0x9aBc), value: 0, callData: abi.encodeWithSelector(
+        Execution[] memory executions = new Execution[](1);
+        executions[0] = Execution({target: address(0x9aBc), value: 0, callData: abi.encodeWithSelector(
             COMMIT_SELECTOR,
             bytes32(uint256(0x1111111111111111111111111111111111111111111111111111111111111111))
         )});
-        bytes memory operationData =
-            abi.encodePacked(vectorValidator.ERC7579_ERC1271_MODE(), abi.encode(executions));
+        bytes memory operationData = _erc1271OperationData(executions);
 
         assertEq(
             vectorValidator.singleChainDigestHarness(address(0x1234), 123, operationData),
@@ -722,183 +511,62 @@ contract StandaloneSingleOwnerHCATest is Test {
         );
     }
 
-    function test_validator_appliesFixedPolicyThroughERC1271() public {
-        bytes32 permissionId = keccak256("registration session");
-        vm.prank(address(hca));
-        validator.enableSession(
-            permissionId,
-            sessionSigner,
-            uint48(block.timestamp + 1 days),
-            resolver
+    function testFuzz_validator_hashesPackedZeroValueOperations(
+        address firstTarget,
+        bytes calldata firstCallData,
+        address secondTarget,
+        bytes calldata secondCallData,
+        bool includeSecond
+    )
+        public
+        view
+    {
+        uint256 firstLength = firstCallData.length > 256 ? 256 : firstCallData.length;
+        uint256 secondLength = secondCallData.length > 256 ? 256 : secondCallData.length;
+        bytes memory firstData = firstCallData[:firstLength];
+        bytes memory secondData = secondCallData[:secondLength];
+        Execution[] memory executions = new Execution[](includeSecond ? 2 : 1);
+        executions[0] = Execution({target: firstTarget, value: 0, callData: firstData});
+        if (includeSecond) {
+            executions[1] = Execution({target: secondTarget, value: 0, callData: secondData});
+        }
+
+        bytes32[] memory executionHashes = new bytes32[](executions.length);
+        for (uint256 i; i < executions.length; ++i) {
+            executionHashes[i] = keccak256(
+                abi.encode(
+                    EXECUTION_TYPEHASH,
+                    executions[i].target,
+                    executions[i].value,
+                    keccak256(executions[i].callData)
+                )
+            );
+        }
+        bytes32 expectedHash =
+            keccak256(
+                abi.encode(
+                    OPERATION_TYPEHASH,
+                    HCAOperationHashLib.ERC7579_ERC1271_MODE,
+                    keccak256(abi.encodePacked(executionHashes))
+                )
+            );
+
+        assertEq(
+            validatorHarness.operationHashHarness(_erc1271OperationData(executions)),
+            expectedHash
         );
-
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](1);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: makeAddr("forbidden"), value: 0, callData: hex"12345678"});
-        bytes memory operationData = _erc1271OperationData(executions);
-        uint256 nonce = 456;
-        bytes32 digest =
-            validatorHarness.singleChainDigestHarness(address(hca), nonce, operationData);
-
-        vm.expectPartialRevert(HCAOwnerAndSessionValidator.ActionNotAllowed.selector);
-        hca.validate(
-            validator,
-            digest,
-            _fixedSessionEnvelope(permissionId, nonce, operationData, sessionKey, digest)
-        );
-    }
-
-    function test_validator_sessionExpiryAndNonceRevocation() public {
-        bytes32 permissionId = keccak256("registration session");
-        uint48 validUntil = uint48(block.timestamp + 1 days);
-        vm.prank(address(hca));
-        validator.enableSession(permissionId, sessionSigner, validUntil, resolver);
-
-        bytes memory operationData = _commitOperationData();
-        hca.setSessionNonce(1);
-        assertFalse(validator.isPermissionEnabled(address(hca), permissionId));
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSigner.selector);
-        _verifySession(permissionId, sessionKey, operationData);
-
-        vm.prank(address(hca));
-        validator.enableSession(permissionId, sessionSigner, validUntil, resolver);
-        assertTrue(validator.isPermissionEnabled(address(hca), permissionId));
-
-        vm.warp(validUntil + 1);
-        assertFalse(validator.isPermissionEnabled(address(hca), permissionId));
-        vm.expectRevert(HCAOwnerAndSessionValidator.SessionExpired.selector);
-        _verifySession(permissionId, sessionKey, operationData);
-    }
-
-    function test_validator_rejectsInvalidFixedSessionAuthorization() public {
-        bytes32 permissionId = keccak256("registration session");
-        uint48 validUntil = uint48(block.timestamp + 1 days);
-        vm.prank(address(hca));
-        validator.enableSession(permissionId, sessionSigner, validUntil, resolver);
-
-        bytes memory operationData = _erc1271CommitOperationData();
-        uint256 nonce = 123;
-        bytes32 digest =
-            validatorHarness.singleChainDigestHarness(address(hca), nonce, operationData);
-
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSigner.selector);
-        hca.validate(
-            validator,
-            digest,
-            _fixedSessionEnvelope(permissionId, nonce, operationData, badKey, digest)
-        );
-
-        hca.setSessionNonce(1);
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSigner.selector);
-        hca.validate(
-            validator,
-            digest,
-            _fixedSessionEnvelope(permissionId, nonce, operationData, sessionKey, digest)
-        );
-
-        hca.setSessionNonce(0);
-        vm.warp(validUntil + 1);
-        vm.expectRevert(HCAOwnerAndSessionValidator.SessionExpired.selector);
-        hca.validate(
-            validator,
-            digest,
-            _fixedSessionEnvelope(permissionId, nonce, operationData, sessionKey, digest)
-        );
-    }
-
-    function test_validator_rejectsMalformedFixedSessionEnvelope() public {
-        bytes memory shortRefundEnvelope = new bytes(130);
-        shortRefundEnvelope[0] = 0x02;
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSessionData.selector);
-        hca.validate(validator, bytes32(0), shortRefundEnvelope);
-
-        bytes memory unknownModeEnvelope = new bytes(130);
-        unknownModeEnvelope[0] = 0x03;
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSessionData.selector);
-        hca.validate(validator, bytes32(0), unknownModeEnvelope);
-
-        bytes memory operationData = _erc1271CommitOperationData();
-        uint256 nonce = 123;
-        bytes32 digest =
-            validatorHarness.singleChainDigestHarness(address(hca), nonce, operationData);
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSigner.selector);
-        hca.validate(
-            validator,
-            digest,
-            _fixedSessionEnvelope(
-                keccak256("missing session"),
-                nonce,
-                operationData,
-                sessionKey,
-                digest
-            )
-        );
-    }
-
-    function test_validator_rejectsInvalidSessionAuthorization() public {
-        bytes32 permissionId = keccak256("registration session");
-        uint48 validUntil = uint48(block.timestamp + 1 days);
-
-        vm.expectRevert(HCAOwnerAndSessionValidator.OwnerUnavailable.selector);
-        validator.enableSession(permissionId, sessionSigner, validUntil, resolver);
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSigner.selector);
-        vm.prank(address(hca));
-        validator.enableSession(permissionId, address(0), validUntil, resolver);
-
-        vm.warp(block.timestamp + 1);
-        vm.expectRevert(HCAOwnerAndSessionValidator.SessionExpired.selector);
-        vm.prank(address(hca));
-        validator.enableSession(permissionId, sessionSigner, uint48(block.timestamp - 1), resolver);
-
-        vm.expectRevert(HCAOwnerAndSessionValidator.GasRefundNotAllowed.selector);
-        vm.prank(address(hca));
-        validator.enableSessionWithRefund(
-            permissionId,
-            sessionSigner,
-            validUntil,
-            resolver,
-            address(0),
-            1,
-            0,
-            1
-        );
-
-        vm.prank(address(hca));
-        validator.enableSession(permissionId, sessionSigner, validUntil, resolver);
-
-        bytes memory operationData = _commitOperationData();
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSigner.selector);
-        _verifySession(permissionId, badKey, operationData);
-
-        HCAOwnerAndSessionValidator.Operation memory operation =
-            HCAOwnerAndSessionValidator.Operation({data: operationData});
-        bytes memory validData = _sessionUse(permissionId, sessionKey, keccak256(operationData));
-        vm.expectRevert(HCAOwnerAndSessionValidator.CallerNotIntentExecutor.selector);
-        validator.verifyExecution(address(hca), keccak256(operationData), validData, operation);
-
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSessionData.selector);
-        vm.prank(intentExecutor);
-        validator.verifyExecution(address(hca), keccak256(operationData), hex"01", operation);
-
-        vm.expectRevert(HCAOwnerAndSessionValidator.InvalidSigner.selector);
-        vm.prank(intentExecutor);
-        validator.verifyExecution(
-            address(hca),
-            keccak256(operationData),
-            _sessionUse(keccak256("missing session"), sessionKey, keccak256(operationData)),
-            operation
-        );
-
-        vm.mockCallRevert(
-            address(hca),
-            abi.encodeWithSignature("ownerAndSessionNonce()"),
-            abi.encode("owner unavailable")
-        );
-        assertFalse(validator.isPermissionEnabled(address(hca), permissionId));
-        vm.clearMockedCalls();
     }
 
     function test_validator_allowsExactCounterfactualResolverDeployment() public view {
+        bytes[] memory setters = new bytes[](2);
+        setters[0] = abi.encodeCall(
+            IAddressSetter.setAddress,
+            (REGISTRATION_NAME, COIN_TYPE_ETH, abi.encodePacked(owner))
+        );
+        setters[1] = abi.encodeCall(
+            ITextSetter.setText,
+            (REGISTRATION_NAME, "avatar", "https://euc.li/alice.eth")
+        );
         validatorHarness.checkRegistrationPolicyHarness(
             address(hca),
             owner,
@@ -908,7 +576,7 @@ contract StandaloneSingleOwnerHCATest is Test {
                 counterfactualResolverSalt,
                 abi.encodeCall(
                     IPermissionedResolverInitializable.initialize,
-                    (_defaultGrants(), new bytes[](0))
+                    (_defaultGrants(), setters)
                 )
             )
         );
@@ -924,11 +592,10 @@ contract StandaloneSingleOwnerHCATest is Test {
                     (_defaultGrants(), new bytes[](0))
                 )
             );
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](3);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: verifiableFactory, value: 0, callData: deploymentCall});
+        Execution[] memory executions = new Execution[](3);
+        executions[0] = Execution({target: verifiableFactory, value: 0, callData: deploymentCall});
         executions[1] = executions[0];
-        executions[2] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
+        executions[2] = Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
             owner,
             counterfactualResolver
         )});
@@ -948,54 +615,24 @@ contract StandaloneSingleOwnerHCATest is Test {
         HCAOwnerAndSessionValidator.GasRefund memory gasRefund;
 
         vm.expectRevert(HCAOwnerAndSessionValidator.InvalidOperationEncoding.selector);
-        validatorHarness.checkInitialRegistrationPolicyHarness(
+        validatorHarness.checkStatelessRegistrationPolicyHarness(
             address(hca),
             owner,
-            bytes32(0),
             proof,
             "",
             gasRefund
         );
 
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](0);
+        Execution[] memory executions = new Execution[](0);
         bytes memory operationData = _erc1271OperationData(executions);
         vm.expectRevert(HCAOwnerAndSessionValidator.PolicyRuleFailed.selector);
-        validatorHarness.checkInitialRegistrationPolicyHarness(
+        validatorHarness.checkStatelessRegistrationPolicyHarness(
             address(hca),
             owner,
-            bytes32(0),
             proof,
             operationData,
             gasRefund
         );
-
-        executions = new HCAOwnerAndSessionValidator.Execution[](2);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(
-            COMMIT_SELECTOR,
-            bytes32("first")
-        )});
-        executions[1] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(
-            COMMIT_SELECTOR,
-            bytes32("second")
-        )});
-        operationData = _erc1271OperationData(executions);
-        vm.expectRevert(HCAOwnerAndSessionValidator.PolicyRuleFailed.selector);
-        validatorHarness.checkInitialRegistrationPolicyHarness(
-            address(hca),
-            owner,
-            bytes32(0),
-            proof,
-            operationData,
-            gasRefund
-        );
-
-        executions = new HCAOwnerAndSessionValidator.Execution[](1);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: usdc, value: 0, callData: abi.encodePacked(
-            validatorHarness.TRANSFER_FROM_SELECTOR()
-        )});
-        vm.expectRevert(HCAOwnerAndSessionValidator.PolicyRuleFailed.selector);
-        validatorHarness.fundingCallIndexesHarness(executions, address(hca), owner, usdc);
 
         vm.expectRevert(HCAOwnerAndSessionValidator.PolicyRuleFailed.selector);
         validatorHarness.checkResolverBindingHarness(address(0), true, false);
@@ -1012,7 +649,7 @@ contract StandaloneSingleOwnerHCATest is Test {
 
         vm.expectRevert(HCAOwnerAndSessionValidator.InvalidOperationEncoding.selector);
         validatorHarness.operationHashHarness(
-            abi.encodePacked(bytes32(uint256(0xDEAD)), abi.encode(executions))
+            _packOperation(bytes32(uint256(0xDEAD) << 240), executions)
         );
 
         vm.expectRevert(HCAOwnerAndSessionValidator.InvalidOperationEncoding.selector);
@@ -1068,7 +705,7 @@ contract StandaloneSingleOwnerHCATest is Test {
 
         grants = _defaultGrants();
         setters = new bytes[](1);
-        setters[0] = abi.encodeCall(ITextSetter.setText, (NAME, "avatar", "ipfs://avatar"));
+        setters[0] = abi.encodeWithSelector(APPROVE_SELECTOR, ethRegistrar, 1);
         _expectValidationRevert(
             _registrationWithResolverDeployment(
                 permittedResolverImpl,
@@ -1079,7 +716,7 @@ contract StandaloneSingleOwnerHCATest is Test {
                 )
             ),
             counterfactualResolver,
-            HCAOwnerAndSessionValidator.PolicyRuleFailed.selector
+            HCAOwnerAndSessionValidator.ActionNotAllowed.selector
         );
         _expectValidationRevert(
             _registrationWithResolverDeployment(
@@ -1096,9 +733,8 @@ contract StandaloneSingleOwnerHCATest is Test {
     }
 
     function test_validator_requiresDeploymentForCounterfactualResolver() public {
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](1);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
+        Execution[] memory executions = new Execution[](1);
+        executions[0] = Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
             owner,
             counterfactualResolver
         )});
@@ -1120,25 +756,24 @@ contract StandaloneSingleOwnerHCATest is Test {
                     (_defaultGrants(), new bytes[](0))
                 )
             );
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](2);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
+        Execution[] memory executions = new Execution[](2);
+        executions[0] = Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
             owner,
             counterfactualResolver
         )});
-        executions[1] = HCAOwnerAndSessionValidator.Execution({target: verifiableFactory, value: 0, callData: deploymentCall});
+        executions[1] = Execution({target: verifiableFactory, value: 0, callData: deploymentCall});
         _expectValidationRevert(
             _operationData(executions),
             counterfactualResolver,
             HCAOwnerAndSessionValidator.PolicyRuleFailed.selector
         );
 
-        executions = new HCAOwnerAndSessionValidator.Execution[](2);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: counterfactualResolver, value: 0, callData: abi.encodeCall(
+        executions = new Execution[](2);
+        executions[0] = Execution({target: counterfactualResolver, value: 0, callData: abi.encodeCall(
             ITextSetter.setText,
             (NAME, "avatar", "ipfs://avatar")
         )});
-        executions[1] = HCAOwnerAndSessionValidator.Execution({target: verifiableFactory, value: 0, callData: deploymentCall});
+        executions[1] = Execution({target: verifiableFactory, value: 0, callData: deploymentCall});
 
         _expectValidationRevert(
             _operationData(executions),
@@ -1171,14 +806,13 @@ contract StandaloneSingleOwnerHCATest is Test {
             _registrationOperationDataWithDefaultReverseName(owner, resolver, "bob.eth")
         );
 
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](2);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: _registerCallDataForLabel(
+        Execution[] memory executions = new Execution[](2);
+        executions[0] = Execution({target: ethRegistrar, value: 0, callData: _registerCallDataForLabel(
             "alice",
             owner,
             resolver
         )});
-        executions[1] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: _registerCallDataForLabel(
+        executions[1] = Execution({target: ethRegistrar, value: 0, callData: _registerCallDataForLabel(
             "bob",
             owner,
             resolver
@@ -1195,19 +829,18 @@ contract StandaloneSingleOwnerHCATest is Test {
         address alternateRegistrar = _deployRegistrarWithOracle(_defaultPaymentTokens());
         ethRegistry.grantRootRoles(RegistryRolesLib.ROLE_REGISTRAR, alternateRegistrar);
 
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](3);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: _registerCallDataForLabel(
+        Execution[] memory executions = new Execution[](3);
+        executions[0] = Execution({target: ethRegistrar, value: 0, callData: _registerCallDataForLabel(
             "alice",
             owner,
             resolver
         )});
-        executions[1] = HCAOwnerAndSessionValidator.Execution({target: alternateRegistrar, value: 0, callData: _registerCallDataForLabel(
+        executions[1] = Execution({target: alternateRegistrar, value: 0, callData: _registerCallDataForLabel(
             "bob",
             owner,
             resolver
         )});
-        executions[2] = HCAOwnerAndSessionValidator.Execution({target: usdc, value: 0, callData: abi.encodeWithSelector(
+        executions[2] = Execution({target: usdc, value: 0, callData: abi.encodeWithSelector(
             APPROVE_SELECTOR,
             alternateRegistrar,
             1 ether
@@ -1505,17 +1138,17 @@ contract StandaloneSingleOwnerHCATest is Test {
             HCAOwnerAndSessionValidator.PolicyRuleFailed.selector
         );
 
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](1);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 1, callData: abi.encodeWithSelector(
+        Execution[] memory executions = new Execution[](1);
+        executions[0] = Execution({target: ethRegistrar, value: 1, callData: abi.encodeWithSelector(
             COMMIT_SELECTOR,
             bytes32("commitment")
         )});
-        operationData = _operationData(executions);
-        _expectValidationRevert(
-            operationData,
+        vm.expectRevert(HCAOwnerAndSessionValidator.PolicyRuleFailed.selector);
+        validatorHarness.checkRegistrationExecutionsHarness(
+            address(hca),
+            owner,
             address(0),
-            HCAOwnerAndSessionValidator.PolicyRuleFailed.selector
+            executions
         );
     }
 
@@ -1536,13 +1169,12 @@ contract StandaloneSingleOwnerHCATest is Test {
             HCAOwnerAndSessionValidator.PolicyRuleFailed.selector
         );
 
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](2);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
+        Execution[] memory executions = new Execution[](2);
+        executions[0] = Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
             owner,
             resolver
         )});
-        executions[1] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
+        executions[1] = Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
             owner,
             otherResolver
         )});
@@ -1553,11 +1185,11 @@ contract StandaloneSingleOwnerHCATest is Test {
             HCAOwnerAndSessionValidator.PolicyRuleFailed.selector
         );
 
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
+        executions[0] = Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
             owner,
             address(0)
         )});
-        executions[1] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
+        executions[1] = Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
             owner,
             resolver
         )});
@@ -1869,6 +1501,8 @@ contract StandaloneSingleOwnerHCATest is Test {
     function test_standaloneSingleOwnerHCA_deploysAndExecutesPaymasterSponsoredOwnerUserOp() public {
         EntryPoint userOpEntryPoint = new EntryPoint();
         MockExecutorModule defaultExecutor = new MockExecutorModule();
+        VerifiableFactory factory = new VerifiableFactory();
+        StandaloneHCAFactory deployer = new StandaloneHCAFactory(factory, address(this));
         StandaloneSingleOwnerHCA implementation =
             new StandaloneSingleOwnerHCA(
                 address(userOpEntryPoint),
@@ -1876,10 +1510,9 @@ contract StandaloneSingleOwnerHCATest is Test {
                 address(defaultExecutor),
                 "",
                 upgradeSet,
-                IAddressSet(address(0))
+                IAddressSet(address(0)),
+                deployer
             );
-        VerifiableFactory factory = new VerifiableFactory();
-        StandaloneHCAFactory deployer = new StandaloneHCAFactory(factory, address(this));
         deployer.setImplementationApproval(address(implementation), true);
         uint256 userSalt = 4337;
         uint256 deploymentSalt = deployer.deploymentSalt(owner, address(implementation), userSalt);
@@ -1943,6 +1576,8 @@ contract StandaloneSingleOwnerHCATest is Test {
     function test_standaloneSingleOwnerHCA_entryPointRejectsOwnerDelegatecallUserOp() public {
         EntryPoint userOpEntryPoint = new EntryPoint();
         MockExecutorModule defaultExecutor = new MockExecutorModule();
+        VerifiableFactory factory = new VerifiableFactory();
+        StandaloneHCAFactory deployer = new StandaloneHCAFactory(factory, address(this));
         StandaloneSingleOwnerHCA implementation =
             new StandaloneSingleOwnerHCA(
                 address(userOpEntryPoint),
@@ -1950,10 +1585,9 @@ contract StandaloneSingleOwnerHCATest is Test {
                 address(defaultExecutor),
                 "",
                 upgradeSet,
-                IAddressSet(address(0))
+                IAddressSet(address(0)),
+                deployer
             );
-        VerifiableFactory factory = new VerifiableFactory();
-        StandaloneHCAFactory deployer = new StandaloneHCAFactory(factory, address(this));
         deployer.setImplementationApproval(address(implementation), true);
         StandaloneSingleOwnerHCA account =
             StandaloneSingleOwnerHCA(payable(deployer.deploy(owner, address(implementation), 4338)));
@@ -2075,7 +1709,8 @@ contract StandaloneSingleOwnerHCATest is Test {
             address(defaultExecutor),
             "",
             upgradeSet,
-            IAddressSet(address(0))
+            IAddressSet(address(0)),
+            IStandaloneHCAFactory(address(0))
         );
         account.initializeAccount(abi.encode(owner));
     }
@@ -2116,7 +1751,8 @@ contract StandaloneSingleOwnerHCATest is Test {
                 address(defaultExecutor),
                 "",
                 upgradeSet,
-                predecessorUpgradeSet
+                predecessorUpgradeSet,
+                IStandaloneHCAFactory(address(0))
             );
     }
 
@@ -2228,14 +1864,13 @@ contract StandaloneSingleOwnerHCATest is Test {
         view
         returns (bytes memory)
     {
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](2);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: verifiableFactory, value: 0, callData: _resolverDeploymentCall(
+        Execution[] memory executions = new Execution[](2);
+        executions[0] = Execution({target: verifiableFactory, value: 0, callData: _resolverDeploymentCall(
             implementation,
             salt,
             initData
         )});
-        executions[1] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
+        executions[1] = Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
             owner,
             counterfactualResolver
         )});
@@ -2269,26 +1904,25 @@ contract StandaloneSingleOwnerHCATest is Test {
         resolverCalls[0] = abi.encodeCall(ITextSetter.setText, (NAME, "avatar", "ipfs://avatar"));
         resolverCalls[1] = abi.encodeCall(INameSetter.setName, (NAME, "alice.eth"));
 
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](5);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
+        Execution[] memory executions = new Execution[](5);
+        executions[0] = Execution({target: ethRegistrar, value: 0, callData: _registerCallData(
             registrant,
             registrationResolver
         )});
-        executions[1] = HCAOwnerAndSessionValidator.Execution({target: registrationResolver, value: 0, callData: abi.encodeCall(
+        executions[1] = Execution({target: registrationResolver, value: 0, callData: abi.encodeCall(
             IAddressSetter.setAddress,
             (NAME, COIN_TYPE_ETH, abi.encodePacked(registrant))
         )});
-        executions[2] = HCAOwnerAndSessionValidator.Execution({target: registrationResolver, value: 0, callData: abi.encodeCall(
+        executions[2] = Execution({target: registrationResolver, value: 0, callData: abi.encodeCall(
             IMulticallable.multicall,
             (resolverCalls)
         )});
-        executions[3] = HCAOwnerAndSessionValidator.Execution({target: usdc, value: 0, callData: abi.encodeWithSelector(
+        executions[3] = Execution({target: usdc, value: 0, callData: abi.encodeWithSelector(
             APPROVE_SELECTOR,
             ethRegistrar,
             1 ether
         )});
-        executions[4] = HCAOwnerAndSessionValidator.Execution({target: defaultReverseRegistrarHCAAdapter, value: 0, callData: abi.encodeWithSelector(
+        executions[4] = Execution({target: defaultReverseRegistrarHCAAdapter, value: 0, callData: abi.encodeWithSelector(
             SET_NAME_WITH_HCA_SELECTOR,
             registrant,
             defaultReverseName
@@ -2329,9 +1963,8 @@ contract StandaloneSingleOwnerHCATest is Test {
     }
 
     function _commitOperationData() internal view returns (bytes memory) {
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](1);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(
+        Execution[] memory executions = new Execution[](1);
+        executions[0] = Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(
             COMMIT_SELECTOR,
             bytes32("commitment")
         )});
@@ -2340,36 +1973,50 @@ contract StandaloneSingleOwnerHCATest is Test {
 
     function _singleOperationData(address target, uint256 value, bytes memory callData)
         internal
-        view
+        pure
         returns (bytes memory)
     {
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](1);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: target, value: value, callData: callData});
+        Execution[] memory executions = new Execution[](1);
+        executions[0] = Execution({target: target, value: value, callData: callData});
         return _operationData(executions);
     }
 
-    function _operationData(HCAOwnerAndSessionValidator.Execution[] memory executions)
-        internal
-        view
-        returns (bytes memory)
-    {
-        return
-            abi.encodePacked(validator.ERC7579_EMISSARY_EXECUTION_MODE(), abi.encode(executions));
+    function _operationData(Execution[] memory executions) internal pure returns (bytes memory) {
+        return _packOperation(HCAOperationHashLib.ERC7579_EMISSARY_EXECUTION_MODE, executions);
     }
 
-    function _erc1271OperationData(HCAOwnerAndSessionValidator.Execution[] memory executions)
+    function _erc1271OperationData(Execution[] memory executions)
         internal
-        view
+        pure
         returns (bytes memory)
     {
-        return abi.encodePacked(validator.ERC7579_ERC1271_MODE(), abi.encode(executions));
+        return _packOperation(HCAOperationHashLib.ERC7579_ERC1271_MODE, executions);
+    }
+
+    function _packOperation(bytes32 mode, Execution[] memory executions)
+        internal
+        pure
+        returns (bytes memory packed)
+    {
+        packed = abi.encodePacked(bytes2(mode), uint8(executions.length));
+        for (uint256 i; i < executions.length; ++i) {
+            Execution memory execution = executions[i];
+            require(execution.value == 0, "nonzero execution value");
+            require(execution.callData.length <= type(uint24).max, "execution calldata too large");
+            packed = bytes.concat(
+                packed,
+                abi.encodePacked(
+                    execution.target,
+                    uint24(execution.callData.length),
+                    execution.callData
+                )
+            );
+        }
     }
 
     function _erc1271CommitOperationData() internal view returns (bytes memory) {
-        HCAOwnerAndSessionValidator.Execution[] memory executions =
-            new HCAOwnerAndSessionValidator.Execution[](1);
-        executions[0] = HCAOwnerAndSessionValidator.Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(
+        Execution[] memory executions = new Execution[](1);
+        executions[0] = Execution({target: ethRegistrar, value: 0, callData: abi.encodeWithSelector(
             COMMIT_SELECTOR,
             bytes32("commitment")
         )});
@@ -2394,23 +2041,6 @@ contract StandaloneSingleOwnerHCATest is Test {
             allowedResolver,
             operationData
         );
-    }
-
-    function _verifySession(bytes32 permissionId, uint256 signerKey, bytes memory operationData)
-        internal
-        returns (bytes4)
-    {
-        bytes32 digest = keccak256(operationData);
-        HCAOwnerAndSessionValidator.Operation memory operation =
-            HCAOwnerAndSessionValidator.Operation({data: operationData});
-        vm.prank(intentExecutor);
-        return
-            validator.verifyExecution(
-                address(hca),
-                digest,
-                _sessionUse(permissionId, signerKey, digest),
-                operation
-            );
     }
 
     function _sessionUse(bytes32 permissionId, uint256 signerKey, bytes32 digest)
@@ -2521,7 +2151,7 @@ contract HCAOwnerAndSessionValidatorHarness is HCAOwnerAndSessionValidator {
     {}
 
     function callArgsHarness(bytes memory callData) external pure returns (bytes memory) {
-        return _callArgs(callData);
+        return HCAExecutionLib.callArgs(callData);
     }
 
     function isBatchRegistrarPaymentTokenHarness(bytes calldata operationData, address token)
@@ -2529,7 +2159,14 @@ contract HCAOwnerAndSessionValidatorHarness is HCAOwnerAndSessionValidator {
         view
         returns (bool)
     {
-        return _isBatchRegistrarPaymentToken(operationData, token);
+        if (operationData.length < 32) {
+            return false;
+        }
+        return
+            HCARegistrarPolicyLib.isBatchPaymentToken(
+                HCAOperationHashLib.decode(operationData).executions,
+                token
+            );
     }
 
     function recoverHarness(bytes32 digest, bytes calldata signature)
@@ -2537,7 +2174,11 @@ contract HCAOwnerAndSessionValidatorHarness is HCAOwnerAndSessionValidator {
         pure
         returns (address)
     {
-        return _recover(digest, signature);
+        address signer = HCASignatureLib.recover(digest, signature);
+        if (signer == address(0)) {
+            revert InvalidSigner();
+        }
+        return signer;
     }
 
     function checkRegistrationPolicyHarness(
@@ -2549,13 +2190,48 @@ contract HCAOwnerAndSessionValidatorHarness is HCAOwnerAndSessionValidator {
         external
         view
     {
-        _checkRegistrationPolicy(account, owner, resolver, operationData);
+        if (operationData.length < 3) {
+            revert InvalidOperationEncoding();
+        }
+        HCAOperationHashLib.DecodedOperation memory operation =
+            HCAOperationHashLib.decode(operationData);
+        if (!HCAOperationHashLib.isSupportedMode(operation.mode)) {
+            revert InvalidOperationEncoding();
+        }
+        _checkRegistrationExecutions(
+            account,
+            owner,
+            resolver,
+            operation.executions,
+            GasRefund(address(0), 0, 0),
+            address(0),
+            false
+        );
     }
 
-    function checkInitialRegistrationPolicyHarness(
+    function checkRegistrationExecutionsHarness(
         address account,
         address owner,
-        bytes32 permissionId,
+        address resolver,
+        Execution[] calldata executions
+    )
+        external
+        view
+    {
+        _checkRegistrationExecutions(
+            account,
+            owner,
+            resolver,
+            executions,
+            GasRefund(address(0), 0, 0),
+            address(0),
+            false
+        );
+    }
+
+    function checkStatelessRegistrationPolicyHarness(
+        address account,
+        address owner,
         SessionEnableProof calldata proof,
         bytes calldata operationData,
         GasRefund calldata gasRefund
@@ -2563,27 +2239,9 @@ contract HCAOwnerAndSessionValidatorHarness is HCAOwnerAndSessionValidator {
         external
         view
     {
-        _checkInitialRegistrationPolicy(
-            account,
-            owner,
-            permissionId,
-            proof,
-            operationData,
-            gasRefund
-        );
-    }
-
-    function fundingCallIndexesHarness(
-        Execution[] memory executions,
-        address account,
-        address owner,
-        address token
-    )
-        external
-        pure
-        returns (uint256 permitIndex, uint256 transferIndex)
-    {
-        return _fundingCallIndexes(executions, account, owner, token);
+        (HCAOperationHashLib.DecodedOperation memory operation, ) =
+            _decodeERC1271Operation(operationData);
+        _checkStatelessRegistrationPolicy(account, owner, proof, operation, gasRefund);
     }
 
     function checkResolverBindingHarness(address resolver, bool usesResolver, bool deploysResolver)
@@ -2592,12 +2250,15 @@ contract HCAOwnerAndSessionValidatorHarness is HCAOwnerAndSessionValidator {
     {
         _checkResolverBinding(
             resolver,
-            RegistrationPolicyState({usesResolver: usesResolver, deploysResolver: deploysResolver})
+            RegistrationPolicyState({usesResolver: usesResolver, deploysResolver: deploysResolver, authorizedRegistrar: address(
+                0
+            )})
         );
     }
 
     function operationHashHarness(bytes calldata operationData) external pure returns (bytes32) {
-        return _operationHash(operationData);
+        (, bytes32 operationHash) = _decodeERC1271Operation(operationData);
+        return operationHash;
     }
 
     function readUintHarness(bytes memory callData, uint256 offset) external pure returns (uint256) {
@@ -2609,7 +2270,8 @@ contract HCAOwnerAndSessionValidatorHarness is HCAOwnerAndSessionValidator {
         view
         returns (bytes32)
     {
-        return _singleChainDigest(account, nonce, operationData, GasRefund(address(0), 0, 0));
+        (, bytes32 operationHash) = _decodeERC1271Operation(operationData);
+        return _singleChainDigest(account, nonce, operationHash, GasRefund(address(0), 0, 0));
     }
 
     function singleChainDigestWithRefundHarness(
@@ -2622,7 +2284,8 @@ contract HCAOwnerAndSessionValidatorHarness is HCAOwnerAndSessionValidator {
         view
         returns (bytes32)
     {
-        return _singleChainDigest(account, nonce, operationData, gasRefund);
+        (, bytes32 operationHash) = _decodeERC1271Operation(operationData);
+        return _singleChainDigest(account, nonce, operationHash, gasRefund);
     }
 }
 
@@ -2642,7 +2305,8 @@ contract StandaloneSingleOwnerHCAHarness is StandaloneSingleOwnerHCA {
             defaultExecutor,
             validatorInitData,
             upgradeSet,
-            predecessorUpgradeSet
+            predecessorUpgradeSet,
+            IStandaloneHCAFactory(address(0))
         )
     {}
 

--- a/contracts/test/unit/hcaDeployHelpers.test.ts
+++ b/contracts/test/unit/hcaDeployHelpers.test.ts
@@ -87,6 +87,9 @@ describe("HCA deployment script scope", () => {
     expect(deployHCAOwnerAndSessionValidator.dependencies).toContain(
       "ETHRegistry",
     );
+    expect(deployHCAOwnerAndSessionValidator.dependencies).toContain(
+      "PermissionedResolverImpl",
+    );
     expect(deployHCAOwnerAndSessionValidator.dependencies).not.toContain(
       "ETHRegistrar",
     );

--- a/docs/HCA.md
+++ b/docs/HCA.md
@@ -43,7 +43,7 @@ write the executor's optional per-account initialization marker. The source Nexu
 funding validator. The HCA prevents module installation and removal. An approved upgrade can change
 the fixed modules.
 
-The destination validator pins the long-lived `ETHRegistry`, not one registrar deployment. A registration target or payment-token spender is permitted only while that registry grants it the root `ROLE_REGISTRAR`. This supports concurrent registrars and registrar replacement without an HCA implementation upgrade. Revoking the role disables the registrar for existing sessions immediately.
+The destination validator pins the long-lived `ETHRegistry`, not one registrar deployment. Each operation batch selects at most one registrar, which must hold the registry's root `ROLE_REGISTRAR`; registrar calls and payment-token approvals in that batch must use the selected deployment. Different batches can select different authorized registrars, supporting concurrent deployments and registrar replacement without an HCA implementation upgrade. Revoking the role disables the registrar for existing sessions immediately.
 
 The HCA rejects delegatecall execution and the standard ERC-721 and ERC-1155 receiver callbacks. It can hold ETH or supported tokens during an operation. Do not use it for long-term funds.
 
@@ -394,10 +394,11 @@ The validator applies these rules:
 
 - Registration must assign the name to the HCA owner.
 - Registration must use the resolver in the session.
+- Every registrar call and registrar payment-token approval in a batch must use the same registrar.
 - A new resolver must use the approved `PermissionedResolver` implementation, grant root `ROLES.ALL` to exactly the HCA and wallet, and include only supported resolver setters in its initializer multicall.
 - An existing resolver must verify against the approved implementation.
 - Every registration must give root `ROLES.ALL` to the wallet.
-- A registrar approval can name only a current root `ROLE_REGISTRAR` holder as spender.
+- A registrar approval can name only the batch's current root `ROLE_REGISTRAR` holder as spender.
 - An execution-fee approval must match the signed fee and the session limits.
 - A first same-chain action can use one wallet permit followed by the same-value transfer into the HCA.
 

--- a/docs/HCA.md
+++ b/docs/HCA.md
@@ -20,7 +20,7 @@ The HCA gives an application a continuous in-app experience. A valid session can
 
 The HCA is not the user's identity or a general wallet. It does not own registered names. `ETHRegistrar` assigns each name to the wallet. The wallet also receives resolver `ROLES.ALL` during registration.
 
-The HCA keeps its resolver roles after registration. These roles support later session actions. The wallet can revoke the roles or the sessions.
+The HCA keeps its resolver roles after registration. These roles support later session actions. The wallet can revoke the roles or invalidate the reusable session authorization.
 
 The application must not select an HCA without user approval. A direct wallet or a capable smart account can use a simpler route.
 
@@ -30,13 +30,18 @@ A registration uses an HCA on the registration chain. A cross-chain registration
 
 | Contract                      | Function                                                                   |
 | ----------------------------- | -------------------------------------------------------------------------- |
-| `StandaloneSingleOwnerHCA`    | Stores one owner, executes calls, revokes sessions, and controls upgrades. |
-| `StandaloneHCAFactory`        | Approves initial implementations and certifies each deployed HCA's owner.  |
+| `StandaloneSingleOwnerHCA`    | Reads its certified owner, executes calls, revokes sessions, and controls upgrades. |
+| `StandaloneHCAFactory`        | Approves initial implementations and stores each deployed HCA's immutable owner certification. |
+| `PermissionedResolver`        | Stores records and grants the HCA and wallet permission to manage them.    |
 | `HCAOwnerAndSessionValidator` | Validates owner actions and the fixed ENS session policy.                  |
 | `HCAFundingSessionValidator`  | Limits how a source Nexus can fund the HCA.                                |
 | `PermissionedAddressSet`      | Stores the implementation upgrades that the DAO permits.                   |
 
-The HCA uses a Nexus implementation with a fixed validator and executor. The source Nexus uses the fixed funding validator. The HCA prevents module installation and removal. An approved upgrade can change the fixed modules.
+The HCA uses a Nexus implementation with a fixed validator and executor. Nexus authorizes the fixed
+executor directly from the immutable account configuration, so HCA proxy initialization does not
+write the executor's optional per-account initialization marker. The source Nexus uses the fixed
+funding validator. The HCA prevents module installation and removal. An approved upgrade can change
+the fixed modules.
 
 The destination validator pins the long-lived `ETHRegistry`, not one registrar deployment. A registration target or payment-token spender is permitted only while that registry grants it the root `ROLE_REGISTRAR`. This supports concurrent registrars and registrar replacement without an HCA implementation upgrade. Revoking the role disables the registrar for existing sessions immediately.
 
@@ -52,6 +57,11 @@ HCA = VerifiableFactory proxy address for (StandaloneHCAFactory, deploymentSalt)
 ```
 
 Anyone can call `StandaloneHCAFactory.deploy(owner, implementation, userSalt)` for an implementation approved by factory governance. The caller cannot change the expected owner, implementation, or HCA address. After deployment, the factory verifies the implementation and owner and permanently records the HCA-to-owner binding used by HCA-aware reverse adapters.
+
+Factory-backed HCAs read `owner()` from this certification instead of writing a duplicate owner
+slot during proxy initialization. The legacy owner slot remains in the account storage layout so an
+upgrade does not move the session nonce or later storage. Direct deployments whose implementation
+has no owner registry continue to initialize and read that legacy slot.
 
 Use these values for this account version:
 
@@ -106,15 +116,18 @@ replacement adapters are controllers and every superseded adapter is not.
 
 ### Test networks
 
-Sepolia is the current registration network. Base Sepolia is the enabled test source network.
+Sepolia remains the current core registration network. The checked-in HCA deployments predate the
+stateless validator source in this branch and must not be enabled for that flow.
 
-| Use          | Network          |   Chain ID | Payment token                                        | Funding validator                            | Frontend status         |
-| ------------ | ---------------- | ---------: | ---------------------------------------------------- | -------------------------------------------- | ----------------------- |
-| Registration | Sepolia          | `11155111` | USDC at `0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238` | Not applicable                               | Enabled                 |
-| Source       | Base Sepolia     |    `84532` | USDC at `0x036CbD53842c5426634e7929541eC2318f3dCF7e` | `0x6FC0FdE0960003AcB24810FFd5dB6224B3d88974` | Enabled for integration |
-| Source       | Arbitrum Sepolia |   `421614` | USDC at `0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d` | Not deployed                                 | Do not enable           |
+| Use          | Network          |   Chain ID | Payment token                                        | Funding validator                            | HCA frontend status          |
+| ------------ | ---------------- | ---------: | ---------------------------------------------------- | -------------------------------------------- | ---------------------------- |
+| Registration | Sepolia          | `11155111` | USDC at `0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238` | Not applicable                               | Pending compatible deploy    |
+| Source       | Base Sepolia     |    `84532` | USDC at `0x036CbD53842c5426634e7929541eC2318f3dCF7e` | `0x6FC0FdE0960003AcB24810FFd5dB6224B3d88974` | Legacy; do not enable        |
+| Source       | Arbitrum Sepolia |   `421614` | USDC at `0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d` | Not deployed                                 | Do not enable                |
 
-Use the [Sepolia deployment address table](../contracts/docs/addresses/sepolia.md) for shared contract addresses. The frontend needs these entries:
+Use the [Sepolia deployment address table](../contracts/docs/addresses/sepolia.md) to reconcile
+shared contract deployments. Do not publish its legacy HCA entries in an enabled frontend manifest.
+A compatible frontend deployment needs these entries:
 
 - `DefaultReverseRegistrarAdapter`
 - `ETHRegistrar`
@@ -124,9 +137,14 @@ Use the [Sepolia deployment address table](../contracts/docs/addresses/sepolia.m
 - `StandaloneHCAImplementation`
 - `VerifiableFactory`
 
-Each enabled source network needs an approved `HCAFundingSessionValidator`. Put its address in the frontend network manifest. Do not deploy this validator for a user.
+Each enabled source network needs an approved `HCAFundingSessionValidator` compiled from the
+compatible source. Put its address in the frontend network manifest. Do not deploy this validator
+for a user.
 
-The live CLI uses the Base Sepolia validator in this table by default. An operator can set `HCA_FUNDING_SESSION_VALIDATOR` for a separate proof deployment.
+The historical addresses remain in the deployment records as on-chain facts. They do not prove
+compatibility with the stateless destination or source validator formats. Until compatible shared
+contracts are deployed and recorded, operators must provide proof-deployment overrides and keep the
+HCA frontend disabled.
 
 These networks do not prove mainnet support.
 
@@ -170,7 +188,7 @@ flowchart LR
     wallet -->|"2. Stablecoin permit"| nexus["Source Nexus"]
     sessionKey["Session key"] -->|"Commit claim"| nexus
     nexus -->|"Commit cost"| across["Across"]
-    across -->|"Deploy, enable session, and commit"| hca["HCA"]
+    across -->|"Deploy and commit with reusable authorization"| hca["HCA"]
     sessionKey -->|"After the commitment delay"| nexus
     nexus -->|"Registration cost"| across
     across -->|"Register and set records"| hca
@@ -187,7 +205,7 @@ The route has these steps:
 6. Ask the wallet for one native stablecoin permit. The source Nexus is the spender.
 7. Submit the commit route with the session key. The wallet must not sign Permit2.
 8. Pull only the quoted commit cost. Keep the registration funds in the wallet.
-9. Deploy the source Nexus and HCA when necessary. Enable the HCA session and submit the commitment.
+9. Deploy the source Nexus and HCA when necessary. Submit the commitment with the reusable destination authorization.
 10. After the delay, get a new registration price and route quote.
 11. Submit the reveal route with the session key. Do not ask the wallet for another signature.
 12. Pull the quoted reveal cost. Register the name and make the selected ENS updates.
@@ -216,16 +234,13 @@ The first Rhinestone request contains these source calls:
 1. `USDC.permit(wallet, HCA, amount, deadline, v, r, s)`
 2. `USDC.transferFrom(wallet, HCA, amount)`
 
-The first session action then calls:
-
-1. `HCAOwnerAndSessionValidator.enableSessionWithRefund(...)`
-2. `ETHRegistrar.commit(commitment)`
+The first session action calls `ETHRegistrar.commit(commitment)`. Its signature envelope carries the owner-authorized session proof and the execution-fee limits.
 
 The session key submits the full commit request. The first request also carries the wallet's session authorization. After the delay, the session key submits the reveal batch. The wallet does not sign again. The route has two wallet signatures, no wallet transaction, and no native-gas requirement.
 
 The same-chain route moves its selected budget into the HCA during the commit request. Unused USDC stays in the user-owned HCA. The user can use it for later operations or recover it with `executeByOwner`.
 
-A sponsored same-chain route uses `enableSession(...)` instead of `enableSessionWithRefund(...)`. Sponsorship pays execution fees. It does not pay the ENS registration price. If the HCA needs payment tokens, the route needs a separate funding authorization.
+A sponsored same-chain route uses the same reusable proof without an execution-fee charge. Sponsorship pays execution fees. It does not pay the ENS registration price. If the HCA needs payment tokens, the route needs a separate funding authorization.
 
 ### Wallet-paid HCA route
 
@@ -266,28 +281,31 @@ The reveal is one atomic HCA operation. Set `value` to zero for every inner call
 
 | Order | Call                                                                        | Required values                                                                                                                           |
 | ----: | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-|     1 | `VerifiableFactory.deployProxy(...)`                                        | Use the approved resolver implementation, the selected salt, and `initialize(HCA, ROLES.ALL, [])`. Omit this call if the resolver exists. |
+|     1 | `VerifiableFactory.deployProxy(...)`                                        | Use the approved `PermissionedResolver` implementation and selected salt. Initialize both the HCA and wallet with root `ROLES.ALL`; supported records may be included in the initializer multicall and must target the intended DNS-encoded name. Omit this call if the resolver exists. |
 |     2 | `paymentToken.approve(ETHRegistrar, price)`                                 | Approve only the current registration price. Use a token the registrar's rent price oracle accepts.                                      |
 |     3 | `ETHRegistrar.register(...)`                                                | Use the wallet as owner, the session resolver, and the commitment inputs.                                                                 |
-|     4 | Resolver setters                                                            | Add only the records selected by the user.                                                                                                |
+|     4 | Resolver setters                                                            | Add only records not already written during initialization, or records for an existing resolver.                                          |
 |     5 | `DefaultReverseRegistrarAdapter.setNameWithHCA(wallet, name)`               | Add this call when the user selects a primary name.                                                                                       |
 |     6 | `ReverseRegistrarAdapter.claimWithHCA(wallet, resolver)`                    | Add this call to claim the wallet's `addr.reverse` node. Use the session resolver or the zero address.                                   |
-|     7 | `PermissionedResolver.authorizeNameRoles(hex"00", ROLES.ALL, wallet, true)` | Include this call in every session registration batch.                                                                                    |
+
+The resolver DNS root (`0x00`) is the lookup key for an optional default forward-record profile. It
+is unrelated to `default.reverse`. This flow leaves the root unlinked and targets registration
+record setters at the exact name.
 
 The session supports these resolver calls:
 
-- `clearRecords`
 - `setABI`
-- Both `setAddr` forms
+- `setAddress`
 - `setContenthash`
 - `setData`
 - `setInterface`
+- `linkToNode`
+- `linkToRecord`
 - `setName`
-- `setPubkey`
 - `setText`
 - Supported resolver multicalls
 
-`PermissionedResolver.setName(...)` writes a resolver record. `setNameWithHCA(...)` writes the wallet's `default.reverse` primary name. Add each call only when the product needs that result.
+When `PermissionedResolver.setName(...)` targets the wallet's Ethereum `addr.reverse` name, it writes the chain-specific primary-name record. `setNameWithHCA(...)` writes the wallet's `default.reverse` primary name. Use the mechanism selected by the product rather than adding both by default.
 
 If any call fails, the full batch reverts. The registrar does not keep the payment. It does not consume the commitment.
 
@@ -353,7 +371,7 @@ The DAO controls the sets. The initial implementation has no predecessor set. A 
 
 ### Destination HCA session
 
-An HCA session stores these values:
+A reusable HCA session authorization binds these values:
 
 - Session key
 - Expiry
@@ -376,16 +394,16 @@ The validator applies these rules:
 
 - Registration must assign the name to the HCA owner.
 - Registration must use the resolver in the session.
-- A new resolver must use the approved implementation and exact initializer.
+- A new resolver must use the approved `PermissionedResolver` implementation, grant root `ROLES.ALL` to exactly the HCA and wallet, and include only supported resolver setters in its initializer multicall.
 - An existing resolver must verify against the approved implementation.
 - Every registration must give root `ROLES.ALL` to the wallet.
 - A registrar approval can name only a current root `ROLE_REGISTRAR` holder as spender.
 - An execution-fee approval must match the signed fee and the session limits.
 - A first same-chain action can use one wallet permit followed by the same-value transfer into the HCA.
 
-The session key can select labels, records, and primary-name strings. The owner does not pre-sign one fixed registration. The session can register more than one name before expiry or revocation.
+The validator does not store this authorization. Each destination signature carries the reusable proof, and the HCA session nonce invalidates it globally. The session key can select labels, records, and primary-name strings. The owner does not pre-sign one fixed registration. The session can register more than one name before expiry or revocation.
 
-Registrar-role governance is therefore part of the session trust boundary: granting the role makes that registrar available to already-enabled, short-lived sessions, while revocation removes it. The remaining selector, registrant, and resolver checks still apply to every authorized registrar.
+Registrar-role governance is therefore part of the session trust boundary: granting the role makes that registrar available to already-authorized, short-lived sessions, while revocation removes it. The remaining selector, registrant, and resolver checks still apply to every authorized registrar.
 
 The session does not permit:
 
@@ -435,7 +453,9 @@ The patch adds only the account-specific work that the SDK needs:
 - Use the fixed HCA and source funding validators with Rhinestone sessions.
 - Keep each session account and salt, and use the HCA configuration for the destination signature.
 
-Rhinestone keeps its existing session, Permit2, Across, and owner-signature formats. The frontend must not encode signatures, call an executor, or call a paymaster directly.
+Rhinestone keeps its existing Smart Session typed data, Permit2 and Across messages, and owner
+signature format. The patch transports those values in an HCA-specific compact envelope. The
+frontend must not encode that envelope, call an executor, or call a paymaster directly.
 
 ### Destination account configuration
 
@@ -477,12 +497,12 @@ The SDK adds `StandaloneHCAFactory.deploy(owner, implementation, userSalt)` when
 
 Select one resolver salt. Derive the resolver as a `VerifiableFactory` proxy with these values:
 
-| Field          | Value                                                 |
-| -------------- | ----------------------------------------------------- |
-| Deployer       | HCA                                                   |
-| Implementation | Approved `PermissionedResolverImpl`                   |
-| Salt           | Frontend-selected resolver salt                       |
-| Initializer    | `PermissionedResolver.initialize(HCA, ROLES.ALL, [])` |
+| Field          | Value                                                                          |
+| -------------- | ------------------------------------------------------------------------------ |
+| Deployer       | HCA                                                                            |
+| Implementation | Approved `PermissionedResolverImpl`                                            |
+| Salt           | Frontend-selected resolver salt                                                |
+| Initializer    | Root `ROLES.ALL` grants for the HCA and wallet plus supported exact-name records |
 
 Bind the session to this exact resolver. One session can use the resolver for more than one name. A different resolver needs a new session authorization.
 
@@ -499,9 +519,25 @@ Each session must name its account, chain, salt, and session key. Call `experime
 
 Use the HCA entry for a same-chain route. For a cross-chain route, also use the entry for the selected source Nexus. One source session is sufficient when the user selects the source first. Include each offered source when the user selects it after authorization. Do not ask the wallet to sign a Permit2 message.
 
-Put `enableSession(...)` or `enableSessionWithRefund(...)` in the first HCA action. The same-chain and cross-chain routes can each enable the HCA session from the same authorization.
+Pass the signed authorization as `enableData` for every destination session request. The SDK packages it into the HCA signature envelope; do not add a validator call to the HCA action list. The same authorization can be reused until its expiry or until the owner increments the HCA session nonce.
 
-Use `experimental_isSessionEnabled(session)` only when the application resumes stored state. A successful atomic transaction is sufficient for state that the application just created.
+`experimental_isSessionEnabled(session)` remains false for the stateless destination validator. Persist the signed authorization with the session state instead of treating on-chain enablement as the resume signal.
+
+The patched SDK and HCA validators use this compact transport encoding:
+
+- A multi-chain entry is an eight-byte chain ID followed by its 32-byte session digest. The proof
+  carries a one-byte selected index, a one-byte entry count, the ordered entries, and the 65-byte
+  owner signature.
+- A destination proof prefixes those entries with the session key, expiry, session nonce, resolver,
+  and fixed refund limits using the on-chain field widths.
+- A session operation contains the two significant mode bytes, a one-byte execution count, and one
+  entry per call: target, three-byte calldata length, and raw calldata. Execution values are omitted
+  because every permitted HCA session action requires zero value.
+- A first-use same-chain refund carries a 96-bit exchange rate, 96-bit maximum refund amount, and
+  48-bit gas overhead. These widths match the limits authorized in the session salt.
+
+Do not substitute standard ABI tuple encoding for these fields. A stock SDK or an older HCA
+validator uses a different envelope and is not wire-compatible.
 
 ### Source Nexus configuration
 
@@ -530,9 +566,9 @@ Use these request parts for each route:
 
 | Request            | Source work                                           | HCA calls                                | Signer                                                             |
 | ------------------ | ----------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------ |
-| Same-chain commit  | Stablecoin permit and transfer to HCA, when needed    | Enable session and `commit`              | Destination session; wallet authorization on first use             |
+| Same-chain commit  | Stablecoin permit and transfer to HCA, when needed    | `commit`                                 | Destination session with reusable wallet authorization             |
 | Same-chain reveal  | None                                                  | Reveal batch                             | Session key                                                        |
-| Cross-chain commit | Permit and exact commit-cost transfer to source Nexus | Enable session and `commit`              | Source and destination sessions; wallet authorization on first use |
+| Cross-chain commit | Permit and exact commit-cost transfer to source Nexus | `commit`                                 | Source and destination sessions with reusable wallet authorization |
 | Cross-chain reveal | Exact reveal-cost transfer to source Nexus            | Reveal batch                             | Source and destination sessions                                    |
 | Later name update  | None                                                  | Supported resolver or primary-name calls | Destination session                                                |
 
@@ -540,7 +576,7 @@ For an unsponsored route, set the supported stablecoin as `feeAsset`. Disable ga
 
 For a cross-chain route, pass the full destination HCA configuration as the recipient. Do not pass only the HCA address. Select Across as the settlement layer.
 
-For the first cross-chain commit, attach the multi-chain enable data to both session entries. The destination call list starts with `enableSessionWithRefund(...)`. The next call is `ETHRegistrar.commit(commitment)`.
+For the first cross-chain commit, attach the multi-chain enable data to both session entries. The destination call list contains `ETHRegistrar.commit(commitment)`; the destination authorization remains in the signature envelope.
 
 For the reveal, refresh the price and quote. Pull only the reveal quote from the wallet. Do not reuse the first quote. Do not request another wallet signature.
 
@@ -601,7 +637,14 @@ Frontend feature code must use the Rhinestone SDK. It must not call port `3007` 
 
 ## Verification
 
-Run a live proof from `contracts`:
+The checked-in Sepolia HCA implementation, destination validator, and Base Sepolia funding validator
+are legacy deployments. They do not match the stateless sources in this branch. Do not run the live
+proof against the default deployment records.
+
+After compatible shared contracts are deployed, run a live proof from `contracts` with
+`HCA_PERMISSIONED_RESOLVER_IMPL`, `HCA_OWNER_AND_SESSION_VALIDATOR`,
+`HCA_STANDALONE_HCA_IMPLEMENTATION`, and, for cross-chain routes,
+`HCA_FUNDING_SESSION_VALIDATOR` set to those proof deployments:
 
 ```sh
 HCA_OWNER_KEY_FILE=<fresh-wallet-key-file> \
@@ -624,5 +667,11 @@ For the cross-chain proof, fund the printed wallet with Base Sepolia USDC. Do no
 The same-chain commands need `HCA_OWNER_KEY` for a fresh Sepolia wallet with enough USDC. The `same-chain-usdc` route also charges execution fees in USDC.
 
 The `same-session` command needs `HCA_OWNER_KEY_FILE`. Its wallet needs enough USDC on Sepolia and Base Sepolia because the command proves both choices in sequence.
+Its generated labels are twelve ASCII characters, keeping the corresponding `https://euc.li/<label>.eth` avatar within Solidity's 31-byte short-string representation for consistent gas measurements.
 
-The live HCA uses implementation `0xaa761541620fc1a42bb701a26a9f107a9df1e904` and destination validator `0x5f249fca8bb4949105651146858c347e8bfb0f7e` (redeployed 2026-08-12 to add MockUSDC as the secondary payment token, following the 2026-07-31 spoof-remediation redeploy; earlier implementations are retired). The Base Sepolia source validator is `0x6FC0FdE0960003AcB24810FFd5dB6224B3d88974`. Their creation inputs match the compiled artifacts in this branch. The current Sepolia addresses are always listed in [`contracts/docs/addresses/sepolia.md`](../contracts/docs/addresses/sepolia.md); the [Base Sepolia deployment record](../contracts/deployments/base-sepolia/HCAFundingSessionValidator.json) contains its transaction and bytecode hashes.
+The current historical Sepolia addresses are listed in
+[`contracts/docs/addresses/sepolia.md`](../contracts/docs/addresses/sepolia.md), and the Base Sepolia
+deployment record is stored in
+[`contracts/deployments/base-sepolia/HCAFundingSessionValidator.json`](../contracts/deployments/base-sepolia/HCAFundingSessionValidator.json).
+These records must be regenerated only as part of an actual compatible deployment; do not edit them
+to describe locally compiled bytecode that has not been deployed.

--- a/patches/@rhinestone%2Fsdk@1.8.0.patch
+++ b/patches/@rhinestone%2Fsdk@1.8.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/src/accounts/hca.d.ts b/dist/src/accounts/hca.d.ts
-index d04976c5..1786c9ca 100644
+index d04976c5c50633fcd09d80af1896196111f0c9c4..1786c9ca561a423534c7abbcac7c5eac02477b58 100644
 --- a/dist/src/accounts/hca.d.ts
 +++ b/dist/src/accounts/hca.d.ts
 @@ -6,10 +6,12 @@ import type { ValidatorConfig } from './utils';
@@ -33,7 +33,7 @@ index d04976c5..1786c9ca 100644
  //# sourceMappingURL=hca.d.ts.map
 \ No newline at end of file
 diff --git a/dist/src/accounts/hca.js b/dist/src/accounts/hca.js
-index 00bdb68d..0e936ec9 100644
+index 00bdb68da2ee6dcbde9591810887ace4c3ab711f..0e936ec906140e7252debfb5e9eee467d8d0c8b2 100644
 --- a/dist/src/accounts/hca.js
 +++ b/dist/src/accounts/hca.js
 @@ -4,6 +4,7 @@ exports.ENS_HCA_MODULE = void 0;
@@ -184,7 +184,7 @@ index 00bdb68d..0e936ec9 100644
  async function getGuardianSmartAccount(client, address, guardians, validatorAddress, sign) {
      return (0, nexus_1.getGuardianSmartAccount)(client, address, guardians, validatorAddress, sign, core_1.ENS_HCA_MODULE);
 diff --git a/dist/src/accounts/index.js b/dist/src/accounts/index.js
-index 509fb55c..ca4030a2 100644
+index 509fb55cfa6e88cc28768bdb90ac2fe56bbbe1a8..ca4030a2be91e4dbd659c1920edf174181c17482 100644
 --- a/dist/src/accounts/index.js
 +++ b/dist/src/accounts/index.js
 @@ -354,7 +354,10 @@ async function getEip1271Signature(config, signers, chain, validator, hash, tran
@@ -227,7 +227,7 @@ index 509fb55c..ca4030a2 100644
      }
  }
 diff --git a/dist/src/accounts/nexus.d.ts b/dist/src/accounts/nexus.d.ts
-index feb346df..eaeaa77b 100644
+index feb346dfd049f7287eb15094ff816d3d9cf95502..eaeaa77b672dd714312dab78fb02a507d15a63d0 100644
 --- a/dist/src/accounts/nexus.d.ts
 +++ b/dist/src/accounts/nexus.d.ts
 @@ -22,7 +22,10 @@ declare function getEip712Domain(config: RhinestoneAccountConfig, chain: Chain):
@@ -243,7 +243,7 @@ index feb346df..eaeaa77b 100644
  declare function signEip7702InitData(config: RhinestoneAccountConfig, eoa: Account): Promise<`0x${string}`>;
  declare function getEip7702InitCall(config: RhinestoneAccountConfig, signature: Hex): {
 diff --git a/dist/src/accounts/nexus.js b/dist/src/accounts/nexus.js
-index 8c484ef9..3f2192bc 100644
+index 8c484ef91f4457b88d830d3309f97c53a1e57370..3f2192bc2e0c9e3044bc9eec1ead9d80a02b92d1 100644
 --- a/dist/src/accounts/nexus.js
 +++ b/dist/src/accounts/nexus.js
 @@ -222,10 +222,10 @@ async function packSignature(signature, validator, transformSignature = (signatu
@@ -278,7 +278,7 @@ index 8c484ef9..3f2192bc 100644
          async getNonce(args) {
              const validatorAddress = nonceValidatorAddress === defaultValidatorAddress
 diff --git a/dist/src/execution/index.js b/dist/src/execution/index.js
-index c556730c..4ae9b7e9 100644
+index c556730c09a8b9771d7ff24820a592d96c0e3419..4ae9b7e90d03cfff2d54eb25061163903e1e39cd 100644
 --- a/dist/src/execution/index.js
 +++ b/dist/src/execution/index.js
 @@ -99,7 +99,7 @@ async function sendTransactionAsIntent(config, sourceChains, targetChain, callIn
@@ -291,7 +291,7 @@ index c556730c..4ae9b7e9 100644
      const authorizations = config.eoa
          ? await (0, utils_2.signAuthorizationsInternal)(config, intentRoute)
 diff --git a/dist/src/execution/utils.d.ts b/dist/src/execution/utils.d.ts
-index f77a7c96..bb5b33cd 100644
+index f77a7c96e7e1a75c92653dc412283cf6883d45c7..bb5b33cd88a8753ff1252f6b5bd45852c8284d5e 100644
 --- a/dist/src/execution/utils.d.ts
 +++ b/dist/src/execution/utils.d.ts
 @@ -5,7 +5,7 @@ import { type IntentOp, type IntentRoute } from '../orchestrator';
@@ -312,15 +312,8 @@ index f77a7c96..bb5b33cd 100644
      originSignatures: OriginSignature[];
      destinationSignature: `0x${string}`;
  }>;
-@@ -108,4 +108,4 @@ declare function hashErc7739TypedDataForSolady({ domain, types, primaryType, mes
- }): Hex;
- export { prepareTransaction, getTransactionMessages, signTransaction, signAuthorizations, signAuthorizationsInternal, signMessage, signTypedData, submitTransaction, prepareUserOperation, signUserOperation, submitUserOperation, signIntent, prepareTransactionAsIntent, submitIntentInternal, getValidatorAccount, parseCalls, getTokenRequests, resolveCallInputs, getIntentAccount, getTargetExecutionSignature, hashErc7739TypedDataForSolady, resolveSessionForChain, resolveSignatureMode, };
- export type { InternalSignerSet, IntentRoute, TransactionResult, PreparedTransactionData, PreparedUserOperationData, SignedTransactionData, SignedUserOperationData, UserOperationResult, };
--//# sourceMappingURL=utils.d.ts.map
-\ No newline at end of file
-+//# sourceMappingURL=utils.d.ts.map
 diff --git a/dist/src/execution/utils.js b/dist/src/execution/utils.js
-index 8e43c7a3..67ded69a 100644
+index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db0c32548b 100644
 --- a/dist/src/execution/utils.js
 +++ b/dist/src/execution/utils.js
 @@ -27,6 +27,7 @@ const viem_1 = require("viem");
@@ -478,38 +471,42 @@ index 8e43c7a3..67ded69a 100644
              preClaimExecutions[chainId] = [
                  {
                      to: validators_1.DUMMY_PRECLAIMOP_TARGET,
-@@ -554,7 +608,7 @@ async function prepareTransactionAsIntent(config, sourceChains, targetChain, cal
+@@ -554,8 +608,13 @@ async function prepareTransactionAsIntent(config, sourceChains, targetChain, cal
      const intentRoute = await orchestrator.getIntentRoute(metaIntent);
      return { intentRoute, intentInput: serializedIntent };
  }
 -async function signIntent(config, intentOp, targetChain, signers, targetExecution) {
 +async function signIntent(config, intentOp, targetChain, signers, targetExecution, recipient) {
      const { origin, destination } = getIntentMessages(config, intentOp);
++    const destinationConfig = recipient && typeof recipient !== 'string' ? recipient : config;
++    if ((0, hca_1.isStandaloneHca)(destinationConfig) &&
++        !hasSameSingleEcdsaOwner(config, destinationConfig)) {
++        throw new Error('Standalone HCA recipient must share the source owner');
++    }
      if (config.account?.type === 'eoa') {
          const eoa = config.eoa;
-@@ -571,7 +625,14 @@ async function signIntent(config, intentOp, targetChain, signers, targetExecutio
+         if (!eoa) {
+@@ -571,7 +630,13 @@ async function signIntent(config, intentOp, targetChain, signers, targetExecutio
                  throw new accounts_1.EoaSigningMethodNotConfiguredError('signTypedData');
              }
          }
 -        const destinationSignature = originSignatures.at(-1);
 +        let destinationSignature = originSignatures.at(-1);
-+        const withPermit2 = intentOp.elements.some((element) => element.mandate.qualifier.settlementContext.fundingMethod === 'PERMIT2');
-+        if (withPermit2 && recipient && typeof recipient !== 'string' && (0, hca_1.isStandaloneHca)(recipient)) {
++        if (recipient && typeof recipient !== 'string' && (0, hca_1.isStandaloneHca)(recipient)) {
 +            if (!destinationSignature || (0, viem_1.size)(destinationSignature) !== 65) {
-+                throw new Error('EOA Permit2 signature must be a 65-byte ECDSA signature');
++                throw new Error('EOA destination signature must be a 65-byte ECDSA signature');
 +            }
 +            destinationSignature = (0, viem_1.concat)([viem_1.zeroAddress, destinationSignature]);
 +        }
          return {
              originSignatures,
              destinationSignature,
-@@ -590,8 +651,15 @@ async function signIntent(config, intentOp, targetChain, signers, targetExecutio
+@@ -590,13 +655,53 @@ async function signIntent(config, intentOp, targetChain, signers, targetExecutio
          const signature = await signIntentTypedData(config, originSigners, validator, isRoot, typedData, chain, targetExecution ?? false);
          originSignatures.push(signature);
      }
 -    const destinationSigners = await resolveSignersForChain(config, signers, targetChain.id);
 -    const destinationSignature = await getDestinationSignature(config, destinationSigners, validator, isRoot, targetChain, destination, originSignatures, targetExecution ?? false);
-+    const destinationConfig = recipient && typeof recipient !== 'string' ? recipient : config;
 +    const destinationSigners = await resolveSignersForChain(destinationConfig, signers, targetChain.id);
 +    const destinationValidator = getValidator(destinationConfig, destinationSigners);
 +    if (!destinationValidator) {
@@ -517,11 +514,50 @@ index 8e43c7a3..67ded69a 100644
 +    }
 +    const destinationOwnerValidator = (0, validators_1.getOwnerValidator)(destinationConfig);
 +    const destinationIsRoot = destinationValidator.address === destinationOwnerValidator.address;
-+    const destinationSignature = await getDestinationSignature(destinationConfig, destinationSigners, destinationValidator, destinationIsRoot, targetChain, destination, originSignatures, targetExecution ?? false);
++    const destinationSignature = canReuseOriginSignatureForDestination(config, destinationConfig, originSignatures)
++        ? await getDestinationSignature(destinationConfig, destinationSigners, destinationValidator, destinationIsRoot, targetChain, destination, originSignatures, targetExecution ?? false)
++        : await signDestinationSeparately(destinationConfig, destinationSigners, destinationValidator, destinationIsRoot, targetChain, destination, targetExecution ?? false);
      return {
          originSignatures,
          destinationSignature,
-@@ -662,6 +730,30 @@ function getTargetExecutionMessage(config, intentOp) {
+     };
+ }
++function getSingleEcdsaOwner(config) {
++    if (config.account?.type === 'eoa') {
++        return config.eoa?.address;
++    }
++    const owners = config.owners;
++    if (owners?.type !== 'ecdsa' ||
++        owners.accounts.length !== 1 ||
++        (owners.threshold ?? 1) !== 1) {
++        return undefined;
++    }
++    return owners.accounts[0].address;
++}
++function hasSameSingleEcdsaOwner(config, destinationConfig) {
++    const sourceOwner = getSingleEcdsaOwner(config);
++    const destinationOwner = getSingleEcdsaOwner(destinationConfig);
++    return (!!sourceOwner &&
++        !!destinationOwner &&
++        sourceOwner.toLowerCase() === destinationOwner.toLowerCase());
++}
++function canReuseOriginSignatureForDestination(config, destinationConfig, originSignatures) {
++    if (config === destinationConfig) {
++        return true;
++    }
++    if (!(0, hca_1.isStandaloneHca)(destinationConfig)) {
++        return false;
++    }
++    const lastOriginSignature = originSignatures.at(-1);
++    return (typeof lastOriginSignature === 'string' &&
++        (0, viem_1.size)(lastOriginSignature) === 85 &&
++        (0, viem_1.slice)(lastOriginSignature, 0, 20).toLowerCase() ===
++            viem_1.zeroAddress.toLowerCase());
++}
+ async function getDestinationSignature(config, signers, validator, isRoot, targetChain, destination, originSignatures, targetExecution) {
+     // Smart sessions require a separate destination signature because the
+     // session enable data differs per chain
+@@ -662,6 +767,32 @@ function getTargetExecutionMessage(config, intentOp) {
      };
      return typedData;
  }
@@ -529,30 +565,32 @@ index 8e43c7a3..67ded69a 100644
 +    if (!operation || typeof operation.vt !== 'string' || !Array.isArray(operation.ops)) {
 +        throw new Error('Intent operation is malformed');
 +    }
-+    return (0, viem_1.concat)([
-+        operation.vt,
-+        (0, viem_1.encodeAbiParameters)([
-+            {
-+                type: 'tuple[]',
-+                components: [
-+                    { name: 'target', type: 'address' },
-+                    { name: 'value', type: 'uint256' },
-+                    { name: 'callData', type: 'bytes' },
-+                ],
-+            },
-+        ], [
-+            operation.ops.map((execution) => ({
-+                target: execution.to,
-+                value: BigInt(execution.value),
-+                callData: execution.data,
-+            })),
-+        ]),
-+    ]);
++    if ((0, viem_1.size)(operation.vt) !== 32 ||
++        (0, viem_1.slice)(operation.vt, 2).toLowerCase() !== `0x${'00'.repeat(30)}`) {
++        throw new Error('Intent operation mode is not compactable');
++    }
++    if (operation.ops.length > 0xff) {
++        throw new Error('Intent operation has too many executions');
++    }
++    const packed = [
++        (0, viem_1.slice)(operation.vt, 0, 2),
++        (0, viem_1.toHex)(operation.ops.length, { size: 1 }),
++    ];
++    for (const execution of operation.ops) {
++        const callDataLength = (0, viem_1.size)(execution.data);
++        if (BigInt(execution.value) !== 0n ||
++            (0, viem_1.size)(execution.to) !== 20 ||
++            callDataLength > 0xffffff) {
++            throw new Error('Intent execution is not compactable');
++        }
++        packed.push(execution.to, (0, viem_1.toHex)(callDataLength, { size: 3 }), execution.data);
++    }
++    return (0, viem_1.concat)(packed);
 +}
  /** Computes claim policy calldata when parameters are Permit2 typed data with claim policies. */
  function resolveClaimPolicyData(signers, parameters) {
      if (parameters.primaryType !== 'PermitBatchWitnessTransferFrom' ||
-@@ -679,6 +771,45 @@ function resolveClaimPolicyData(signers, parameters) {
+@@ -679,6 +810,45 @@ function resolveClaimPolicyData(signers, parameters) {
      return (0, permit2_1.buildPermit2ClaimPolicyCalldata)(signers.session.claimPolicies[0], parameters.message);
  }
  async function signIntentTypedData(config, signers, validator, isRoot, parameters, chain, targetExecution) {
@@ -598,7 +636,7 @@ index 8e43c7a3..67ded69a 100644
      if ((0, core_1.supportsEip712)(validator)) {
          const isK1Validator = validator.address.toLowerCase() ===
              startale_1.K1_DEFAULT_VALIDATOR_ADDRESS.toLowerCase();
-@@ -738,6 +869,332 @@ async function signIntentTypedData(config, signers, validator, isRoot, parameter
+@@ -738,6 +908,304 @@ async function signIntentTypedData(config, signers, validator, isRoot, parameter
          isRoot,
      }, hash);
  }
@@ -693,64 +731,69 @@ index 8e43c7a3..67ded69a 100644
 +        throw new Error('HCA funding session Permit2 route does not match its fixed policy');
 +    }
 +    const { r: ownerR, s: ownerS, v: ownerV, yParity: ownerYParity, } = (0, viem_1.parseSignature)((0, viem_1.slice)(userSignature, 20));
-+    const proofData = (0, viem_1.encodeAbiParameters)([
-+        {
-+            type: 'tuple',
-+            components: [
-+                { name: 'sessionToEnableIndex', type: 'uint8' },
-+                {
-+                    name: 'hashesAndChainIds',
-+                    type: 'tuple[]',
-+                    components: [
-+                        { name: 'chainId', type: 'uint64' },
-+                        { name: 'sessionDigest', type: 'bytes32' },
-+                    ],
-+                },
-+                { name: 'ownerR', type: 'bytes32' },
-+                { name: 'ownerS', type: 'bytes32' },
-+                { name: 'ownerV', type: 'uint8' },
-+            ],
-+        },
-+    ], [
-+        {
-+            sessionToEnableIndex: signers.enableData.sessionToEnableIndex,
-+            hashesAndChainIds: signers.enableData.hashesAndChainIds,
-+            ownerR,
-+            ownerS,
-+            ownerV: Number(ownerV ?? BigInt(27 + (ownerYParity ?? 0))),
-+        },
-+    ]);
-+    const proofLength = (0, viem_1.size)(proofData);
-+    if (proofLength > 0xffffffff) {
-+        throw new Error('HCA funding session owner proof is too large');
-+    }
-+    return (0, viem_1.encodePacked)(['address', 'bytes1', 'bytes32', 'bytes4', 'bytes', 'bytes', 'bytes', 'bytes'], [
++    const proofData = packHcaAuthorizationProof(signers.enableData, ownerR, ownerS, Number(ownerV ?? BigInt(27 + (ownerYParity ?? 0))));
++    return (0, viem_1.encodePacked)(['address', 'bytes1', 'bytes32', 'bytes', 'bytes', 'bytes', 'bytes'], [
 +        module,
 +        '0x04',
 +        permissionId,
-+        (0, viem_1.toHex)(proofLength, { size: 4 }),
 +        proofData,
 +        (0, viem_1.slice)(packedSessionSignature, 85, 150),
 +        claimPolicyData,
 +        operationData,
 +    ]);
 +}
-+function buildStandaloneHcaEnableProof(signers, permissionId, enableOperation) {
-+    if (!signers.enableData ||
-+        !enableOperation?.data ||
-+        (0, viem_1.size)(enableOperation.data) < 4) {
-+        throw new Error('Standalone HCA session enable operation is missing');
++function packHcaAuthorizationProof(enableData, ownerR, ownerS, ownerV) {
++    const sessions = enableData.hashesAndChainIds;
++    const selectedIndex = Number(enableData.sessionToEnableIndex);
++    if (!Array.isArray(sessions) ||
++        sessions.length === 0 ||
++        sessions.length > 0xff ||
++        !Number.isInteger(selectedIndex) ||
++        selectedIndex < 0 ||
++        selectedIndex >= sessions.length) {
++        throw new Error('HCA multi-chain authorization is malformed');
 +    }
-+    const [enabledPermissionId, sessionKey, validUntil, resolver, refundToken, maxRefundExchangeRate, maxRefundGasOverhead, maxRefundAmount,] = (0, viem_1.decodeAbiParameters)([
-+        { type: 'bytes32' },
-+        { type: 'address' },
-+        { type: 'uint48' },
-+        { type: 'address' },
-+        { type: 'address' },
-+        { type: 'uint96' },
-+        { type: 'uint48' },
-+        { type: 'uint96' },
-+    ], (0, viem_1.slice)(enableOperation.data, 4));
++    const packed = [
++        (0, viem_1.toHex)(selectedIndex, { size: 1 }),
++        (0, viem_1.toHex)(sessions.length, { size: 1 }),
++    ];
++    for (const session of sessions) {
++        packed.push((0, viem_1.encodePacked)(['uint64', 'bytes32'], [BigInt(session.chainId), session.sessionDigest]));
++    }
++    packed.push(ownerR, ownerS, (0, viem_1.toHex)(ownerV, { size: 1 }));
++    return (0, viem_1.concat)(packed);
++}
++function buildStandaloneHcaEnableProof(signers, permissionId, enableOperation) {
++    if (!signers.enableData) {
++        throw new Error('Standalone HCA session authorization is missing');
++    }
++    let enabledPermissionId;
++    let sessionKey;
++    let validUntil;
++    let resolver;
++    let refundToken;
++    let maxRefundExchangeRate;
++    let maxRefundGasOverhead;
++    let maxRefundAmount;
++    if (signers.enableData.hcaSessionConfig) {
++        enabledPermissionId = permissionId;
++        ({ sessionKey, validUntil, resolver, refundToken, maxRefundExchangeRate, maxRefundGasOverhead, maxRefundAmount, } = signers.enableData.hcaSessionConfig);
++    }
++    else {
++        if (!enableOperation?.data || (0, viem_1.size)(enableOperation.data) < 4) {
++            throw new Error('Standalone HCA session configuration is missing');
++        }
++        [enabledPermissionId, sessionKey, validUntil, resolver, refundToken, maxRefundExchangeRate, maxRefundGasOverhead, maxRefundAmount,] = (0, viem_1.decodeAbiParameters)([
++            { type: 'bytes32' },
++            { type: 'address' },
++            { type: 'uint48' },
++            { type: 'address' },
++            { type: 'address' },
++            { type: 'uint96' },
++            { type: 'uint48' },
++            { type: 'uint96' },
++        ], (0, viem_1.slice)(enableOperation.data, 4));
++    }
 +    if (enabledPermissionId.toLowerCase() !== permissionId.toLowerCase() ||
 +        signers.enableData.hcaSessionNonce === undefined) {
 +        throw new Error('Standalone HCA enable operation does not match its session');
@@ -761,48 +804,18 @@ index 8e43c7a3..67ded69a 100644
 +        throw new Error('Standalone HCA owner authorization has an unexpected shape');
 +    }
 +    const { r: ownerR, s: ownerS, v: ownerV, yParity: ownerYParity, } = (0, viem_1.parseSignature)((0, viem_1.slice)(userSignature, 20));
-+    return (0, viem_1.encodeAbiParameters)([
-+        {
-+            type: 'tuple',
-+            components: [
-+                { name: 'sessionKey', type: 'address' },
-+                { name: 'validUntil', type: 'uint48' },
-+                { name: 'sessionNonce', type: 'uint96' },
-+                { name: 'resolver', type: 'address' },
-+                { name: 'refundToken', type: 'address' },
-+                { name: 'maxRefundExchangeRate', type: 'uint96' },
-+                { name: 'maxRefundGasOverhead', type: 'uint48' },
-+                { name: 'maxRefundAmount', type: 'uint96' },
-+                { name: 'sessionToEnableIndex', type: 'uint8' },
-+                {
-+                    name: 'hashesAndChainIds',
-+                    type: 'tuple[]',
-+                    components: [
-+                        { name: 'chainId', type: 'uint64' },
-+                        { name: 'sessionDigest', type: 'bytes32' },
-+                    ],
-+                },
-+                { name: 'ownerR', type: 'bytes32' },
-+                { name: 'ownerS', type: 'bytes32' },
-+                { name: 'ownerV', type: 'uint8' },
-+            ],
-+        },
-+    ], [
-+        {
++    return (0, viem_1.concat)([
++        (0, viem_1.encodePacked)(['address', 'uint48', 'uint96', 'address', 'address', 'uint96', 'uint48', 'uint96'], [
 +            sessionKey,
 +            validUntil,
-+            sessionNonce: signers.enableData.hcaSessionNonce,
++            signers.enableData.hcaSessionNonce,
 +            resolver,
 +            refundToken,
 +            maxRefundExchangeRate,
 +            maxRefundGasOverhead,
 +            maxRefundAmount,
-+            sessionToEnableIndex: signers.enableData.sessionToEnableIndex,
-+            hashesAndChainIds: signers.enableData.hashesAndChainIds,
-+            ownerR,
-+            ownerS,
-+            ownerV: Number(ownerV ?? BigInt(27 + (ownerYParity ?? 0))),
-+        },
++        ]),
++        packHcaAuthorizationProof(signers.enableData, ownerR, ownerS, Number(ownerV ?? BigInt(27 + (ownerYParity ?? 0)))),
 +    ]);
 +}
 +function packStandaloneHcaPermit2SessionSignature(config, signers, parameters, packedSessionSignature) {
@@ -843,16 +856,11 @@ index 8e43c7a3..67ded69a 100644
 +        ]);
 +    }
 +    const proofData = buildStandaloneHcaEnableProof(signers, permissionId, message.mandate.destOps.ops.find((execution) => execution.to.toLowerCase() === config.account.validator.toLowerCase()));
-+    const proofLength = (0, viem_1.size)(proofData);
-+    if (proofLength > 0xffffffff) {
-+        throw new Error('Standalone HCA owner proof is too large');
-+    }
 +    return (0, viem_1.concat)([
 +        viem_1.zeroAddress,
-+        (0, viem_1.encodePacked)(['bytes1', 'bytes32', 'bytes4', 'bytes', 'uint256', 'bytes', 'bytes', 'bytes'], [
++        (0, viem_1.encodePacked)(['bytes1', 'bytes32', 'bytes', 'uint256', 'bytes', 'bytes', 'bytes'], [
 +            '0x04',
 +            permissionId,
-+            (0, viem_1.toHex)(proofLength, { size: 4 }),
 +            proofData,
 +            sourceChainId,
 +            claimPolicyData,
@@ -888,21 +896,23 @@ index 8e43c7a3..67ded69a 100644
 +        BigInt(gasRefund.overhead) !== 0n;
 +    if (signers.enableData) {
 +        const proofData = buildStandaloneHcaEnableProof(signers, permissionId, op.ops.find((execution) => execution.to.toLowerCase() === config.account.validator.toLowerCase()));
-+        const proofLength = (0, viem_1.size)(proofData);
-+        if (proofLength > 0xffffffff) {
-+            throw new Error('Standalone HCA owner proof is too large');
++        const refundOverhead = BigInt(gasRefund.overhead);
++        const refundAmount = refundOverhead >> 128n;
++        const gasOverhead = refundOverhead & ((1n << 128n) - 1n);
++        if (gasOverhead > ((1n << 48n) - 1n)) {
++            throw new Error('Standalone HCA gas refund overhead is too large');
 +        }
 +        return (0, viem_1.concat)([
 +            viem_1.zeroAddress,
-+            (0, viem_1.encodePacked)(['bytes1', 'bytes32', 'bytes4', 'bytes', 'uint256', 'address', 'uint256', 'uint256', 'bytes', 'bytes'], [
++            (0, viem_1.encodePacked)(['bytes1', 'bytes32', 'bytes', 'uint256', 'address', 'uint96', 'uint96', 'uint48', 'bytes', 'bytes'], [
 +                '0x05',
 +                permissionId,
-+                (0, viem_1.toHex)(proofLength, { size: 4 }),
 +                proofData,
 +                BigInt(message.nonce),
 +                gasRefund.token,
 +                BigInt(gasRefund.exchangeRate),
-+                BigInt(gasRefund.overhead),
++                refundAmount,
++                gasOverhead,
 +                operationData,
 +                (0, viem_1.slice)(packedSessionSignature, 33),
 +            ]),
@@ -932,7 +942,7 @@ index 8e43c7a3..67ded69a 100644
      const validator = getValidator(config, signers);
      if (!validator) {
 diff --git a/dist/src/index.d.ts b/dist/src/index.d.ts
-index 65670fb2..fd598e6c 100644
+index 65670fb2f50b45a1f810414a1c4aad816958ef7e..fd598e6c86eb07cb35797fc0f78559c61955253d 100644
 --- a/dist/src/index.d.ts
 +++ b/dist/src/index.d.ts
 @@ -8,7 +8,7 @@ import { type IntentRoute, type PreparedTransactionData, type PreparedUserOperat
@@ -953,7 +963,7 @@ index 65670fb2..fd598e6c 100644
  //# sourceMappingURL=index.d.ts.map
 \ No newline at end of file
 diff --git a/dist/src/index.js b/dist/src/index.js
-index 8a656a17..8af430c8 100644
+index 8a656a1741ce6ddfcab2489e24624df42e0a0ddb..8af430c8350f6d092a55c8f94a7eadbfde242d42 100644
 --- a/dist/src/index.js
 +++ b/dist/src/index.js
 @@ -246,7 +246,11 @@ async function createRhinestoneAccount(config) {
@@ -970,7 +980,7 @@ index 8a656a17..8af430c8 100644
      function experimental_signEnableSession(details) {
          return (0, modules_1.signEnableSession)(config, details);
 diff --git a/dist/src/modules/validators/smart-sessions.d.ts b/dist/src/modules/validators/smart-sessions.d.ts
-index 66f6604a..64bd9548 100644
+index 66f6604a74663ece0d782ce184022cfc302ac954..64bd95487d3774ac579baa8074bc82709b54ab46 100644
 --- a/dist/src/modules/validators/smart-sessions.d.ts
 +++ b/dist/src/modules/validators/smart-sessions.d.ts
 @@ -182,7 +182,7 @@ interface ResolvedSessionSignerSet {
@@ -983,7 +993,7 @@ index 66f6604a..64bd9548 100644
  declare function getEnableSessionCall(account: Address, session: Session, enableSessionSignature: Hex, hashesAndChainIds: {
      chainId: bigint;
 diff --git a/dist/src/modules/validators/smart-sessions.js b/dist/src/modules/validators/smart-sessions.js
-index 17a41949..1694e42a 100644
+index 17a419494de4548b759a9a33df5fcff378c349ba..1694e42aa1a1100bbee07b26c2dac771ce5f688c 100644
 --- a/dist/src/modules/validators/smart-sessions.js
 +++ b/dist/src/modules/validators/smart-sessions.js
 @@ -258,9 +258,9 @@ function packSignature(signers, validatorSignature) {
@@ -1040,7 +1050,7 @@ index 17a41949..1694e42a 100644
          additionalContext: '0x',
          type: common_1.MODULE_TYPE_ID_VALIDATOR,
 diff --git a/dist/src/types.d.ts b/dist/src/types.d.ts
-index 6d4ec528..022b94be 100644
+index 6d4ec528d6c661a14fbf019b20855a7ff05cb94a..22569d6587e67fb6bff1496e42110e10188f189a 100644
 --- a/dist/src/types.d.ts
 +++ b/dist/src/types.d.ts
 @@ -26,9 +26,21 @@ interface StartaleAccount {
@@ -1083,20 +1093,27 @@ index 6d4ec528..022b94be 100644
          compatibilityFallback?: Address;
      };
      recovery?: Recovery;
-@@ -313,6 +328,7 @@ interface SessionEnableData {
+@@ -313,6 +328,16 @@ interface SessionEnableData {
          sessionDigest: Hex;
      }[];
      sessionToEnableIndex: number;
 +    hcaSessionNonce?: bigint;
++    hcaSessionConfig?: {
++        sessionKey: Address;
++        validUntil: number;
++        resolver: Address;
++        refundToken: Address;
++        maxRefundExchangeRate: bigint;
++        maxRefundGasOverhead: number;
++        maxRefundAmount: bigint;
++    };
  }
  interface ChainSessionConfig {
      session: Session;
-@@ -388,5 +404,5 @@ interface UserOperationTransaction {
+@@ -388,5 +413,5 @@ interface UserOperationTransaction {
      chain: Chain;
  }
  type Transaction = SameChainTransaction | CrossChainTransaction;
 -export type { AccountType, SafeAccount, NexusAccount, KernelAccount, StartaleAccount, PassportAccount, HcaAccount, EoaAccount, RhinestoneAccountConfig, RhinestoneSDKConfig, RhinestoneConfig, AccountProviderConfig, ProviderConfig, BundlerConfig, PaymasterConfig, Transaction, UserOperationTransaction, TokenSymbol, CalldataInput, LazyCallInput, CallInput, CallResolveContext, Call, Sponsorship, TokenRequest, TokenRequests, SourceAssetInput, OwnerSet, OwnableValidatorConfig, ENSValidatorConfig, WebauthnValidatorConfig, MultiFactorValidatorConfig, SignerSet, ChainSessionConfig, SingleSessionSignerSet, PerChainSessionSignerSet, SessionSignerSet, Action, SessionInput, SessionEnableData, Session, Recovery, ModuleType, ModuleInput, Policy, Permit2ClaimPolicy, UniversalActionPolicyParamCondition, ApiKeyAuth, JwtAuth, AuthConfig, };
--//# sourceMappingURL=types.d.ts.map
-\ No newline at end of file
 +export type { AccountType, SafeAccount, NexusAccount, KernelAccount, StartaleAccount, PassportAccount, LegacyHcaAccount, StandaloneHcaAccount, HcaAccount, EoaAccount, RhinestoneAccountConfig, RhinestoneSDKConfig, RhinestoneConfig, AccountProviderConfig, ProviderConfig, BundlerConfig, PaymasterConfig, Transaction, UserOperationTransaction, TokenSymbol, CalldataInput, LazyCallInput, CallInput, CallResolveContext, Call, Sponsorship, TokenRequest, TokenRequests, SourceAssetInput, OwnerSet, OwnableValidatorConfig, ENSValidatorConfig, WebauthnValidatorConfig, MultiFactorValidatorConfig, SignerSet, ChainSessionConfig, SingleSessionSignerSet, PerChainSessionSignerSet, SessionSignerSet, Action, SessionInput, SessionEnableData, Session, Recovery, ModuleType, ModuleInput, Policy, Permit2ClaimPolicy, UniversalActionPolicyParamCondition, ApiKeyAuth, JwtAuth, AuthConfig, };
-+//# sourceMappingURL=types.d.ts.map
+ //# sourceMappingURL=types.d.ts.map

--- a/patches/@rhinestone%2Fsdk@1.8.0.patch
+++ b/patches/@rhinestone%2Fsdk@1.8.0.patch
@@ -291,7 +291,7 @@ index c556730c09a8b9771d7ff24820a592d96c0e3419..4ae9b7e90d03cfff2d54eb2506116390
      const authorizations = config.eoa
          ? await (0, utils_2.signAuthorizationsInternal)(config, intentRoute)
 diff --git a/dist/src/execution/utils.d.ts b/dist/src/execution/utils.d.ts
-index f77a7c96e7e1a75c92653dc412283cf6883d45c7..bb5b33cd88a8753ff1252f6b5bd45852c8284d5e 100644
+index f77a7c96e7e1a75c92653dc412283cf6883d45c7..578c774e0e539f224e2fa774605dd001069240bb 100644
 --- a/dist/src/execution/utils.d.ts
 +++ b/dist/src/execution/utils.d.ts
 @@ -5,7 +5,7 @@ import { type IntentOp, type IntentRoute } from '../orchestrator';
@@ -313,7 +313,7 @@ index f77a7c96e7e1a75c92653dc412283cf6883d45c7..bb5b33cd88a8753ff1252f6b5bd45852
      destinationSignature: `0x${string}`;
  }>;
 diff --git a/dist/src/execution/utils.js b/dist/src/execution/utils.js
-index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db0c32548b 100644
+index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..3fa080e46b35204e3f6a9d3ea35dca78c89b75ff 100644
 --- a/dist/src/execution/utils.js
 +++ b/dist/src/execution/utils.js
 @@ -27,6 +27,7 @@ const viem_1 = require("viem");
@@ -324,42 +324,7 @@ index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db
  const common_1 = require("../accounts/signing/common");
  const startale_1 = require("../accounts/startale");
  const utils_1 = require("../accounts/utils");
-@@ -46,12 +47,42 @@ const singleChainOps_1 = require("./singleChainOps");
- function isResolvedSessionSignerSet(signers) {
-     return (signers?.type === 'experimental_session' && 'verifyExecutions' in signers);
- }
-+function buildStandaloneHcaMockSignature(config, session) {
-+    const validatorAddress = config.account.validator;
-+    const operationData = (0, viem_1.concat)([
-+        `0x0201${'00'.repeat(30)}`,
-+        (0, viem_1.encodeAbiParameters)([
-+            {
-+                type: 'tuple[]',
-+                components: [
-+                    { name: 'target', type: 'address' },
-+                    { name: 'value', type: 'uint256' },
-+                    { name: 'callData', type: 'bytes' },
-+                ],
-+            },
-+        ], [[]]),
-+    ]);
-+    const sessionData = (0, viem_1.encodePacked)(['bytes1', 'bytes32', 'uint256', 'bytes', 'bytes'], [
-+        '0x01',
-+        (0, validators_1.getPermissionId)(session),
-+        0n,
-+        operationData,
-+        `0x${'00'.repeat(65)}`,
-+    ]);
-+    return (0, viem_1.concat)([validatorAddress, sessionData]);
-+}
-+function buildSessionMockSignature(config, session, chainCount, targetChainId) {
-+    if ((0, hca_1.isStandaloneHca)(config)) {
-+        return buildStandaloneHcaMockSignature(config, session);
-+    }
-+    return (0, validators_1.buildMockSignature)(session, config.useDevContracts, chainCount, targetChainId);
-+}
- async function resolveSignersForChain(config, signers, chainId) {
-     if (signers?.type !== 'experimental_session') {
+@@ -51,7 +52,7 @@ async function resolveSignersForChain(config, signers, chainId) {
          return signers;
      }
      const resolved = resolveSessionForChain(signers, chainId);
@@ -368,7 +333,7 @@ index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db
      const enableData = enabled ? undefined : resolved.enableData;
      const hasExplicitActions = !!resolved.session.actions?.length;
      const verifyExecutions = resolved.verifyExecutions ?? signers.verifyExecutions ?? hasExplicitActions;
-@@ -65,7 +96,7 @@ async function resolveSignersForChain(config, signers, chainId) {
+@@ -65,18 +66,24 @@ async function resolveSignersForChain(config, signers, chainId) {
  // Picks the single signature mode that matches the bytes shape the SDK will
  // actually sign, so the on-chain dispatcher hits the right validator on the
  // first try instead of falling through a hybrid.
@@ -377,7 +342,16 @@ index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db
      if (config.account?.type === 'eoa') {
          return types_1.SIG_MODE_ERC1271;
      }
-@@ -77,6 +108,7 @@ async function resolveSignatureMode(config, signers, sourceChains, targetChain)
+     if (signers?.type !== 'experimental_session') {
+         return types_1.SIG_MODE_ERC1271;
+     }
++    const standaloneHca = (0, hca_1.isStandaloneHca)(config);
++    if (standaloneHca &&
++        (sourceChains ?? []).some((chain) => chain.id !== targetChain.id)) {
++        throw new Error('Standalone HCA cross-chain sessions are not supported');
++    }
+     const chainIds = [
+         ...new Set([...(sourceChains ?? []).map((c) => c.id), targetChain.id]),
      ];
      const resolvedSet = await Promise.all(chainIds.map((chainId) => resolveSignersForChain(config, signers, chainId)));
      let anyVerifyExecutions = false;
@@ -385,7 +359,7 @@ index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db
      for (const resolved of resolvedSet) {
          if (!isResolvedSessionSignerSet(resolved)) {
              return types_1.SIG_MODE_ERC1271;
-@@ -85,12 +117,25 @@ async function resolveSignatureMode(config, signers, sourceChains, targetChain)
+@@ -85,12 +92,21 @@ async function resolveSignatureMode(config, signers, sourceChains, targetChain)
          // all origin signatures — a single mode field can't describe divergence.
          if (resolved.verifyExecutions)
              anyVerifyExecutions = true;
@@ -395,8 +369,6 @@ index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db
      // Mode 4 (pure emissary-execution) is unused: signIntentTypedData always
      // emits a dual sig for the intent's origin/destination signatures when
      // verifyExecutions=true, so mode 5 is the right hybrid.
-+    const standaloneSameChain = (0, hca_1.isStandaloneHca)(config) &&
-+        chainIds.every((chainId) => chainId === targetChain.id);
 +    const standaloneHcaRecipient = !!recipient &&
 +        typeof recipient !== 'string' &&
 +        (0, hca_1.isStandaloneHca)(recipient);
@@ -404,15 +376,13 @@ index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db
 -        ? types_1.SIG_MODE_EMISSARY_EXECUTION_ERC1271
 +        ? hasHcaFundingSession && standaloneHcaRecipient
 +            ? types_1.SIG_MODE_ERC1271_EMISSARY_EXECUTION
-+            : standaloneSameChain
++            : standaloneHca
 +            ? types_1.SIG_MODE_ERC1271
-+            : (0, hca_1.isStandaloneHca)(config)
-+                ? types_1.SIG_MODE_EMISSARY_EXECUTION
-+                : types_1.SIG_MODE_EMISSARY_EXECUTION_ERC1271
++            : types_1.SIG_MODE_EMISSARY_EXECUTION_ERC1271
          : types_1.SIG_MODE_ERC1271;
  }
  function resolveSessionForChain(signers, chainId) {
-@@ -158,7 +203,7 @@ async function signTransaction(config, preparedTransaction) {
+@@ -158,7 +174,7 @@ async function signTransaction(config, preparedTransaction) {
      const targetChain = 'targetChain' in preparedTransaction.transaction
          ? preparedTransaction.transaction.targetChain
          : preparedTransaction.transaction.chain;
@@ -421,10 +391,11 @@ index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db
      const targetExecutionSignature = await getTargetExecutionSignature(config, intentRoute.intentOp, targetChain, signers);
      return {
          intentRoute,
-@@ -430,6 +475,13 @@ function getIntentAccount(config, eip7702InitSignature, account) {
+@@ -430,6 +446,14 @@ function getIntentAccount(config, eip7702InitSignature, account) {
  async function prepareTransactionAsIntent(config, sourceChains, targetChain, callInputs, gasLimit, tokenRequests, recipientInput, sponsored, eip7702InitSignature, settlementLayers, sourceAssets, feeAsset, lockFunds, auxiliaryFunds, account, signers, sourceCalls) {
      const calls = parseCalls(callInputs, targetChain.id);
      const accountAccessList = createAccountAccessList(sourceChains, sourceAssets);
++    const signatureMode = await resolveSignatureMode(config, signers, sourceChains, targetChain, recipientInput);
 +    const targetSessionSigners = signers?.type === 'experimental_session'
 +        ? await resolveSignersForChain(config, signers, targetChain.id)
 +        : undefined;
@@ -435,34 +406,24 @@ index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db
      function getRecipient(recipient) {
          if (typeof recipient === 'string') {
              // Passed as an address, assume it's an EOA
-@@ -447,9 +499,9 @@ async function prepareTransactionAsIntent(config, sourceChains, targetChain, cal
+@@ -447,7 +471,7 @@ async function prepareTransactionAsIntent(config, sourceChains, targetChain, cal
      }
      const intentAccount = {
          ...getIntentAccount(config, eip7702InitSignature, account),
 -        ...(signers?.type === 'experimental_session' && {
 +        ...(signers?.type === 'experimental_session' && !standaloneHcaFirstUse && {
              // Global fallback: target-chain sig for backward-compat with older orchestrators
--            mockSignature: (0, validators_1.buildMockSignature)(resolveSessionForChain(signers, targetChain.id).session, config.useDevContracts, sourceChains?.length ?? 1),
-+            mockSignature: buildSessionMockSignature(config, resolveSessionForChain(signers, targetChain.id).session, sourceChains?.length ?? 1),
+             mockSignature: (0, validators_1.buildMockSignature)(resolveSessionForChain(signers, targetChain.id).session, config.useDevContracts, sourceChains?.length ?? 1),
              // Per-chain map: enables accurate per-chain session validation gas simulation
-             mockSignatures: Object.fromEntries([
-                 ...new Set([
-@@ -458,12 +510,12 @@ async function prepareTransactionAsIntent(config, sourceChains, targetChain, cal
-                 ]),
-             ].map((chainId) => [
-                 String(chainId),
--                (0, validators_1.buildMockSignature)(resolveSessionForChain(signers, chainId).session, config.useDevContracts, sourceChains?.length ?? 1, chainId),
-+                buildSessionMockSignature(config, resolveSessionForChain(signers, chainId).session, sourceChains?.length ?? 1, chainId),
-             ])),
+@@ -463,7 +487,6 @@ async function prepareTransactionAsIntent(config, sourceChains, targetChain, cal
          }),
      };
      const recipient = getRecipient(recipientInput);
 -    const signatureMode = await resolveSignatureMode(config, signers, sourceChains, targetChain);
-+    const signatureMode = await resolveSignatureMode(config, signers, sourceChains, targetChain, recipientInput);
      // For session signers that need enabling, pass a dummy preclaimop per source chain
      // so the orchestrator bakes it into the bundle before computing its HMAC. The filler
      // executes the op via verifyExecution in ENABLE mode, enabling the session on-chain
-@@ -481,6 +533,8 @@ async function prepareTransactionAsIntent(config, sourceChains, targetChain, cal
+@@ -481,6 +504,8 @@ async function prepareTransactionAsIntent(config, sourceChains, targetChain, cal
              const { enableData, verifyExecutions } = resolved;
              if (!verifyExecutions || !enableData)
                  continue;
@@ -471,7 +432,7 @@ index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db
              preClaimExecutions[chainId] = [
                  {
                      to: validators_1.DUMMY_PRECLAIMOP_TARGET,
-@@ -554,8 +608,13 @@ async function prepareTransactionAsIntent(config, sourceChains, targetChain, cal
+@@ -554,8 +579,13 @@ async function prepareTransactionAsIntent(config, sourceChains, targetChain, cal
      const intentRoute = await orchestrator.getIntentRoute(metaIntent);
      return { intentRoute, intentInput: serializedIntent };
  }
@@ -486,7 +447,7 @@ index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db
      if (config.account?.type === 'eoa') {
          const eoa = config.eoa;
          if (!eoa) {
-@@ -571,7 +630,13 @@ async function signIntent(config, intentOp, targetChain, signers, targetExecutio
+@@ -571,7 +601,13 @@ async function signIntent(config, intentOp, targetChain, signers, targetExecutio
                  throw new accounts_1.EoaSigningMethodNotConfiguredError('signTypedData');
              }
          }
@@ -501,7 +462,7 @@ index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db
          return {
              originSignatures,
              destinationSignature,
-@@ -590,13 +655,53 @@ async function signIntent(config, intentOp, targetChain, signers, targetExecutio
+@@ -590,13 +626,53 @@ async function signIntent(config, intentOp, targetChain, signers, targetExecutio
          const signature = await signIntentTypedData(config, originSigners, validator, isRoot, typedData, chain, targetExecution ?? false);
          originSignatures.push(signature);
      }
@@ -557,7 +518,7 @@ index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db
  async function getDestinationSignature(config, signers, validator, isRoot, targetChain, destination, originSignatures, targetExecution) {
      // Smart sessions require a separate destination signature because the
      // session enable data differs per chain
-@@ -662,6 +767,32 @@ function getTargetExecutionMessage(config, intentOp) {
+@@ -662,6 +738,32 @@ function getTargetExecutionMessage(config, intentOp) {
      };
      return typedData;
  }
@@ -590,7 +551,7 @@ index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db
  /** Computes claim policy calldata when parameters are Permit2 typed data with claim policies. */
  function resolveClaimPolicyData(signers, parameters) {
      if (parameters.primaryType !== 'PermitBatchWitnessTransferFrom' ||
-@@ -679,6 +810,45 @@ function resolveClaimPolicyData(signers, parameters) {
+@@ -679,6 +781,45 @@ function resolveClaimPolicyData(signers, parameters) {
      return (0, permit2_1.buildPermit2ClaimPolicyCalldata)(signers.session.claimPolicies[0], parameters.message);
  }
  async function signIntentTypedData(config, signers, validator, isRoot, parameters, chain, targetExecution) {
@@ -636,7 +597,7 @@ index 8e43c7a314d93072c6ef9e74bcee7cc31aa60329..c425a1ca857fa0c4976573e27e5ec0db
      if ((0, core_1.supportsEip712)(validator)) {
          const isK1Validator = validator.address.toLowerCase() ===
              startale_1.K1_DEFAULT_VALIDATOR_ADDRESS.toLowerCase();
-@@ -738,6 +908,304 @@ async function signIntentTypedData(config, signers, validator, isRoot, parameter
+@@ -738,6 +879,304 @@ async function signIntentTypedData(config, signers, validator, isRoot, parameter
          isRoot,
      }, hash);
  }
@@ -1050,7 +1011,7 @@ index 17a419494de4548b759a9a33df5fcff378c349ba..1694e42aa1a1100bbee07b26c2dac771
          additionalContext: '0x',
          type: common_1.MODULE_TYPE_ID_VALIDATOR,
 diff --git a/dist/src/types.d.ts b/dist/src/types.d.ts
-index 6d4ec528d6c661a14fbf019b20855a7ff05cb94a..22569d6587e67fb6bff1496e42110e10188f189a 100644
+index 6d4ec528d6c661a14fbf019b20855a7ff05cb94a..b1e8ca749397e99b9367b627a6f78c6c767a87c7 100644
 --- a/dist/src/types.d.ts
 +++ b/dist/src/types.d.ts
 @@ -26,9 +26,21 @@ interface StartaleAccount {
@@ -1117,3 +1078,4 @@ index 6d4ec528d6c661a14fbf019b20855a7ff05cb94a..22569d6587e67fb6bff1496e42110e10
 -export type { AccountType, SafeAccount, NexusAccount, KernelAccount, StartaleAccount, PassportAccount, HcaAccount, EoaAccount, RhinestoneAccountConfig, RhinestoneSDKConfig, RhinestoneConfig, AccountProviderConfig, ProviderConfig, BundlerConfig, PaymasterConfig, Transaction, UserOperationTransaction, TokenSymbol, CalldataInput, LazyCallInput, CallInput, CallResolveContext, Call, Sponsorship, TokenRequest, TokenRequests, SourceAssetInput, OwnerSet, OwnableValidatorConfig, ENSValidatorConfig, WebauthnValidatorConfig, MultiFactorValidatorConfig, SignerSet, ChainSessionConfig, SingleSessionSignerSet, PerChainSessionSignerSet, SessionSignerSet, Action, SessionInput, SessionEnableData, Session, Recovery, ModuleType, ModuleInput, Policy, Permit2ClaimPolicy, UniversalActionPolicyParamCondition, ApiKeyAuth, JwtAuth, AuthConfig, };
 +export type { AccountType, SafeAccount, NexusAccount, KernelAccount, StartaleAccount, PassportAccount, LegacyHcaAccount, StandaloneHcaAccount, HcaAccount, EoaAccount, RhinestoneAccountConfig, RhinestoneSDKConfig, RhinestoneConfig, AccountProviderConfig, ProviderConfig, BundlerConfig, PaymasterConfig, Transaction, UserOperationTransaction, TokenSymbol, CalldataInput, LazyCallInput, CallInput, CallResolveContext, Call, Sponsorship, TokenRequest, TokenRequests, SourceAssetInput, OwnerSet, OwnableValidatorConfig, ENSValidatorConfig, WebauthnValidatorConfig, MultiFactorValidatorConfig, SignerSet, ChainSessionConfig, SingleSessionSignerSet, PerChainSessionSignerSet, SessionSignerSet, Action, SessionInput, SessionEnableData, Session, Recovery, ModuleType, ModuleInput, Policy, Permit2ClaimPolicy, UniversalActionPolicyParamCondition, ApiKeyAuth, JwtAuth, AuthConfig, };
  //# sourceMappingURL=types.d.ts.map
+\ No newline at end of file


### PR DESCRIPTION
first-time HCA registrations were repeating some setup work and storing values that were already available elsewhere.

changes:
- validate reusable authorizations without storing them onchain
- avoid storing the HCA owner in both the factory and the account
- remove repeated account setup and validation work
- reduce the size of registration data
- pass initial resolver updates into resolver creation instead of making separate HCA calls
- update the HCA integration, tests and documentation

this reduces measured gas for a fresh owner-paid registration from 1,487,368 to 1,206,987.