### PR TITLE
Fix `PermissionedRegistry.safeTransferFrom()` with root `ROLE_CAN_TRANSFER_ADMIN` while expired (better)

### DIFF
--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -384,16 +384,6 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
     }
 
     /// @inheritdoc IEnhancedAccessControl
-    function hasAssignees(uint256 anyId, uint256 roleBitmap)
-        public
-        view
-        override(EnhancedAccessControl, IEnhancedAccessControl)
-        returns (bool)
-    {
-        return super.hasAssignees(getResource(anyId), roleBitmap);
-    }
-
-    /// @inheritdoc IEnhancedAccessControl
     function getAssigneeCount(uint256 anyId, uint256 roleBitmap)
         public
         view
@@ -491,7 +481,7 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
                 uint256 tokenId = tokenIds[i];
                 // only check ROLE_CAN_TRANSFER_ADMIN on original owner (from)
                 // ROLE_CAN_TRANSFER_ADMIN is technically a property of the token
-                if (!hasRoles(tokenId, RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, from)) {
+                if (_isExpired(_entry(tokenId).expiry) || !hasRoles(tokenId, RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, from)) {
                     revert TransferDisallowed(tokenId, from);
                 } else if (amounts[i] > 0) {
                     _transferRoles(getResource(tokenId), from, to, false);

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -481,7 +481,10 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
                 uint256 tokenId = tokenIds[i];
                 // only check ROLE_CAN_TRANSFER_ADMIN on original owner (from)
                 // ROLE_CAN_TRANSFER_ADMIN is technically a property of the token
-                if (_isExpired(_entry(tokenId).expiry) || !hasRoles(tokenId, RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, from)) {
+                if (
+                    _isExpired(_entry(tokenId).expiry) ||
+                    !hasRoles(tokenId, RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, from)
+                ) {
                     revert TransferDisallowed(tokenId, from);
                 } else if (amounts[i] > 0) {
                     _transferRoles(getResource(tokenId), from, to, false);

--- a/contracts/src/registry/PermissionedRegistry.sol
+++ b/contracts/src/registry/PermissionedRegistry.sol
@@ -479,15 +479,13 @@ contract PermissionedRegistry is ERC1155Singleton, EnhancedAccessControl, IPermi
             // only transfers (skip mint and burn)
             for (uint256 i; i < tokenIds.length; ++i) {
                 uint256 tokenId = tokenIds[i];
+                uint256 resource = getResource(tokenId);
                 // only check ROLE_CAN_TRANSFER_ADMIN on original owner (from)
                 // ROLE_CAN_TRANSFER_ADMIN is technically a property of the token
-                if (
-                    _isExpired(_entry(tokenId).expiry) ||
-                    !hasRoles(tokenId, RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, from)
-                ) {
+                if ((_getRoles(resource, from) & RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN) == 0) {
                     revert TransferDisallowed(tokenId, from);
                 } else if (amounts[i] > 0) {
-                    _transferRoles(getResource(tokenId), from, to, false);
+                    _transferRoles(resource, from, to, false);
                 }
             }
         }

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -814,11 +814,18 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
     }
 
     function test_safeTransferFrom_rootOwnedTokenWithoutRoles() external {
-        // as long as the token owner has ROLE_CAN_TRANSFER_ADMIN on root or token, the transfer can occur
+        // ROLE_CAN_TRANSFER_ADMIN must be on the token for the transfer to occur
         assertTrue(registry.hasRootRoles(RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, address(this)));
         testOwner = address(this); // mint to account with root
         uint256 tokenId = this._register();
         assertEq(registry.roles(tokenId, address(this)), 0); // no roles
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IStandardRegistry.TransferDisallowed.selector,
+                tokenId,
+                address(this)
+            )
+        );
         registry.safeTransferFrom(address(this), user2, tokenId, 1, "");
     }
 

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -795,6 +795,20 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         registry.safeTransferFrom(user1, user2, tokenId, 1, "");
     }
 
