### PR TITLE
Change `ANUR` and `LibENSIP15` to use `bytes name` instead of `string inputName`

### DIFF
--- a/contracts/src/universalResolver/AbstractNormalizedUniversalResolver.sol
+++ b/contracts/src/universalResolver/AbstractNormalizedUniversalResolver.sol
@@ -96,18 +96,14 @@ abstract contract AbstractNormalizedUniversalResolver is
     }
 
     /// @inheritdoc INormalizedUniversalResolver
-    function resolveWithNormalization(
-        string calldata inputName,
-        bytes calldata data,
-        IENSIP15 ensip15
-    )
+    function resolveWithNormalization(bytes calldata name, bytes calldata data, IENSIP15 ensip15)
         external
         view
         returns (bytes memory, address)
     {
         return
             resolveWithGatewaysAndNormalization(
-                inputName,
+                name,
                 data,
                 BATCH_GATEWAY_PROVIDER.gateways(),
                 ensip15
@@ -251,15 +247,13 @@ abstract contract AbstractNormalizedUniversalResolver is
         if (bytes(primary).length == 0) {
             return ("", address(0), args.resolver);
         }
-        bytes memory name;
+        bytes memory name = NameCoder.encode(primary);
         if (address(args.ensip15) != address(0)) {
             bool wasNorm;
-            (wasNorm, name) = normalize(primary, args.ensip15);
+            (wasNorm, name) = normalize(name, args.ensip15);
             if (!wasNorm) {
                 revert PrimaryNameNotNormalized(primary);
             }
-        } else {
-            name = NameCoder.encode(primary);
         }
         ResolverInfo memory info = requireResolver(name);
         _callResolver(
@@ -326,12 +320,12 @@ abstract contract AbstractNormalizedUniversalResolver is
         returns (address, bytes32, uint256);
 
     /// @inheritdoc INormalizedUniversalResolver
-    function normalize(string memory inputName, IENSIP15 ensip15)
+    function normalize(bytes memory name, IENSIP15 ensip15)
         public
         view
         returns (bool, bytes memory)
     {
-        return LibENSIP15.normalize(inputName, ensip15);
+        return LibENSIP15.normalize(name, ensip15);
     }
 
     /// @inheritdoc IUniversalResolverExtended
@@ -359,7 +353,7 @@ abstract contract AbstractNormalizedUniversalResolver is
 
     /// @inheritdoc INormalizedUniversalResolverExtended
     function resolveWithGatewaysAndNormalization(
-        string calldata inputName,
+        bytes calldata name,
         bytes calldata data,
         string[] memory gateways,
         IENSIP15 ensip15
@@ -368,14 +362,14 @@ abstract contract AbstractNormalizedUniversalResolver is
         view
         returns (bytes memory, address)
     {
-        (bool wasNorm, bytes memory name) = normalize(inputName, ensip15);
-        ResolverInfo memory info = requireResolver(name);
+        (bool wasNorm, bytes memory norm) = normalize(name, ensip15);
+        ResolverInfo memory info = requireResolver(norm);
         _callResolver(
             info,
             ResolverProfileRewriterLib.replaceNode(data, info.node),
             gateways,
             this.resolveCallback.selector, // ==> step 2
-            abi.encode(info.resolver, wasNorm ? bytes("") : name)
+            abi.encode(info.resolver, wasNorm ? bytes("") : norm)
         );
     }
 

--- a/contracts/src/universalResolver/interfaces/INormalizedUniversalResolver.sol
+++ b/contracts/src/universalResolver/interfaces/INormalizedUniversalResolver.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.13;
 import {IENSIP15} from "./IENSIP15.sol";
 
 /// @notice Interface for ENSv2-specific `UniversalResolver`.
-/// @dev Interface selector: `0x2146c173`
+/// @dev Interface selector: `0xfe0badd6`
 interface INormalizedUniversalResolver {
     ////////////////////////////////////////////////////////////////////////
     // Errors
@@ -25,16 +25,12 @@ interface INormalizedUniversalResolver {
     /// @notice Performs ENS forward resolution for the supplied name and data.
     ///         Caller should enable EIP-3668.
     ///         Reverts `NormalizationChangedName`.
-    /// @param inputName Human-readable name to resolve, eg. `nick.eth`.
+    /// @param name DNS-encoded name to resolve.
     /// @param data The ABI-encoded resolver calldata.
     /// @param ensip15 ENSIP-15 Normalization implementation.
     /// @return result The ABI-encoded response for the calldata.
     /// @return resolver The resolver that was used to resolve the name.
-    function resolveWithNormalization(
-        string calldata inputName,
-        bytes calldata data,
-        IENSIP15 ensip15
-    )
+    function resolveWithNormalization(bytes calldata name, bytes calldata data, IENSIP15 ensip15)
         external
         view
         returns (bytes memory result, address resolver);
@@ -58,14 +54,14 @@ interface INormalizedUniversalResolver {
         returns (string memory primary, address resolver, address reverseResolver);
 
     /// @notice Normalize a name according to ENSIP-15.
-    /// @param inputName Human-readable name to normalize, eg. `nick.eth`.
+    /// @param name DNS-encoded name to normalize.
     /// @param ensip15 ENSIP-15 Normalization implementation.
     /// @return wasNormalized `true` if `name` was already normalized.
-    /// @return name Normalized DNS-encoded name, eg. `\x04nick\x03eth\x00`.
-    function normalize(string calldata inputName, IENSIP15 ensip15)
+    /// @return normalizedName Normalized DNS-encoded name.
+    function normalize(bytes calldata name, IENSIP15 ensip15)
         external
         view
-        returns (bool wasNormalized, bytes memory name);
+        returns (bool wasNormalized, bytes memory normalizedName);
 
     /// @notice Return `true` if ENSv2 otherwise ENSv1.
     function isENSv2() external view returns (bool);

--- a/contracts/src/universalResolver/interfaces/INormalizedUniversalResolverExtended.sol
+++ b/contracts/src/universalResolver/interfaces/INormalizedUniversalResolverExtended.sol
@@ -5,20 +5,20 @@ import {IENSIP15} from "./IENSIP15.sol";
 import {INormalizedUniversalResolver} from "./INormalizedUniversalResolver.sol";
 
 /// @notice Interface for advanced `UniversalResolver` functionality.
-/// @dev Interface selector: `0xa0c805ea`
+/// @dev Interface selector: `0x17cd12d9`
 interface INormalizedUniversalResolverExtended is INormalizedUniversalResolver {
     /// @notice Performs ENS normalization and forward resolution for the supplied name and data.
     ///         `bytes32 node` is automatically replaced in calldata.
     /// @dev Caller should enable EIP-3668.
     ///      Reverts `NormalizationChangedName` if `inputName` was not normalized.
-    /// @param inputName Human-readable name to resolve, eg. `nick.eth`.
+    /// @param name DNS-encoded name to resolve.
     /// @param data The ABI-encoded resolver calldata.
     /// @param gateways The list of batch gateway URLs to use.
     /// @param ensip15 ENSIP-15 Normalization implementation.
     /// @return result The ABI-encoded response for the calldata.
     /// @return resolver The resolver that was used to resolve the name.
     function resolveWithGatewaysAndNormalization(
-        string calldata inputName,
+        bytes calldata name,
         bytes calldata data,
         string[] calldata gateways,
         IENSIP15 ensip15

--- a/contracts/src/universalResolver/libraries/LibENSIP15.sol
+++ b/contracts/src/universalResolver/libraries/LibENSIP15.sol
@@ -8,7 +8,7 @@ import {IENSIP15} from "../interfaces/IENSIP15.sol";
 /// @dev Library for normalizing human-readable names into normalized DNS-encoded names.
 library LibENSIP15 {
     /// @dev Normalize a name according to ENSIP-15.
-    ///      Reverts `LabelIsEmpty`, `LabelIsTooLong`, and `CannotNormalize`. 
+    ///      Reverts `DNSEncodingFailed`, `LabelIsEmpty`, `LabelIsTooLong`, and `CannotNormalize`.
     /// @param name DNS-encoded name to normalize.
     /// @param ensip15 ENSIP-15 Normalization implementation.
     /// @return wasNormalized `true` if `name` was already normalized.

--- a/contracts/src/universalResolver/libraries/LibENSIP15.sol
+++ b/contracts/src/universalResolver/libraries/LibENSIP15.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
 
-import {BytesUtils} from "@ens/contracts/utils/BytesUtils.sol";
 import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 
 import {IENSIP15} from "../interfaces/IENSIP15.sol";
@@ -10,54 +9,40 @@ import {IENSIP15} from "../interfaces/IENSIP15.sol";
 library LibENSIP15 {
     /// @dev Normalize a name according to ENSIP-15.
     ///      Reverts `LabelIsEmpty`, `LabelIsTooLong`, and `CannotNormalize`. 
-    /// @param inputName Human-readable name to normalize, eg. `nick.eth`.
+    /// @param name DNS-encoded name to normalize.
     /// @param ensip15 ENSIP-15 Normalization implementation.
-    /// @return wasNormalized `true` if `inputName` was already normalized.
-    /// @return name Normalized DNS-encoded name, eg. `\x04nick\x03eth\x00`.
-    function normalize(string memory inputName, IENSIP15 ensip15)
+    /// @return wasNormalized `true` if `name` was already normalized.
+    /// @return normalizedName Normalized DNS-encoded name.
+    function normalize(bytes memory name, IENSIP15 ensip15)
         internal
         view
-        returns (bool wasNormalized, bytes memory name)
+        returns (bool wasNormalized, bytes memory normalizedName)
     {
         wasNormalized = true;
-        uint256 size = bytes(inputName).length;
-        if (size == 0) {
-            return (true, hex"00");
-        }
-        uint256 labelCount = 1;
-        for (uint256 i; i < size; ++i) {
-            if (bytes(inputName)[i] == ".") {
-                ++labelCount;
-            }
-        }
-        name = new bytes(labelCount * 256 + 1);
+        normalizedName = new bytes((NameCoder.countLabels(name, 0) << 8) + 1);
+        uint256 offset;
         uint256 dst;
         assembly {
-            dst := add(name, 32)
+            dst := add(normalizedName, 32)
         }
-        uint256 prev;
-        while (prev < size) {
-            uint256 next = BytesUtils.find(bytes(inputName), prev, size - prev, ".");
-            if (next > size) {
-                next = size; // last label
+        for (;;) {
+            string memory label;
+            (label, offset) = NameCoder.extractLabel(name, offset);
+            if (bytes(label).length == 0) {
+                break;
             }
-            bytes memory label = BytesUtils.substring(bytes(inputName), prev, next - prev);
-            string memory norm = ensip15.normalize(string(label));
+            string memory norm = ensip15.normalize(label);
             NameCoder.assertLabelSize(norm);
-            wasNormalized = wasNormalized && keccak256(label) == keccak256(bytes(norm));
+            wasNormalized = wasNormalized && keccak256(bytes(label)) == keccak256(bytes(norm));
             assembly {
                 let n := mload(norm)
                 mstore8(dst, n) // write length
                 mcopy(add(dst, 1), add(norm, 32), n) // write normalized label
                 dst := add(dst, add(n, 1))
             }
-            prev = next + 1;
-        }
-        if (prev == size) {
-            revert NameCoder.LabelIsEmpty(); // trailing empty, eg. "eth."
         }
         assembly {
-            mstore(name, sub(dst, add(name, 31))) // truncate
+            mstore(normalizedName, sub(dst, add(normalizedName, 31))) // truncate
         }
     }
 }

--- a/contracts/src/universalResolver/libraries/LibENSIP15.sol
+++ b/contracts/src/universalResolver/libraries/LibENSIP15.sol
@@ -5,7 +5,7 @@ import {NameCoder} from "@ens/contracts/utils/NameCoder.sol";
 
 import {IENSIP15} from "../interfaces/IENSIP15.sol";
 
-/// @dev Library for normalizing human-readable names into normalized DNS-encoded names.
+/// @dev Library for normalizing DNS-encoded names into normalized DNS-encoded names.
 library LibENSIP15 {
     /// @dev Normalize a name according to ENSIP-15.
     ///      Reverts `DNSEncodingFailed`, `LabelIsEmpty`, `LabelIsTooLong`, and `CannotNormalize`.

--- a/contracts/test/integration/UniversalResolverV1.test.ts
+++ b/contracts/test/integration/UniversalResolverV1.test.ts
@@ -474,10 +474,10 @@ describe("UniversalResolverV1", () => {
   describe("normalize()", () => {
     for (const name of [
       "",
-      "a".repeat(256),
-      ".",
-      ".eth",
-      "eth.",
+      // "a".repeat(256), \
+      // ".",             | does not
+      // ".eth",          |  encode
+      // "eth.",          /
       " abc",
       "abc ",
       "abc.eth ",
@@ -496,11 +496,11 @@ describe("UniversalResolverV1", () => {
         } catch {}
         if (typeof norm === "string") {
           await expect(
-            F.ur.read.normalize([name, F.ensip15.address]),
+            F.ur.read.normalize([dnsEncodeName(name), F.ensip15.address]),
           ).resolves.toStrictEqual([name === norm, dnsEncodeName(norm)]);
         } else {
           await expect(
-            F.ur.read.normalize([name, F.ensip15.address]),
+            F.ur.read.normalize([dnsEncodeName(name), F.ensip15.address]),
           ).rejects.toThrow();
         }
       });
@@ -524,7 +524,7 @@ describe("UniversalResolverV1", () => {
         addresses: [{ coinType: COIN_TYPE_ETH, value: anotherAddress }],
       });
       const [answer, resolver] = await F.ur.read.resolveWithNormalization([
-        testName,
+        dnsEncodeName(testName),
         res.call,
         F.ensip15.address,
       ]);
@@ -548,7 +548,7 @@ describe("UniversalResolverV1", () => {
       });
       await expect(
         F.ur.read.resolveWithNormalization([
-          testName.toUpperCase(),
+          dnsEncodeName(testName.toUpperCase()),
           res.call,
           F.ensip15.address,
         ]),
@@ -566,7 +566,7 @@ describe("UniversalResolverV1", () => {
       const badLabel = " ";
       await expect(
         F.ur.read.resolveWithNormalization([
-          `test.${badLabel}.eth`,
+          dnsEncodeName(`test.${badLabel}.eth`),
           dummyCalldata,
           F.ensip15.address,
         ]),
@@ -711,7 +711,7 @@ describe("UniversalResolverV1", () => {
       await F.ss1.write.setOffchain([true]);
       await expect(
         F.ur.read.resolveWithGatewaysAndNormalization([
-          testName,
+          dnsEncodeName(testName),
           res.call,
           [],
           F.ensip15.address,
@@ -719,7 +719,7 @@ describe("UniversalResolverV1", () => {
       ).rejects.toThrow();
       const [answer, resolver] =
         await F.ur.read.resolveWithGatewaysAndNormalization([
-          testName,
+          dnsEncodeName(testName),
           res.call,
           [LOCAL_BATCH_GATEWAY_URL],
           F.ensip15.address,

--- a/contracts/test/integration/UniversalResolverV2.test.ts
+++ b/contracts/test/integration/UniversalResolverV2.test.ts
@@ -420,10 +420,10 @@ describe("UniversalResolverV2", () => {
   describe("normalize()", () => {
     for (const name of [
       "",
-      "a".repeat(256),
-      ".",
-      ".eth",
-      "eth.",
+      // "a".repeat(256), \
+      // ".",             | does not
+      // ".eth",          |  encode
+      // "eth.",          /
       " abc",
       "abc ",
       "abc.eth ",
@@ -442,11 +442,11 @@ describe("UniversalResolverV2", () => {
         } catch {}
         if (typeof norm === "string") {
           await expect(
-            F.ur.read.normalize([name, F.ensip15.address]),
+            F.ur.read.normalize([dnsEncodeName(name), F.ensip15.address]),
           ).resolves.toStrictEqual([name === norm, dnsEncodeName(norm)]);
         } else {
           await expect(
-            F.ur.read.normalize([name, F.ensip15.address]),
+            F.ur.read.normalize([dnsEncodeName(name), F.ensip15.address]),
           ).rejects.toThrow();
         }
       });
@@ -470,7 +470,7 @@ describe("UniversalResolverV2", () => {
         addresses: [{ coinType: COIN_TYPE_ETH, value: anotherAddress }],
       });
       const [answer, resolver] = await F.ur.read.resolveWithNormalization([
-        testName,
+        dnsEncodeName(testName),
         res.call,
         F.ensip15.address,
       ]);
@@ -495,7 +495,7 @@ describe("UniversalResolverV2", () => {
       });
       await expect(
         F.ur.read.resolveWithNormalization([
-          testName.toUpperCase(),
+          dnsEncodeName(testName.toUpperCase()),
           res.call,
           F.ensip15.address,
         ]),
@@ -509,7 +509,7 @@ describe("UniversalResolverV2", () => {
       const badLabel = " ";
       await expect(
         F.ur.read.resolveWithNormalization([
-          `test.${badLabel}.eth`,
+          dnsEncodeName(`test.${badLabel}.eth`),
           dummyCalldata,
           F.ensip15.address,
         ]),
@@ -654,7 +654,7 @@ describe("UniversalResolverV2", () => {
       await F.ss1.write.setOffchain([true]);
       await expect(
         F.ur.read.resolveWithGatewaysAndNormalization([
-          testName,
+          dnsEncodeName(testName),
           res.call,
           [],
           F.ensip15.address,
@@ -662,7 +662,7 @@ describe("UniversalResolverV2", () => {
       ).rejects.toThrow();
       const [answer, resolver] =
         await F.ur.read.resolveWithGatewaysAndNormalization([
-          testName,
+          dnsEncodeName(testName),
           res.call,
           [LOCAL_BATCH_GATEWAY_URL],
           F.ensip15.address,

--- a/contracts/test/mocks/MockENSIP15.sol
+++ b/contracts/test/mocks/MockENSIP15.sol
@@ -4,17 +4,36 @@ pragma solidity ^0.8.13;
 import {IENSIP15} from "~src/universalResolver/interfaces/IENSIP15.sol";
 
 contract MockENSIP15 is IENSIP15 {
-    /// @dev ASCII case-folding: [A-Z] => [a-z].
-    ///      Revert `CannotNormalize` if contains a space.
+    /// @dev ASCII case-folding: [A-Z] => [a-z], expand: "'" => "\u2019", shrink: "\u00AD" => "".
+    ///      Revert `CannotNormalize` if contains " ".
     function normalize(string memory label) external pure returns (string memory) {
-        bytes memory v = abi.encodePacked(label);
-        for (uint256 i; i < v.length; ++i) {
-            bytes1 ch = v[i];
+        uint256 n = bytes(label).length;
+        bytes memory v = new bytes(n * 3);
+        uint256 size;
+        for (uint256 i; i < n; ++i) {
+            bytes1 ch = bytes(label)[i];
             if (ch >= "A" && ch <= "Z") {
-                v[i] = bytes1(uint8(ch) + 32);
+                v[size++] = bytes1(uint8(ch) + 32); // mapped (in place)
             } else if (ch == " ") {
-                revert CannotNormalize(label);
+                revert CannotNormalize(label); // invalid
+            } else if (ch == "'") {
+                // mapped (expand)
+                // typewriter apostrophe
+                // utf8(0x2009) = 0xE28099
+                v[size++] = 0xE2;
+                v[size++] = 0x80;
+                v[size++] = 0x99;
+            } else if (ch == 0xC2 && i + 1 < n && bytes(label)[i + 1] == 0xAD) {
+                // ignored (shrink)
+                // soft hyphen
+                // utf8(0xAD) = 0xC2AD
+                ++i; // skip
+            } else {
+                v[size++] = ch; // va.id
             }
+        }
+        assembly {
+            mstore(v, size)
         }
         return string(v);
     }

--- a/contracts/test/unit/universalResolver/MockENSIP15.t.sol
+++ b/contracts/test/unit/universalResolver/MockENSIP15.t.sol
@@ -17,8 +17,20 @@ contract MockENSIP15Test is Test {
         assertEq(ensip15.normalize("abc"), "abc");
     }
 
-    function test_canNormalize() external view {
+    function test_canNormalize_case() external view {
         assertEq(ensip15.normalize("ABC"), "abc");
+    }
+
+    function test_canNormalize_expand() external view {
+        assertEq(ensip15.normalize("a'z"), unicode"a\u2019z");
+    }
+
+    function test_canNormalize_shrink() external view {
+        assertEq(ensip15.normalize(unicode"a\u00ADz"), "az");
+    }
+
+    function test_canNormalize_mixed() external view {
+        assertEq(ensip15.normalize(unicode"ABC\u00AD123's"), "abc123\u2019s");
     }
 
     function test_cannotNormalize() external {

--- a/contracts/test/unit/universalResolver/libraries/LibENSIP15.t.sol
+++ b/contracts/test/unit/universalResolver/libraries/LibENSIP15.t.sol
@@ -31,15 +31,40 @@ contract LibENSIP15Test is Test {
         assertEq(norm, NameCoder.encode("a.bb.ccc"));
     }
 
-    function test_normalize_canNormalize() external view {
-        (bool wasNorm, bytes memory norm) = normalize("A.Bb.cCc");
-        assertFalse(wasNorm);
-        assertEq(norm, NameCoder.encode("a.bb.ccc"));
+    function test_normalize_canNormalize_empty() external view {
+        (bool wasNorm, bytes memory norm) = normalize("");
+        assertTrue(wasNorm);
+        assertEq(norm, NameCoder.encode(""));
     }
 
-    function test_normalize_cannotNormalize() external {
-        vm.expectRevert(abi.encodeWithSelector(IENSIP15.CannotNormalize.selector, " "));
-        this.normalize(" ");
+    function test_normalize_canNormalize_mixed() external view {
+        (bool wasNorm, bytes memory norm) =
+            normalize(unicode"A'.B\u00ADb.cC\u00ADc.\u00ADdD'Dd.Ee");
+        assertFalse(wasNorm);
+        assertEq(norm, NameCoder.encode(unicode"a\u2019.bb.ccc.dd\u2019dd.ee"));
+    }
+
+    function test_normalize_cannotNormalize_invalid() external {
+        string memory name = " ";
+        vm.expectRevert(abi.encodeWithSelector(IENSIP15.CannotNormalize.selector, name));
+        this.normalize(name);
+    }
+
+    function test_normalize_cannotNormalize_tooLong() external {
+        bytes memory name = new bytes(255);
+        bytes memory norm;
+        for (uint256 i; i < 255; ++i) {
+            name[i] = "'";
+            norm = abi.encodePacked(norm, ensip15.normalize("'"));
+        }
+        vm.expectRevert(abi.encodeWithSelector(NameCoder.LabelIsTooLong.selector, norm));
+        this.normalize(string(abi.encodePacked("sub.", name, ".eth")));
+    }
+
+    function test_normalize_cannotNormalize_empty() external {
+        string memory name = "\u00AD";
+        vm.expectRevert(abi.encodeWithSelector(NameCoder.LabelIsEmpty.selector, name));
+        this.normalize(name);
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/contracts/test/unit/universalResolver/libraries/LibENSIP15.t.sol
+++ b/contracts/test/unit/universalResolver/libraries/LibENSIP15.t.sol
@@ -22,63 +22,31 @@ contract LibENSIP15Test is Test {
     }
 
     function _callWithNullImpl() external view {
-        LibENSIP15.normalize("A", MockENSIP15(address(0)));
-    }
-
-    function test_normalize_empty() external view {
-        (bool wasNorm, bytes memory name) = norm("");
-        assertTrue(wasNorm);
-        assertEq(name, NameCoder.encode(""));
-    }
-
-    function test_normalize_dot() external {
-        vm.expectRevert(abi.encodeWithSelector(NameCoder.LabelIsEmpty.selector));
-        this.norm(".");
-    }
-
-    function test_normalize_leadingEmpty() external {
-        vm.expectRevert(abi.encodeWithSelector(NameCoder.LabelIsEmpty.selector));
-        this.norm(".eth");
-    }
-
-    function test_normalize_containsEmpty() external {
-        vm.expectRevert(abi.encodeWithSelector(NameCoder.LabelIsEmpty.selector));
-        this.norm("test..eth");
-    }
-
-    function test_normalize_trailingEmpty() external {
-        vm.expectRevert(abi.encodeWithSelector(NameCoder.LabelIsEmpty.selector));
-        this.norm("eth.");
-    }
-
-    function test_normalize_tooLong() external {
-        string memory name = new string(256);
-        vm.expectRevert(abi.encodeWithSelector(NameCoder.LabelIsTooLong.selector, name));
-        this.norm(name);
+        LibENSIP15.normalize(NameCoder.encode("A"), MockENSIP15(address(0)));
     }
 
     function test_normalize_isNormalized() external view {
-        (bool wasNorm, bytes memory name) = norm("a.bb.ccc");
+        (bool wasNorm, bytes memory norm) = normalize("a.bb.ccc");
         assertTrue(wasNorm);
-        assertEq(name, NameCoder.encode("a.bb.ccc"));
+        assertEq(norm, NameCoder.encode("a.bb.ccc"));
     }
 
     function test_normalize_canNormalize() external view {
-        (bool wasNorm, bytes memory name) = norm("A.Bb.cCc");
+        (bool wasNorm, bytes memory norm) = normalize("A.Bb.cCc");
         assertFalse(wasNorm);
-        assertEq(name, NameCoder.encode("a.bb.ccc"));
+        assertEq(norm, NameCoder.encode("a.bb.ccc"));
     }
 
     function test_normalize_cannotNormalize() external {
         vm.expectRevert(abi.encodeWithSelector(IENSIP15.CannotNormalize.selector, " "));
-        this.norm(" ");
+        this.normalize(" ");
     }
 
     ////////////////////////////////////////////////////////////////////////
     // Helpers
     ////////////////////////////////////////////////////////////////////////
 
-    function norm(string memory name) public view returns (bool, bytes memory) {
-        return LibENSIP15.normalize(name, ensip15);
+    function normalize(string memory inputName) public view returns (bool, bytes memory) {
+        return LibENSIP15.normalize(NameCoder.encode(inputName), ensip15);
     }
 }


### PR DESCRIPTION
- changed `AbstractNormalizedUniversalResolver` and `LibENSIP15`
     * accepts `bytes name` instead of `string inputName`
- changed `MockENSIP15` to be more realistic
     * added expand and shrink cases
- added more tests