+    function test_safeTransferFrom_rootOwnedTokenWhileExpired() external {
+        // even though root has ROLE_CAN_TRANSFER_ADMIN independent of expiry
+        // the transfer is disallowed due to expiry
+        assertTrue(registry.hasRootRoles(RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, address(this)));
+        testOwner = address(this); // mint to account with root
+        uint256 tokenId = this._register();
+        vm.warp(testExpiry);
+        assertEq(registry.ownerOf(tokenId), address(0));
+        vm.expectRevert(
+            abi.encodeWithSelector(IStandardRegistry.TransferDisallowed.selector, tokenId, address(this))
+        );
+        registry.safeTransferFrom(address(this), user2, tokenId, 1, "");
+    }
+
     function test_safeTransferFrom_rootOwnedTokenWithoutRoles() external {
         // as long as the token owner has ROLE_CAN_TRANSFER_ADMIN on root or token, the transfer can occur
         assertTrue(registry.hasRootRoles(RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, address(this)));

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -804,7 +804,11 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         vm.warp(testExpiry);
         assertEq(registry.ownerOf(tokenId), address(0));
         vm.expectRevert(
-            abi.encodeWithSelector(IStandardRegistry.TransferDisallowed.selector, tokenId, address(this))
+            abi.encodeWithSelector(
+                IStandardRegistry.TransferDisallowed.selector,
+                tokenId,
+                address(this)
+            )
         );
         registry.safeTransferFrom(address(this), user2, tokenId, 1, "");
     }

--- a/contracts/test/unit/registry/PermissionedRegistry.t.sol
+++ b/contracts/test/unit/registry/PermissionedRegistry.t.sol
@@ -781,9 +781,8 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         registry.safeTransferFrom(user1, user2, tokenId, 1, "");
     }
 
-    function test_safeTransferFrom_rootAuthorizationIgnored() external {
-        // even though root has ROLE_CAN_TRANSFER_ADMIN and has approval for transfer,
-        // the transfer role check is only applied to the token owner
+    function test_safeTransferFrom_rootAuthorizedTokenWithoutRoles() external {
+        // ROLE_CAN_TRANSFER_ADMIN must be on the token for the transfer to occur
         assertTrue(registry.hasRootRoles(RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, address(this)));
         uint256 tokenId = this._register();
         assertEq(registry.ownerOf(tokenId), user1);
@@ -795,14 +794,12 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         registry.safeTransferFrom(user1, user2, tokenId, 1, "");
     }
 
-    function test_safeTransferFrom_rootOwnedTokenWhileExpired() external {
-        // even though root has ROLE_CAN_TRANSFER_ADMIN independent of expiry
-        // the transfer is disallowed due to expiry
+    function test_safeTransferFrom_rootOwnedTokenWithoutRoles() external {
+        // ROLE_CAN_TRANSFER_ADMIN must be on the token for the transfer to occur
         assertTrue(registry.hasRootRoles(RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, address(this)));
         testOwner = address(this); // mint to account with root
         uint256 tokenId = this._register();
-        vm.warp(testExpiry);
-        assertEq(registry.ownerOf(tokenId), address(0));
+        assertEq(registry.roles(tokenId, address(this)), 0); // no token roles
         vm.expectRevert(
             abi.encodeWithSelector(
                 IStandardRegistry.TransferDisallowed.selector,
@@ -813,12 +810,13 @@ contract PermissionedRegistryTest is Test, ERC1155Holder, IRegistryURIRenderer {
         registry.safeTransferFrom(address(this), user2, tokenId, 1, "");
     }
 
-    function test_safeTransferFrom_rootOwnedTokenWithoutRoles() external {
+    function test_safeTransferFrom_rootOwnedTokenWhileExpired() external {
         // ROLE_CAN_TRANSFER_ADMIN must be on the token for the transfer to occur
         assertTrue(registry.hasRootRoles(RegistryRolesLib.ROLE_CAN_TRANSFER_ADMIN, address(this)));
         testOwner = address(this); // mint to account with root
         uint256 tokenId = this._register();
-        assertEq(registry.roles(tokenId, address(this)), 0); // no roles
+        vm.warp(testExpiry);
+        assertEq(registry.ownerOf(tokenId), address(0)); // expired
         vm.expectRevert(
             abi.encodeWithSelector(
                 IStandardRegistry.TransferDisallowed.selector,


### PR DESCRIPTION
- ignored `ROLE_CAN_TRANSFER_ADMIN` on root
- removed unnecessary `PermissionedRegistry.hasAssignees()` override