### PR TITLE
feat(migration): let a nominated wallet own the seeded fixture names

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,7 +7,8 @@ runs:
       uses: actions/cache@v4
       with:
         path: .git
-        key: git-folder
+        key: git-folder-${{ github.sha }}
+        restore-keys: git-folder-
 
     - name: Checkout repo
       uses: actions/checkout@v5

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,9 @@
+codecov:
+  notify:
+    # hold the report until every coverage job has uploaded, so a slow or
+    # missing upload cannot grade the project against a partial report
+    manual_trigger: true
+
 coverage:
   status:
     project:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,6 +102,23 @@ jobs:
           CC_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           CC_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
 
+  notify-coverage:
+    name: Notify Coverage
+    needs: [forge-tests, hardhat-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: ".bun-version"
+
+      - name: Release coverage report
+        run: cd contracts && bun run coverage:notify
+        env:
+          CC_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CC_GIT_SERVICE: github
+          CC_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
   lint:
     name: Lint and Format
     runs-on: ubuntu-latest

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -49,7 +49,7 @@ Phase numbering matches the console output of the `fork full` orchestrator in
 | --- | --- | --- | --- | --- |
 | 0 | Deploy fresh v1 contracts | part of `clean-testnet` | clean-testnet only | `deployer` |
 | 1 | Deploy all v2 contracts, including reverse-registrar adapters and the HCA stack on HCA-enabled networks (registrar deferred) | `phase deploy-v2` | live + clean-testnet | `deployer` / `owner` / `urManager` (+ v1 owner) |
-| F1 | *(optional)* Seed the ENSv1 test fixture corpus and check the shaped v1 state | `fixture seed-v1` → `verify-v1` | live + clean-testnet | fixture operator + actors (+ v1 owner) |
+| F1 | *(optional)* Seed the ENSv1 test fixture corpus and check the shaped v1 state | `fixture fund-actors` → `seed-v1` → `verify-v1` | live + clean-testnet | fixture operator + actors (+ v1 owner) |
 | 2 | Seed v1 names as reserved on v2 | `premigration run` → `verify` | live + clean-testnet | BatchRegistrar owner |
 | 3 | Freeze v1 registrations | `phase disable-v1-registrars` (+ `verify-*`) | live + clean-testnet | v1 owner |
 | 4 | Keep unmigrated names renewable | `phase authorize-v1-renewer` | live + clean-testnet | v1 owner |
@@ -350,9 +350,10 @@ prerequisites, and result:
    and replaying the resolver update and reverse-adapter grants via
    `phase execute-owner-txs --role v1Owner`.
    Then, *(optional)* [seed the ENSv1 test fixture corpus](#ensv1-test-fixture-corpus):
-   `fixture seed-v1` → `fixture verify-v1`, passing `--fixture-owner-key` to `seed-v1` if the names
-   should belong to a tester. **This must sit after phase 1**, which deploys the `MigrationHelper`
-   the corpus approves, **and before phase 3**, which freezes v1 registration.
+   `fixture fund-actors` → `fixture seed-v1` → `fixture verify-v1`. If the names should belong to a
+   tester, pass `--fixture-owner-key` to *both* of the first two — it decides which accounts sign the
+   seeding, so the funding step has to see it as well. **This must sit after phase 1**, which deploys
+   the `MigrationHelper` the corpus approves, **and before phase 3**, which freezes v1 registration.
 2. [Phase 2 — initial pre-migration](#phase-2-initial-pre-migration) (`--work-dir .dev/sepolia-live/premig-1`).
    Pass the fixture label CSV alongside the real export if the corpus was seeded.
 3. [Phase 3 — freeze v1 registrations](#phase-3-disable-v1-registrars) (`--private-key $SEPOLIA_V1_OWNER_KEY`).
@@ -504,7 +505,8 @@ distributed across five named actors, which need funding because a large share o
 must be signed by the holder rather than batched. Those actors hold the names because shaping demands
 it, not because they are meant to keep them — [nominate an owner
 wallet](#choosing-who-owns-the-seeded-names) with `--fixture-owner-key` and the names are registered
-to it instead.
+to it instead. `fund-actors` takes that key too, and needs it: it funds whichever accounts seeding
+will sign from, and nominating a wallet is what changes them.
 
 ```bash
 export MIGRATION_FIXTURE_ACTOR_MNEMONIC="<dedicated fixture mnemonic>"
@@ -580,14 +582,21 @@ wallet](#choosing-who-owns-the-seeded-names) is checked against that wallet.
 
 By default the corpus is owned by the five actor accounts the mnemonic derives, which is fine when
 nobody but the tooling needs to touch it. To put it in a tester's hands, nominate the wallet with
-`--fixture-owner-key` and every name is registered to it from the start:
+`--fixture-owner-key` and every name is registered to it from the start. Both commands take the key,
+and both need it:
 
 ```bash
+bun run migration -- fixture fund-actors --network sepolia \
+  --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
+  --fixture-owner-key 0x<tester key>
+
 bun run migration -- fixture seed-v1 --network sepolia \
   --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
   --fixture-scenarios live_now --fixture-replicas-per-vector 4 \
   --fixture-owner-key 0x<tester key>
 ```
+
+Export `MIGRATION_FIXTURE_OWNER_KEY` instead if you would rather not repeat it; both commands read it.
 
 `fork full` and `clean-testnet` take the same flag. It is a **key**, not an address, and that is the
 whole trick: shaping a name means signing as its owner — reverse claims, operator approvals, unwraps,
@@ -610,6 +619,13 @@ owner is *not*.
 
 The operator key (`--fixture-private-key`) is separate and still needed: it pays for the batcher and
 the registrations. Only ownership moves to the nominated wallet.
+
+> **Fund the nominated wallet, not the accounts it replaces.** On a live chain `fund-actors` is the
+> only thing that puts gas where seeding needs it. Give the key to `seed-v1` alone and funding tops up
+> three mnemonic accounts that will never sign anything, while the wallet that signs everything starts
+> empty: seeding then runs out of gas part-way through a name it has already registered, and that name
+> is part-shaped, which the resume guard refuses to replay. The wallet is funded to three times
+> `--floor` for the same reason — one account is now doing three actors' work.
 
 ### Reserving the fixture labels on v2
 
@@ -838,7 +854,7 @@ and idempotency rules.
 | `premigration status` | Print the current pre-migration checkpoint JSON (local; `--work-dir` only) |
 | `premigration verify` | Verify eligible CSV names were reserved or registered on v2 |
 | `fixture verify` | Offline: validate a fixture selection and plan every scenario's calls |
-| `fixture fund-actors` | Top up the fixture actor accounts from the operator key |
+| `fixture fund-actors` | Top up the fixture actor accounts from the operator key. Takes the same `--fixture-owner-key` as `seed-v1`, so the wallet that will own the names is the one funded; `--floor` (default 0.5 ETH) is charged per alias, so an account carrying all three owner aliases is topped up to three floors |
 | `fixture deploy-fixtures` | Deploy the fixture batcher and the corpus counterparty contracts |
 | `fixture seed-v1` | Register the ENSv1 fixture corpus, shape each name's pre-migration state, and emit the label subset pre-migration reserves (after phase 1, before phase 3) |
 | `fixture verify-v1` | Read the shaped v1 state back and check it against each scenario (after `seed-v1`) |
@@ -905,7 +921,7 @@ flags/env). See `bunx hardhat migration <task> --help` for options.
 | `PREMIGRATION_PRIVATE_KEY`, `BATCH_REGISTRAR_OWNER_KEY`, `DEPLOYER_KEY` | BatchRegistrar owner key fallbacks for `premigration run` / `resume` |
 | `MIGRATION_FIXTURE_ACTOR_MNEMONIC` | Dedicated mnemonic for the five `fixture` actor accounts — never reuse a mnemonic held elsewhere |
 | `MIGRATION_FIXTURE_PRIVATE_KEY` | Fixture operator key (`fixture` commands) when `--fixture-private-key` is omitted |
-| `MIGRATION_FIXTURE_OWNER_KEY` | Key for the wallet that should own every seeded name, when `--fixture-owner-key` is omitted |
+| `MIGRATION_FIXTURE_OWNER_KEY` | Key for the wallet that should own every seeded name, when `--fixture-owner-key` is omitted; read by `fixture fund-actors` and `fixture seed-v1` alike |
 | `MIGRATION_FIXTURE_V1_OWNER` | v1 owner address used only when `fixture seed-v1` finds v1 registration already frozen |
 | `MIGRATION_FIXTURE_COMMIT_BATCH_SIZE`, `MIGRATION_FIXTURE_REGISTER_BATCH_SIZE` | Fixture registration batch sizes (default 80 and 12) |
 | `THEGRAPH_API_KEY` / `GRAPH_API_KEY` | TheGraph Gateway key for `fetch-data` |

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -467,10 +467,13 @@ controlled clock, a v2 state that needs the name already registered there, or a 
 controller's minimum. `fixture verify` applies the same check offline, so a cohort can be tested
 before a run starts. Every `live_now` scenario passes it.
 
-> **Reverse records are shared.** A reverse node derives from the account that claims it, and each
-> actor alias is one account, so scenarios claiming from the same alias all write the same node and
-> only the last survives. Seeding reports the overlap. Nothing else the corpus shapes or checks
-> depends on it, and no migration route reads a reverse record.
+> **Reverse records are shared.** A reverse node derives from the account that claims it, so
+> scenarios claiming from the same account all write the same node and only the last survives. Which
+> claims collide therefore depends on the layout: by default an alias is an account; with a
+> [nominated wallet](#choosing-who-owns-the-seeded-names) the three owner aliases are one account, so
+> claims that were distinct now overwrite each other. Both `verify` and seeding report the overlap,
+> counted per account. Nothing else the corpus shapes or checks depends on it, and no migration route
+> reads a reverse record.
 
 `--fixture-scenarios live_now --fixture-replicas-per-vector 4` is the recommended default: it covers every scenario
 the public network can express, several times over, without the long tail of replicas that adds
@@ -493,6 +496,13 @@ bun run migration -- fixture verify --network sepolia \
   --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
   --fixture-scenarios live_now --fixture-replicas-per-vector 4
 ```
+
+**Dry-run the layout you intend to seed.** `verify` takes `--fixture-owner-key` for the same reason
+`fund-actors` does: nominating a wallet decides which accounts the owner aliases resolve to, and so
+which plan there is to preview. Pass it and the preview is the run you are about to make. Omit it and
+the preview is the [default three-owner layout](#choosing-who-owns-the-seeded-names), whatever key
+seeding is later given. The reported `owner` is the wallet the plan registers to, and `null` when no
+wallet is nominated.
 
 Planning is not a state check. It confirms every call can be *built*; whether the resulting state is
 reachable on-chain is what [`verify-v1`](#checking-the-shaped-state) answers, after seeding.
@@ -582,10 +592,17 @@ wallet](#choosing-who-owns-the-seeded-names) is checked against that wallet.
 
 By default the corpus is owned by the five actor accounts the mnemonic derives, which is fine when
 nobody but the tooling needs to touch it. To put it in a tester's hands, nominate the wallet with
-`--fixture-owner-key` and seeding shapes every name into it rather than into a mnemonic account. Both
-commands take the key, and both need it:
+`--fixture-owner-key` and seeding shapes every name into it rather than into a mnemonic account.
+Every command up to and including registration takes the key, and each needs it: the dry run to
+preview this layout rather than the default one, funding to top up the wallet that will sign, and
+seeding to register to it.
 
 ```bash
+bun run migration -- fixture verify --network sepolia \
+  --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
+  --fixture-scenarios live_now --fixture-replicas-per-vector 4 \
+  --fixture-owner-key 0x<tester key>
+
 bun run migration -- fixture fund-actors --network sepolia \
   --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
   --fixture-owner-key 0x<tester key>
@@ -596,7 +613,9 @@ bun run migration -- fixture seed-v1 --network sepolia \
   --fixture-owner-key 0x<tester key>
 ```
 
-Export `MIGRATION_FIXTURE_OWNER_KEY` instead if you would rather not repeat it; both commands read it.
+Export `MIGRATION_FIXTURE_OWNER_KEY` instead if you would rather not repeat it; all three read it.
+Nothing after registration takes it: `verify-v1` resolves each alias against the addresses the
+seeding run recorded, and no command can change who owns a name once it is seeded.
 
 `fork full` and `clean-testnet` take the same flag. It is a **key**, not an address, and that is the
 whole trick: shaping a name means signing as its owner — reverse claims, operator approvals, unwraps,
@@ -860,7 +879,7 @@ and idempotency rules.
 | `premigration resume` | Resume pre-migration from the checkpoint |
 | `premigration status` | Print the current pre-migration checkpoint JSON (local; `--work-dir` only) |
 | `premigration verify` | Verify eligible CSV names were reserved or registered on v2 |
-| `fixture verify` | Offline: validate a fixture selection and plan every scenario's calls |
+| `fixture verify` | Offline: validate a fixture selection and plan every scenario's calls. Takes the same `--fixture-owner-key` as `seed-v1`, so the previewed plan is the one seeding will execute |
 | `fixture fund-actors` | Top up the fixture actor accounts from the operator key. Takes the same `--fixture-owner-key` as `seed-v1`, so the wallet that will own the names is the one funded; `--floor` (default 0.5 ETH) is charged per alias, so an account carrying all three owner aliases is topped up to three floors |
 | `fixture deploy-fixtures` | Deploy the fixture batcher and the corpus counterparty contracts |
 | `fixture seed-v1` | Register the ENSv1 fixture corpus, shape each name's pre-migration state, and emit the label subset pre-migration reserves (after phase 1, before phase 3) |
@@ -928,7 +947,7 @@ flags/env). See `bunx hardhat migration <task> --help` for options.
 | `PREMIGRATION_PRIVATE_KEY`, `BATCH_REGISTRAR_OWNER_KEY`, `DEPLOYER_KEY` | BatchRegistrar owner key fallbacks for `premigration run` / `resume` |
 | `MIGRATION_FIXTURE_ACTOR_MNEMONIC` | Dedicated mnemonic for the five `fixture` actor accounts — never reuse a mnemonic held elsewhere |
 | `MIGRATION_FIXTURE_PRIVATE_KEY` | Fixture operator key (`fixture` commands) when `--fixture-private-key` is omitted |
-| `MIGRATION_FIXTURE_OWNER_KEY` | Key for the wallet that should own every seeded name, when `--fixture-owner-key` is omitted; read by `fixture fund-actors` and `fixture seed-v1` alike |
+| `MIGRATION_FIXTURE_OWNER_KEY` | Key for the wallet that should own every seeded name, when `--fixture-owner-key` is omitted; read by `fixture verify`, `fixture fund-actors` and `fixture seed-v1` alike |
 | `MIGRATION_FIXTURE_V1_OWNER` | v1 owner address used only when `fixture seed-v1` finds v1 registration already frozen |
 | `MIGRATION_FIXTURE_COMMIT_BATCH_SIZE`, `MIGRATION_FIXTURE_REGISTER_BATCH_SIZE` | Fixture registration batch sizes (default 80 and 12) |
 | `THEGRAPH_API_KEY` / `GRAPH_API_KEY` | TheGraph Gateway key for `fetch-data` |

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -350,9 +350,9 @@ prerequisites, and result:
    and replaying the resolver update and reverse-adapter grants via
    `phase execute-owner-txs --role v1Owner`.
    Then, *(optional)* [seed the ENSv1 test fixture corpus](#ensv1-test-fixture-corpus):
-   `fixture seed-v1` → `fixture verify-v1`, passing `--fixture-owner-key` if the names should belong
-   to a tester. **This must sit after phase 1**, which deploys the `MigrationHelper` the corpus
-   approves, **and before phase 3**, which freezes v1 registration.
+   `fixture seed-v1` → `fixture verify-v1`, passing `--fixture-owner-key` to `seed-v1` if the names
+   should belong to a tester. **This must sit after phase 1**, which deploys the `MigrationHelper`
+   the corpus approves, **and before phase 3**, which freezes v1 registration.
 2. [Phase 2 — initial pre-migration](#phase-2-initial-pre-migration) (`--work-dir .dev/sepolia-live/premig-1`).
    Pass the fixture label CSV alongside the real export if the corpus was seeded.
 3. [Phase 3 — freeze v1 registrations](#phase-3-disable-v1-registrars) (`--private-key $SEPOLIA_V1_OWNER_KEY`).
@@ -558,6 +558,10 @@ corpus does not restate those, and the check allows for them.
 It exits non-zero listing every mismatch, and writes the full set to
 `<work-dir>/fixture-v1-verification.json`. Run it before pre-migration, while a name whose state did
 not take can still be reshaped.
+
+It takes no owner option of its own. Each actor alias is resolved against the addresses the seeding
+run recorded in `<work-dir>/fixture-run.json`, so a cohort registered to a [nominated
+wallet](#choosing-who-owns-the-seeded-names) is checked against that wallet.
 
 > **Known-bad vectors — exclude them from the cohort.** Some scenarios declare `CAN_EXTEND_EXPIRY` on
 > a `.eth` 2LD, which cannot be satisfied on-chain: the fuse is parent-controlled, and `wrapETH2LD`

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -455,11 +455,11 @@ is. Selection flags compose:
 
 | Flag | Effect |
 | --- | --- |
-| `--scenarios live_now` | Only scenarios a public testnet can express. `fork_only` needs Anvil/Tenderly time and reorg control. |
-| `--replicas-per-vector <n>` | Keep at most *n* copies of each distinct scenario. |
-| `--tiers <list>` | Restrict to popularity tiers. Concentrates volume on common shapes at the cost of behavioural coverage. |
-| `--ids <list>` | An explicit set, for reproducing one case. |
-| `--limit <n>` | Cap the cohort at *n* names, applied after the filters above. |
+| `--fixture-scenarios live_now` | Only scenarios a public testnet can express. `fork_only` needs Anvil/Tenderly time and reorg control. |
+| `--fixture-replicas-per-vector <n>` | Keep at most *n* copies of each distinct scenario. |
+| `--fixture-tiers <list>` | Restrict to popularity tiers. Concentrates volume on common shapes at the cost of behavioural coverage. |
+| `--fixture-ids <list>` | An explicit set, for reproducing one case. |
+| `--fixture-limit <n>` | Cap the cohort at *n* names, applied after the filters above. |
 
 Seeding refuses a selection whose scenarios it cannot establish, naming them: an expiry that needs a
 controlled clock, a v2 state that needs the name already registered there, or a lease below the v1
@@ -471,11 +471,11 @@ before a run starts. Every `live_now` scenario passes it.
 > only the last survives. Seeding reports the overlap. Nothing else the corpus shapes or checks
 > depends on it, and no migration route reads a reverse record.
 
-`--scenarios live_now --replicas-per-vector 4` is the recommended default: it covers every scenario
+`--fixture-scenarios live_now --fixture-replicas-per-vector 4` is the recommended default: it covers every scenario
 the public network can express, several times over, without the long tail of replicas that adds
 registration cost but no new behaviour.
 
-`--scenarios` filters on each scenario's `execution.scenario` — whether it can run on a public network
+`--fixture-scenarios` filters on each scenario's `execution.scenario` — whether it can run on a public network
 at all. That is a separate axis from the v2 state a scenario declares, which is what decides
 [whether its label gets reserved](#reserving-the-fixture-labels-on-v2); neither filters the other, so
 a `live_now` cohort still contains names meant to stay unreserved.
@@ -490,7 +490,7 @@ export MIGRATION_FIXTURE_ACTOR_MNEMONIC="<dedicated fixture mnemonic>"
 
 bun run migration -- fixture verify --network sepolia \
   --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
-  --scenarios live_now --replicas-per-vector 4
+  --fixture-scenarios live_now --fixture-replicas-per-vector 4
 ```
 
 Planning is not a state check. It confirms every call can be *built*; whether the resulting state is
@@ -503,7 +503,7 @@ Requires `bun run compile` first, a funded operator key, and a dedicated actor m
 distributed across five named actors, which need funding because a large share of the state shaping
 must be signed by the holder rather than batched. Those actors hold the names because shaping demands
 it, not because they are meant to keep them: to put the cohort in a tester's wallet, add
-[`--handover-to`](#handing-the-corpus-to-a-tester).
+[`--fixture-handover-to`](#handing-the-corpus-to-a-tester).
 
 ```bash
 export MIGRATION_FIXTURE_ACTOR_MNEMONIC="<dedicated fixture mnemonic>"
@@ -513,7 +513,7 @@ bun run migration -- fixture fund-actors --network sepolia \
 
 bun run migration -- fixture seed-v1 --network sepolia \
   --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
-  --scenarios live_now --replicas-per-vector 4
+  --fixture-scenarios live_now --fixture-replicas-per-vector 4
 ```
 
 `seed-v1` deploys a batching helper and the corpus's counterparty contracts, registers each name
@@ -566,10 +566,10 @@ not take can still be reshaped.
 >
 > 38 of the 761 distinct `live_now` vectors are affected; their ids all begin `3W-`, `FE-` or `PW-`
 > (most vectors under those prefixes are fine — the report names the exact ones). Because
-> `--replicas-per-vector` sorts by scenario id, `--limit` takes an alphabetical prefix that starts on
+> `--fixture-replicas-per-vector` sorts by scenario id, `--fixture-limit` takes an alphabetical prefix that starts on
 > an affected vector: ten of the first forty. Standalone this is a report you can read past;
 > [in a rehearsal it aborts the run](#in-a-rehearsal). Until the corpus is fixed, pin the cohort with
-> `--ids` from a list the affected vectors are excluded from.
+> `--fixture-ids` from a list the affected vectors are excluded from.
 
 ### Handing the corpus to a tester
 
@@ -579,11 +579,11 @@ wallet instead, so a tester holds the names on v1 and can drive the migration fr
 ```bash
 bun run migration -- fixture handover --network sepolia \
   --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
-  --scenarios live_now --replicas-per-vector 4 --handover-to 0x<tester>
+  --fixture-scenarios live_now --fixture-replicas-per-vector 4 --fixture-handover-to 0x<tester>
 ```
 
-Passing `--handover-to` to `seed-v1` runs the same three steps in order — seed, check, hand over —
-and `fork full` and `clean-testnet` take it as `--fixture-handover-to`. However it is reached, the
+Passing `--fixture-handover-to` to `seed-v1` runs the same three steps in order — seed, check, hand
+over — and `fork full` and `clean-testnet` take the same flag. However it is reached, the
 handover runs **after** `verify-v1`: the corpus declares which actor holds each name, so the shaped
 state is proved as written before that owner stops being the one holding it. Afterwards `verify-v1`
 expects the recipient instead, which it reads back from the run state, so it can be re-run at any
@@ -684,12 +684,12 @@ bun run migration -- fork full --network sepolia \
   --fixture-scenarios live_now --fixture-replicas-per-vector 1 --fixture-limit 40
 ```
 
-The selection flags are the standalone ones under a `--fixture-` prefix
-(`--fixture-scenarios`, `--fixture-tiers`, `--fixture-ids`, `--fixture-limit`,
-`--fixture-replicas-per-vector`), and `--fixture-handover-to <address>`
+The fixture flags are spelled exactly as they are standalone — every one carries the `--fixture-`
+prefix, so a cohort selected on one is selected the same way on the other, and none of them can be
+mistaken for the rehearsal's own `--initial-limit`, `--finish-limit` or signer options. That includes
+`--fixture-handover-to <address>`, which
 [hands the seeded cohort to a tester](#handing-the-corpus-to-a-tester) once the state check passes.
-The prefix is what keeps them apart from the rehearsal's own `--initial-limit`, `--finish-limit` and
-signer options. Keep a rehearsal cohort small:
+Keep a rehearsal cohort small:
 every name is a real commit/reveal registration plus its state-shaping calls, so the whole corpus
 costs far more wall-clock than the rest of the rehearsal put together.
 
@@ -932,7 +932,7 @@ flags/env). See `bunx hardhat migration <task> --help` for options.
 | `<PREFIX>_MNEMONIC`, `<PREFIX>_MNEMONIC_PATH`, `<PREFIX>_MNEMONIC_INDEX`, `<PREFIX>_MNEMONIC_PASSPHRASE` | Mnemonic-backed signer alternatives for `phase execute-owner-txs`; prefixes `OWNER_TX`, `SEPOLIA_V1_OWNER` / `V1_OWNER`, `SEPOLIA_TOP_URP_OWNER` / `TOP_URP_OWNER` |
 | `PREMIGRATION_PRIVATE_KEY`, `BATCH_REGISTRAR_OWNER_KEY`, `DEPLOYER_KEY` | BatchRegistrar owner key fallbacks for `premigration run` / `resume` |
 | `MIGRATION_FIXTURE_ACTOR_MNEMONIC` | Dedicated mnemonic for the five `fixture` actor accounts — never reuse a mnemonic held elsewhere |
-| `MIGRATION_FIXTURE_PRIVATE_KEY` | Fixture operator key (`fixture` commands) when `--private-key` is omitted |
+| `MIGRATION_FIXTURE_PRIVATE_KEY` | Fixture operator key (`fixture` commands) when `--fixture-private-key` is omitted |
 | `MIGRATION_FIXTURE_V1_OWNER` | v1 owner address used only when `fixture seed-v1` finds v1 registration already frozen |
 | `MIGRATION_FIXTURE_COMMIT_BATCH_SIZE`, `MIGRATION_FIXTURE_REGISTER_BATCH_SIZE` | Fixture registration batch sizes (default 80 and 12) |
 | `THEGRAPH_API_KEY` / `GRAPH_API_KEY` | TheGraph Gateway key for `fetch-data` |

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -49,7 +49,7 @@ Phase numbering matches the console output of the `fork full` orchestrator in
 | --- | --- | --- | --- | --- |
 | 0 | Deploy fresh v1 contracts | part of `clean-testnet` | clean-testnet only | `deployer` |
 | 1 | Deploy all v2 contracts, including reverse-registrar adapters and the HCA stack on HCA-enabled networks (registrar deferred) | `phase deploy-v2` | live + clean-testnet | `deployer` / `owner` / `urManager` (+ v1 owner) |
-| F1 | *(optional)* Seed the ENSv1 test fixture corpus, then check the shaped v1 state | `fixture seed-v1` → `verify-v1` | live + clean-testnet | fixture operator + actors (+ v1 owner) |
+| F1 | *(optional)* Seed the ENSv1 test fixture corpus, check the shaped v1 state, and optionally hand it to a tester | `fixture seed-v1` → `verify-v1` → `handover` | live + clean-testnet | fixture operator + actors (+ v1 owner) |
 | 2 | Seed v1 names as reserved on v2 | `premigration run` → `verify` | live + clean-testnet | BatchRegistrar owner |
 | 3 | Freeze v1 registrations | `phase disable-v1-registrars` (+ `verify-*`) | live + clean-testnet | v1 owner |
 | 4 | Keep unmigrated names renewable | `phase authorize-v1-renewer` | live + clean-testnet | v1 owner |
@@ -350,8 +350,9 @@ prerequisites, and result:
    and replaying the resolver update and reverse-adapter grants via
    `phase execute-owner-txs --role v1Owner`.
    Then, *(optional)* [seed the ENSv1 test fixture corpus](#ensv1-test-fixture-corpus):
-   `fixture seed-v1` → `fixture verify-v1`. **This must sit after phase 1**, which deploys the
-   `MigrationHelper` the corpus approves, **and before phase 3**, which freezes v1 registration.
+   `fixture seed-v1` → `fixture verify-v1`, and `fixture handover` to put the names in a tester's
+   wallet. **This must sit after phase 1**, which deploys the `MigrationHelper` the corpus approves,
+   **and before phase 3**, which freezes v1 registration.
 2. [Phase 2 — initial pre-migration](#phase-2-initial-pre-migration) (`--work-dir .dev/sepolia-live/premig-1`).
    Pass the fixture label CSV alongside the real export if the corpus was seeded.
 3. [Phase 3 — freeze v1 registrations](#phase-3-disable-v1-registrars) (`--private-key $SEPOLIA_V1_OWNER_KEY`).
@@ -417,7 +418,9 @@ claims, parent/child hierarchies — and most of the labels are then reserved on
 pre-migration phases.
 
 The corpus seeds v1 state and gets labels reserved. It does **not** migrate names: migrating a name is
-a manual action its owner takes whenever they choose, and no phase performs it.
+a manual action its owner takes whenever they choose, and no phase performs it. Seeded names can be
+[handed to a tester's wallet](#handing-the-corpus-to-a-tester) so that owner is a person rather than a
+throwaway key.
 
 This is test scaffolding. It is refused against live mainnet, and nothing in the canonical phases
 depends on it.
@@ -498,7 +501,9 @@ reachable on-chain is what [`verify-v1`](#checking-the-shaped-state) answers, af
 Requires `bun run compile` first, a funded operator key, and a dedicated actor mnemonic
 (`MIGRATION_FIXTURE_ACTOR_MNEMONIC`) — never a mnemonic used for anything else. Fixture names are
 distributed across five named actors, which need funding because a large share of the state shaping
-must be signed by the holder rather than batched.
+must be signed by the holder rather than batched. Those actors hold the names because shaping demands
+it, not because they are meant to keep them: to put the cohort in a tester's wallet, add
+[`--handover-to`](#handing-the-corpus-to-a-tester).
 
 ```bash
 export MIGRATION_FIXTURE_ACTOR_MNEMONIC="<dedicated fixture mnemonic>"
@@ -566,6 +571,56 @@ not take can still be reshaped.
 > [in a rehearsal it aborts the run](#in-a-rehearsal). Until the corpus is fixed, pin the cohort with
 > `--fixture-ids` from a list the affected vectors are excluded from.
 
+### Handing the corpus to a tester
+
+Seeding leaves every name on the actor its scenario names. `handover` gives the whole selection to one
+wallet instead, so a tester holds the names on v1 and can drive the migration from the app:
+
+```bash
+bun run migration -- fixture handover --network sepolia \
+  --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
+  --scenarios live_now --replicas-per-vector 4 --handover-to 0x<tester>
+```
+
+Passing `--handover-to` to `seed-v1` runs the same three steps in order — seed, check, hand over —
+and `fork full` and `clean-testnet` take it as `--fixture-handover-to`. However it is reached, the
+handover runs **after** `verify-v1`: the corpus declares which actor holds each name, so the shaped
+state is proved as written before that owner stops being the one holding it. Afterwards `verify-v1`
+expects the recipient instead, which it reads back from the run state, so it can be re-run at any
+point.
+
+Ownership is all that moves: fuses, expiry, resolver, records and wrapper form are untouched, and an
+unwrapped name's registry record travels with its token. One recipient owns everything — a second
+address in the same work directory is refused, because splitting a cohort across wallets is almost
+always a mistake. Nothing asks the recipient to sign, and the run is idempotent: a name already held
+is left alone, so an interrupted handover resumes.
+
+Three limits worth knowing before pointing a tester at the result:
+
+- **Some names cannot move at all.** The wrapper refuses a name with `CANNOT_TRANSFER` burned — 172
+  of the 6,052 `live_now` rows, all `wrapped_locked` or `locked_child` — and refuses an emancipated
+  name that has reached its grace period. Both stay with their actor, and the run reports each one
+  with its reason rather than failing.
+- **Operator approvals lapse.** 1,288 of the 7,104 corpus names approve `MigrationHelper` or a
+  fixture operator while shaping. An approval is scoped to the owner that granted it, so every one of
+  them is inert the moment the name moves. A recipient migrating through a helper route grants their
+  own first, which is what the app asks for anyway.
+- **Reverse records stay behind.** `set_reverse_claim` writes the *claiming actor's* reverse node,
+  not the owner's, so the actors keep reverse records naming fixtures they no longer hold and the
+  recipient's primary name is untouched.
+
+Child scenarios move with their parent 2LD, which seeding leaves wrapped to the batcher. Without it
+the recipient could never migrate the subname: `MigrationHelper` reverts `ParentNotMigrated` until
+the name above it has migrated, and only the parent's owner can do that.
+
+A cohort travels in batches, not one transaction per name. Each holder grants the batcher operator
+rights once per registry — at most six transactions for the three owner actors — and every transfer
+then runs
+inside the batcher. The grant confers nothing over a name once it has reached the recipient.
+
+The run writes `<work-dir>/fixture-handover.json`: what moved, with transaction hashes, and what was
+left behind with the reason.
+
 ### Reserving the fixture labels on v2
 
 **Seeding registers the whole cohort on v1; pre-migration reserves only part of it.** Every scenario
@@ -613,7 +668,9 @@ bun run migration -- fork full --network sepolia \
 ```
 
 The selection flags mirror the standalone ones (`--fixture-scenarios`, `--fixture-tiers`,
-`--fixture-ids`, `--fixture-limit`, `--fixture-replicas-per-vector`). Keep a rehearsal cohort small:
+`--fixture-ids`, `--fixture-limit`, `--fixture-replicas-per-vector`), and
+`--fixture-handover-to <address>` [hands the seeded cohort to a tester](#handing-the-corpus-to-a-tester)
+once the state check passes. Keep a rehearsal cohort small:
 every name is a real commit/reveal registration plus its state-shaping calls, so the whole corpus
 costs far more wall-clock than the rest of the rehearsal put together.
 
@@ -793,6 +850,7 @@ and idempotency rules.
 | `fixture deploy-fixtures` | Deploy the fixture batcher and the corpus counterparty contracts |
 | `fixture seed-v1` | Register the ENSv1 fixture corpus, shape each name's pre-migration state, and emit the label subset pre-migration reserves (after phase 1, before phase 3) |
 | `fixture verify-v1` | Read the shaped v1 state back and check it against each scenario (after `seed-v1`) |
+| `fixture handover` | Give every seeded name in the selection to one wallet, so a tester holds them on v1 (after `verify-v1`) |
 | `phase deploy-v2` | Phase 1: deploy the v2 migration contracts, reverse-registrar adapters, and enabled HCA infrastructure with the registrar deferred; archives any existing namespace and deploys fresh by default (`--resume` continues an interrupted deploy) |
 | `phase reclaim-v1-registrar-ownership` | Re-migration only: reclaim v1 `BaseRegistrar` ownership from a prior deployment's `ETHRenewerV1` back to the v1 owner (run before the phase-1 deferred-tx replay on an already-migrated chain) |
 | `phase disable-v1-registrars` | Phase 3: revoke every v1 authorization (BaseRegistrar + reverse registrars) the active deployment did not grant |

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -49,7 +49,7 @@ Phase numbering matches the console output of the `fork full` orchestrator in
 | --- | --- | --- | --- | --- |
 | 0 | Deploy fresh v1 contracts | part of `clean-testnet` | clean-testnet only | `deployer` |
 | 1 | Deploy all v2 contracts, including reverse-registrar adapters and the HCA stack on HCA-enabled networks (registrar deferred) | `phase deploy-v2` | live + clean-testnet | `deployer` / `owner` / `urManager` (+ v1 owner) |
-| F1 | *(optional)* Seed the ENSv1 test fixture corpus, check the shaped v1 state, and optionally hand it to a tester | `fixture seed-v1` → `verify-v1` → `handover` | live + clean-testnet | fixture operator + actors (+ v1 owner) |
+| F1 | *(optional)* Seed the ENSv1 test fixture corpus and check the shaped v1 state | `fixture seed-v1` → `verify-v1` | live + clean-testnet | fixture operator + actors (+ v1 owner) |
 | 2 | Seed v1 names as reserved on v2 | `premigration run` → `verify` | live + clean-testnet | BatchRegistrar owner |
 | 3 | Freeze v1 registrations | `phase disable-v1-registrars` (+ `verify-*`) | live + clean-testnet | v1 owner |
 | 4 | Keep unmigrated names renewable | `phase authorize-v1-renewer` | live + clean-testnet | v1 owner |
@@ -350,9 +350,9 @@ prerequisites, and result:
    and replaying the resolver update and reverse-adapter grants via
    `phase execute-owner-txs --role v1Owner`.
    Then, *(optional)* [seed the ENSv1 test fixture corpus](#ensv1-test-fixture-corpus):
-   `fixture seed-v1` → `fixture verify-v1`, and `fixture handover` to put the names in a tester's
-   wallet. **This must sit after phase 1**, which deploys the `MigrationHelper` the corpus approves,
-   **and before phase 3**, which freezes v1 registration.
+   `fixture seed-v1` → `fixture verify-v1`, passing `--fixture-owner-key` if the names should belong
+   to a tester. **This must sit after phase 1**, which deploys the `MigrationHelper` the corpus
+   approves, **and before phase 3**, which freezes v1 registration.
 2. [Phase 2 — initial pre-migration](#phase-2-initial-pre-migration) (`--work-dir .dev/sepolia-live/premig-1`).
    Pass the fixture label CSV alongside the real export if the corpus was seeded.
 3. [Phase 3 — freeze v1 registrations](#phase-3-disable-v1-registrars) (`--private-key $SEPOLIA_V1_OWNER_KEY`).
@@ -419,8 +419,8 @@ pre-migration phases.
 
 The corpus seeds v1 state and gets labels reserved. It does **not** migrate names: migrating a name is
 a manual action its owner takes whenever they choose, and no phase performs it. Seeded names can be
-[handed to a tester's wallet](#handing-the-corpus-to-a-tester) so that owner is a person rather than a
-throwaway key.
+[registered to a tester's wallet](#choosing-who-owns-the-seeded-names) so that owner is a person
+rather than a throwaway key.
 
 This is test scaffolding. It is refused against live mainnet, and nothing in the canonical phases
 depends on it.
@@ -502,8 +502,9 @@ Requires `bun run compile` first, a funded operator key, and a dedicated actor m
 (`MIGRATION_FIXTURE_ACTOR_MNEMONIC`) — never a mnemonic used for anything else. Fixture names are
 distributed across five named actors, which need funding because a large share of the state shaping
 must be signed by the holder rather than batched. Those actors hold the names because shaping demands
-it, not because they are meant to keep them: to put the cohort in a tester's wallet, add
-[`--fixture-handover-to`](#handing-the-corpus-to-a-tester).
+it, not because they are meant to keep them — [nominate an owner
+wallet](#choosing-who-owns-the-seeded-names) with `--fixture-owner-key` and the names are registered
+to it instead.
 
 ```bash
 export MIGRATION_FIXTURE_ACTOR_MNEMONIC="<dedicated fixture mnemonic>"
@@ -571,72 +572,40 @@ not take can still be reshaped.
 > [in a rehearsal it aborts the run](#in-a-rehearsal). Until the corpus is fixed, pin the cohort with
 > `--fixture-ids` from a list the affected vectors are excluded from.
 
-### Handing the corpus to a tester
+### Choosing who owns the seeded names
 
-Seeding leaves every name on the actor its scenario names. `handover` gives the whole selection to one
-wallet instead, so a tester holds the names on v1 and can drive the migration from the app:
+By default the corpus is owned by the five actor accounts the mnemonic derives, which is fine when
+nobody but the tooling needs to touch it. To put it in a tester's hands, nominate the wallet with
+`--fixture-owner-key` and every name is registered to it from the start:
 
 ```bash
-bun run migration -- fixture handover --network sepolia \
+bun run migration -- fixture seed-v1 --network sepolia \
   --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
-  --fixture-scenarios live_now --fixture-replicas-per-vector 4 --fixture-handover-to 0x<tester>
+  --fixture-scenarios live_now --fixture-replicas-per-vector 4 \
+  --fixture-owner-key 0x<tester key>
 ```
 
-Passing `--fixture-handover-to` to `seed-v1` runs the same three steps in order — seed, check, hand
-over — and `fork full` and `clean-testnet` take the same flag. However it is reached, the
-handover runs **after** `verify-v1`: the corpus declares which actor holds each name, so the shaped
-state is proved as written before that owner stops being the one holding it. Afterwards `verify-v1`
-expects the recipient instead, which it reads back from the run state, so it can be re-run at any
-point.
+`fork full` and `clean-testnet` take the same flag. It is a **key**, not an address, and that is the
+whole trick: shaping a name means signing as its owner — reverse claims, operator approvals, unwraps,
+records written after the name leaves the batcher — so an owner we can sign for can be the tester
+from the first block. Nothing is transferred afterwards, which means nothing can refuse to be: the
+196 names carrying `CANNOT_TRANSFER`, which no transfer could ever have moved, are the tester's on
+the same terms as every other name. Subnames come with the name above them, so they can actually be
+migrated.
 
-Ownership is all that moves: fuses, expiry, resolver, records and wrapper form are untouched, and an
-unwrapped name's registry record travels with its token. One recipient owns everything — a second
-address in the same work directory is refused, because splitting a cohort across wallets is almost
-always a mistake. Nothing asks the recipient to sign, and the run is idempotent: a name already held
-is left alone, so an interrupted handover resumes.
+The key covers `owner_a`, `owner_b` and `owner_c` — every alias the corpus ever names as an owner.
+`operator` and `attacker` stay on the mnemonic, because each is only meaningful as an address the
+owner is *not*.
 
-Three limits worth knowing before pointing a tester at the result:
+> **What one wallet costs.** Collapsing the three owner aliases onto one account means the scenarios
+> that turn on owners differing no longer do: 356 `transfer_registrant` steps become self-transfers,
+> 2,034 scenarios name an `alternate_owner` that is now the owner itself, and 16 of the 48 helper
+> batches stop spanning more than one owner — so `MigrationHelper`'s per-owner grouping goes
+> unexercised. Nothing fails; the coverage is simply narrower. Seed without the flag when the point
+> is to exercise the migration paths rather than to hand someone a wallet.
 
-- **Some names cannot move at all.** The wrapper refuses a name with `CANNOT_TRANSFER` burned — 196
-  corpus names, 172 of them `live_now`, all `wrapped_locked` or `locked_child` — and refuses an
-  emancipated `.eth` 2LD that has reached its grace period, or an emancipated subname past its
-  expiry. Those stay with their actor, and so does the parent of a subname that stayed: moving the
-  parent alone would split a pair that has to travel together, since neither wallet could then drive
-  the scenario. The run reports each one with its reason rather than failing.
-- **Blanket operator approvals lapse; frozen per-token ones do not.** 1,288 corpus names approve
-  `MigrationHelper` or a fixture operator with `setApprovalForAll`, which is scoped to the owner that
-  granted it, so all of those are inert the moment the name moves — a recipient migrating through a
-  helper route grants their own first, which is what the app asks for anyway. A further 72 names (56
-  `live_now`) instead approve a single wrapper token and then burn `CANNOT_APPROVE`.
-  `NameWrapper._beforeTransfer` clears a token approval only while that fuse is *unburned*, so those
-  approvals survive the transfer and the recipient cannot revoke them. The residual capability is
-  narrow — a stale approval feeds only `canExtendSubnames` and `upgrade`, never transfer authority or
-  `canModifyName` — but it is real, and it is deliberate: those scenarios exist to exercise a frozen
-  approval.
-- **Reverse records stay behind.** `set_reverse_claim` writes the *claiming actor's* reverse node,
-  not the owner's, so the actors keep reverse records naming fixtures they no longer hold and the
-  recipient's primary name is untouched.
-
-Child scenarios move with their parent 2LD, which seeding leaves wrapped to the batcher. Without it
-the recipient could never migrate the subname: `MigrationHelper` reverts `ParentNotMigrated` until
-the name above it has migrated, and only the parent's owner can do that. The pair is all-or-nothing —
-a subname the wrapper refuses to move leaves its parent on the batcher.
-
-A cohort travels in batches, not one transaction per name. Each holder grants the batcher operator
-rights once per registry — at most six transactions for the three owner actors — and every transfer
-then runs inside the batcher. The grant confers nothing over a name once it has reached the
-recipient.
-
-The run writes `<work-dir>/fixture-handover.json`: what moved, with transaction hashes, and what was
-left behind with the reason. It is written even when the run fails partway, and a rerun merges into
-it rather than replacing it, so the record of what moved survives the reruns the command invites.
-A `completed` flag says whether the batches finished; after an interrupted run, re-run the command
-before re-running `verify-v1`.
-
-After a handover `verify-v1` expects the recipient wherever the corpus names the actor the name was
-taken from, and says so — its summary reports how many ownership assertions were satisfied that way
-rather than against the declared actor. A name that moved off any other holder keeps asserting
-exactly what the corpus declares.
+The operator key (`--fixture-private-key`) is separate and still needed: it pays for the batcher and
+the registrations. Only ownership moves to the nominated wallet.
 
 ### Reserving the fixture labels on v2
 
@@ -687,8 +656,8 @@ bun run migration -- fork full --network sepolia \
 The fixture flags are spelled exactly as they are standalone — every one carries the `--fixture-`
 prefix, so a cohort selected on one is selected the same way on the other, and none of them can be
 mistaken for the rehearsal's own `--initial-limit`, `--finish-limit` or signer options. That includes
-`--fixture-handover-to <address>`, which
-[hands the seeded cohort to a tester](#handing-the-corpus-to-a-tester) once the state check passes.
+`--fixture-owner-key <key>`, which
+[registers the cohort to a tester's wallet](#choosing-who-owns-the-seeded-names).
 Keep a rehearsal cohort small:
 every name is a real commit/reveal registration plus its state-shaping calls, so the whole corpus
 costs far more wall-clock than the rest of the rehearsal put together.
@@ -869,7 +838,6 @@ and idempotency rules.
 | `fixture deploy-fixtures` | Deploy the fixture batcher and the corpus counterparty contracts |
 | `fixture seed-v1` | Register the ENSv1 fixture corpus, shape each name's pre-migration state, and emit the label subset pre-migration reserves (after phase 1, before phase 3) |
 | `fixture verify-v1` | Read the shaped v1 state back and check it against each scenario (after `seed-v1`) |
-| `fixture handover` | Give every seeded name in the selection to one wallet, so a tester holds them on v1 (after `verify-v1`) |
 | `phase deploy-v2` | Phase 1: deploy the v2 migration contracts, reverse-registrar adapters, and enabled HCA infrastructure with the registrar deferred; archives any existing namespace and deploys fresh by default (`--resume` continues an interrupted deploy) |
 | `phase reclaim-v1-registrar-ownership` | Re-migration only: reclaim v1 `BaseRegistrar` ownership from a prior deployment's `ETHRenewerV1` back to the v1 owner (run before the phase-1 deferred-tx replay on an already-migrated chain) |
 | `phase disable-v1-registrars` | Phase 3: revoke every v1 authorization (BaseRegistrar + reverse registrars) the active deployment did not grant |
@@ -933,6 +901,7 @@ flags/env). See `bunx hardhat migration <task> --help` for options.
 | `PREMIGRATION_PRIVATE_KEY`, `BATCH_REGISTRAR_OWNER_KEY`, `DEPLOYER_KEY` | BatchRegistrar owner key fallbacks for `premigration run` / `resume` |
 | `MIGRATION_FIXTURE_ACTOR_MNEMONIC` | Dedicated mnemonic for the five `fixture` actor accounts — never reuse a mnemonic held elsewhere |
 | `MIGRATION_FIXTURE_PRIVATE_KEY` | Fixture operator key (`fixture` commands) when `--fixture-private-key` is omitted |
+| `MIGRATION_FIXTURE_OWNER_KEY` | Key for the wallet that should own every seeded name, when `--fixture-owner-key` is omitted |
 | `MIGRATION_FIXTURE_V1_OWNER` | v1 owner address used only when `fixture seed-v1` finds v1 registration already frozen |
 | `MIGRATION_FIXTURE_COMMIT_BATCH_SIZE`, `MIGRATION_FIXTURE_REGISTER_BATCH_SIZE` | Fixture registration batch sizes (default 80 and 12) |
 | `THEGRAPH_API_KEY` / `GRAPH_API_KEY` | TheGraph Gateway key for `fetch-data` |

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -582,8 +582,8 @@ wallet](#choosing-who-owns-the-seeded-names) is checked against that wallet.
 
 By default the corpus is owned by the five actor accounts the mnemonic derives, which is fine when
 nobody but the tooling needs to touch it. To put it in a tester's hands, nominate the wallet with
-`--fixture-owner-key` and every name is registered to it from the start. Both commands take the key,
-and both need it:
+`--fixture-owner-key` and seeding shapes every name into it rather than into a mnemonic account. Both
+commands take the key, and both need it:
 
 ```bash
 bun run migration -- fixture fund-actors --network sepolia \
@@ -601,7 +601,8 @@ Export `MIGRATION_FIXTURE_OWNER_KEY` instead if you would rather not repeat it; 
 `fork full` and `clean-testnet` take the same flag. It is a **key**, not an address, and that is the
 whole trick: shaping a name means signing as its owner — reverse claims, operator approvals, unwraps,
 records written after the name leaves the batcher — so an owner we can sign for can be the tester
-from the first block. Nothing is transferred afterwards, which means nothing can refuse to be: the
+from the moment the name leaves the batcher. Nothing is transferred once seeding is done with a name,
+which means nothing can refuse to be: the
 196 names carrying `CANNOT_TRANSFER`, which no transfer could ever have moved, are the tester's on
 the same terms as every other name. Subnames come with the name above them, so they can actually be
 migrated.
@@ -619,6 +620,12 @@ owner is *not*.
 
 The operator key (`--fixture-private-key`) is separate and still needed: it pays for the batcher and
 the registrations. Only ownership moves to the nominated wallet.
+
+> **Registration still goes through the batcher.** Every name is registered to the batching helper,
+> which does the commit/reveal in bulk, and moves to its owner while its state is being shaped — before
+> any fuse that would refuse a transfer is burned. The wallet therefore holds the name by the time
+> seeding finishes with it, with no handover afterwards. A run interrupted between the two leaves the
+> name on the batcher and part-shaped, which is the case the resume guard refuses above.
 
 > **Fund the nominated wallet, not the accounts it replaces.** On a live chain `fund-actors` is the
 > only thing that puts gas where seeding needs it. Give the key to `seed-v1` alone and funding tops up

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -597,29 +597,46 @@ is left alone, so an interrupted handover resumes.
 
 Three limits worth knowing before pointing a tester at the result:
 
-- **Some names cannot move at all.** The wrapper refuses a name with `CANNOT_TRANSFER` burned — 172
-  of the 6,052 `live_now` rows, all `wrapped_locked` or `locked_child` — and refuses an emancipated
-  name that has reached its grace period. Both stay with their actor, and the run reports each one
-  with its reason rather than failing.
-- **Operator approvals lapse.** 1,288 of the 7,104 corpus names approve `MigrationHelper` or a
-  fixture operator while shaping. An approval is scoped to the owner that granted it, so every one of
-  them is inert the moment the name moves. A recipient migrating through a helper route grants their
-  own first, which is what the app asks for anyway.
+- **Some names cannot move at all.** The wrapper refuses a name with `CANNOT_TRANSFER` burned — 196
+  corpus names, 172 of them `live_now`, all `wrapped_locked` or `locked_child` — and refuses an
+  emancipated `.eth` 2LD that has reached its grace period, or an emancipated subname past its
+  expiry. Those stay with their actor, and so does the parent of a subname that stayed: moving the
+  parent alone would split a pair that has to travel together, since neither wallet could then drive
+  the scenario. The run reports each one with its reason rather than failing.
+- **Blanket operator approvals lapse; frozen per-token ones do not.** 1,288 corpus names approve
+  `MigrationHelper` or a fixture operator with `setApprovalForAll`, which is scoped to the owner that
+  granted it, so all of those are inert the moment the name moves — a recipient migrating through a
+  helper route grants their own first, which is what the app asks for anyway. A further 72 names (56
+  `live_now`) instead approve a single wrapper token and then burn `CANNOT_APPROVE`.
+  `NameWrapper._beforeTransfer` clears a token approval only while that fuse is *unburned*, so those
+  approvals survive the transfer and the recipient cannot revoke them. The residual capability is
+  narrow — a stale approval feeds only `canExtendSubnames` and `upgrade`, never transfer authority or
+  `canModifyName` — but it is real, and it is deliberate: those scenarios exist to exercise a frozen
+  approval.
 - **Reverse records stay behind.** `set_reverse_claim` writes the *claiming actor's* reverse node,
   not the owner's, so the actors keep reverse records naming fixtures they no longer hold and the
   recipient's primary name is untouched.
 
 Child scenarios move with their parent 2LD, which seeding leaves wrapped to the batcher. Without it
 the recipient could never migrate the subname: `MigrationHelper` reverts `ParentNotMigrated` until
-the name above it has migrated, and only the parent's owner can do that.
+the name above it has migrated, and only the parent's owner can do that. The pair is all-or-nothing —
+a subname the wrapper refuses to move leaves its parent on the batcher.
 
 A cohort travels in batches, not one transaction per name. Each holder grants the batcher operator
 rights once per registry — at most six transactions for the three owner actors — and every transfer
-then runs
-inside the batcher. The grant confers nothing over a name once it has reached the recipient.
+then runs inside the batcher. The grant confers nothing over a name once it has reached the
+recipient.
 
 The run writes `<work-dir>/fixture-handover.json`: what moved, with transaction hashes, and what was
-left behind with the reason.
+left behind with the reason. It is written even when the run fails partway, and a rerun merges into
+it rather than replacing it, so the record of what moved survives the reruns the command invites.
+A `completed` flag says whether the batches finished; after an interrupted run, re-run the command
+before re-running `verify-v1`.
+
+After a handover `verify-v1` expects the recipient wherever the corpus names the actor the name was
+taken from, and says so — its summary reports how many ownership assertions were satisfied that way
+rather than against the declared actor. A name that moved off any other holder keeps asserting
+exactly what the corpus declares.
 
 ### Reserving the fixture labels on v2
 

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -458,7 +458,7 @@ is. Selection flags compose:
 | `--scenarios live_now` | Only scenarios a public testnet can express. `fork_only` needs Anvil/Tenderly time and reorg control. |
 | `--replicas-per-vector <n>` | Keep at most *n* copies of each distinct scenario. |
 | `--tiers <list>` | Restrict to popularity tiers. Concentrates volume on common shapes at the cost of behavioural coverage. |
-| `--fixture-ids <list>` | An explicit set, for reproducing one case. |
+| `--ids <list>` | An explicit set, for reproducing one case. |
 | `--limit <n>` | Cap the cohort at *n* names, applied after the filters above. |
 
 Seeding refuses a selection whose scenarios it cannot establish, naming them: an expiry that needs a
@@ -569,7 +569,7 @@ not take can still be reshaped.
 > `--replicas-per-vector` sorts by scenario id, `--limit` takes an alphabetical prefix that starts on
 > an affected vector: ten of the first forty. Standalone this is a report you can read past;
 > [in a rehearsal it aborts the run](#in-a-rehearsal). Until the corpus is fixed, pin the cohort with
-> `--fixture-ids` from a list the affected vectors are excluded from.
+> `--ids` from a list the affected vectors are excluded from.
 
 ### Handing the corpus to a tester
 
@@ -684,10 +684,12 @@ bun run migration -- fork full --network sepolia \
   --fixture-scenarios live_now --fixture-replicas-per-vector 1 --fixture-limit 40
 ```
 
-The selection flags mirror the standalone ones (`--fixture-scenarios`, `--fixture-tiers`,
-`--fixture-ids`, `--fixture-limit`, `--fixture-replicas-per-vector`), and
-`--fixture-handover-to <address>` [hands the seeded cohort to a tester](#handing-the-corpus-to-a-tester)
-once the state check passes. Keep a rehearsal cohort small:
+The selection flags are the standalone ones under a `--fixture-` prefix
+(`--fixture-scenarios`, `--fixture-tiers`, `--fixture-ids`, `--fixture-limit`,
+`--fixture-replicas-per-vector`), and `--fixture-handover-to <address>`
+[hands the seeded cohort to a tester](#handing-the-corpus-to-a-tester) once the state check passes.
+The prefix is what keeps them apart from the rehearsal's own `--initial-limit`, `--finish-limit` and
+signer options. Keep a rehearsal cohort small:
 every name is a real commit/reveal registration plus its state-shaping calls, so the whole corpus
 costs far more wall-clock than the rest of the rehearsal put together.
 

--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -40,10 +40,8 @@ Two things cut across every path:
 
 ## Phases
 
-Phase numbering matches the console output of the `fork full` orchestrator in
-[`script/migration.ts`](../script/migration.ts). Every command below also takes the shared
-[common options](#common-options) (`--network`, `--rpc-url`, deployment dirs); run any command with
-`--help` for its authoritative option list.
+Every command below also takes the shared [common options](#common-options) (`--network`,
+`--rpc-url`, deployment dirs); run any command with `--help` for its authoritative option list.
 
 | Phase | Action | Command(s) | Applies to | Signer |
 | --- | --- | --- | --- | --- |
@@ -70,7 +68,6 @@ Phase numbering matches the console output of the `fork full` orchestrator in
 
 ### Phase 1: deploy v2 contracts
 
-- **Applies to:** live + clean-testnet.
 - **Command:**
   ```bash
   bun run migration -- phase deploy-v2 --network sepolia
@@ -100,22 +97,17 @@ Phase numbering matches the console output of the `fork full` orchestrator in
 The deferred v1-owner transactions point the v1 `.eth` resolver at `ENSV2Resolver` and authorize the
 reverse adapters, including `DefaultReverseRegistrarAdapter` when HCA is enabled.
 
-On an HCA-enabled network, phase 1 deploys `HCAOwnerAndSessionValidator`, `StandaloneHCAFactory`,
-`HCAUpgradeSet`, and `StandaloneHCAImplementation` — the shared infrastructure only. Individual
-owner-bound HCAs remain counterfactual and are deployed lazily through `StandaloneHCAFactory`.
-Sepolia defaults to the fixed Rhinestone intent executor and production USDC addresses in
-[`script/deploy-constants.ts`](../script/deploy-constants.ts); local, test, and clean-testnet
-deployments use local mock infrastructure. The `HCA_*` address variables are optional overrides.
-
-**Updating the HCA stack in place.** `--resume --tags hca` refreshes the shared HCA contracts and
-their reverse adapters inside an existing namespace: it reuses the core deployment records, deploys
-contracts whose bytecode or constructor arguments changed, and prepares replacement-adapter grants
-followed by revocations of every recorded prior adapter. Replay the deferred owner transactions, then
-verify that both replacement adapters are controllers and every superseded adapter is not.
+HCA deploys as shared infrastructure only — the validator, factory, upgrade set and standalone
+implementation. Individual owner-bound HCAs stay counterfactual and are created lazily through the
+factory. Sepolia uses the fixed Rhinestone intent executor and production USDC addresses from
+[`script/deploy-constants.ts`](../script/deploy-constants.ts), overridable through the `HCA_*`
+variables; local, test and clean-testnet deployments use mocks. `--resume --tags hca` refreshes that
+stack inside an existing namespace, redeploying only what changed and preparing grants for the
+replacement reverse adapters plus revocations of every prior one — replay the deferred owner
+transactions afterwards.
 
 ### Phase 2: initial pre-migration
 
-- **Applies to:** live + clean-testnet.
 - **Command:**
   ```bash
   bun run migration -- premigration run --network sepolia \
@@ -135,7 +127,6 @@ If you seeded a fixture corpus, run this a second time against its own CSV and w
 
 ### Phase 3: disable v1 registrars
 
-- **Applies to:** live + clean-testnet.
 - **Command:**
   ```bash
   bun run migration -- phase disable-v1-registrars --network sepolia \
@@ -169,15 +160,12 @@ If you seeded a fixture corpus, run this a second time against its own CSV and w
   the grant; everything else is listed as `v1-owned, outside migration remit` and left enabled.
 
 > **Use an archival RPC.** Each surface's controller history is read from its events across the whole
-> chain. An uncapped archival endpoint reads each surface in one request. Providers that cap
-> `eth_getLogs` by block span or result count (free tiers commonly at 1k–10k blocks) still complete
-> and return the same controllers, but cost hundreds of requests and several minutes. A refusal that
-> persists at the smallest span, or a fork whose history predates its fork block, **fails** both
-> commands rather than falling back to a partial audit.
+> chain — one request per surface on an uncapped endpoint, hundreds and several minutes on one that
+> caps `eth_getLogs`. An endpoint that refuses even the smallest span, or a fork whose history
+> predates its fork block, **fails** both commands rather than auditing partially.
 
 ### Phase 4: authorize ETHRenewerV1
 
-- **Applies to:** live + clean-testnet.
 - **Command:**
   ```bash
   bun run migration -- phase authorize-v1-renewer --network sepolia
@@ -199,7 +187,6 @@ If you seeded a fixture corpus, run this a second time against its own CSV and w
 
 ### Phase 5: final pre-migration sync
 
-- **Applies to:** live + clean-testnet.
 - **Command:**
   ```bash
   bun run migration -- premigration run --network sepolia \
@@ -218,7 +205,6 @@ a fresh `--work-dir`; the corpus is frozen by then, so the file does not need re
 
 ### Phase 6: enable the v2 controller
 
-- **Applies to:** live + clean-testnet.
 - **Command:** four owner-gated steps, **in order**, then verify:
   ```bash
   bun run migration -- phase disable-batch-registrar          --network sepolia
@@ -234,19 +220,17 @@ a fresh `--work-dir`; the corpus is frozen by then, so the file does not need re
 - **Keys / args:** registry root-role admin key (`OWNER_KEY`, falls back to `DEPLOYER_KEY`) for
   `disable-batch-registrar` and `enable-v2-registrar`; v1 owner key for the `activate-v1-*` steps. The
   owner-gated and v1-owner steps accept `--calldata-only` for a multisig. On testnets
-  `TestnetV1PremigrationRegistrar` keeps its roles, re-authorized by `activate-v1-handoff-controllers`
-  (the individual steps are also available as `activate-v1-graveyard` and
-  `authorize-testnet-v1-premigration-registrar`).
+  `TestnetV1PremigrationRegistrar` keeps its roles, re-authorized by
+  `activate-v1-handoff-controllers`.
 - **Result:** `BatchRegistrar` roles revoked (pre-migration seeding ends); `Graveyard` (+ testnet
   helper) authorized as v1 controllers; v1 `BaseRegistrar` ownership transferred to `ETHRenewerV1`
   (final lock-down); `ETHRegistrar` granted `REGISTRAR | RENEW` on the v2 `ETHRegistry` — live v2
   registrations open. `verify-v2-registrar` confirms the grant.
 
-These handoff grants are the last step to touch v1 authorizations, so `verify-v1-registrars-disabled`
-is re-run here to assert the final set: only the active deployment's contracts may hold a v1 grant.
-`fork full` runs this assertion automatically. It is the check that catches a superseded deployment's
-controller surviving the freeze; the phase 3 registration smoke test cannot see one, because it only
-exercises the official registrar controller's path.
+These grants are the last step to touch v1 authorizations, so `verify-v1-registrars-disabled` runs
+again here to assert the final set: only the active deployment's contracts may hold a v1 grant. It is
+what catches a superseded deployment's controller surviving the freeze, which the phase 3 smoke test
+cannot see — that only exercises the official registrar controller's path.
 
 ### Phase 7: switch the Universal Resolver to v2
 
@@ -342,28 +326,18 @@ sample, not a real export.
 
 ### Run the phases
 
-Run the phases in order; each links to its entry in [Phases](#phases) for the exact command,
-prerequisites, and result:
+Run [phases 1–7](#phases) in order, each with its own `--work-dir`. Four things are particular to
+this path:
 
-1. [Phase 1 — deploy fresh v2](#phase-1-deploy-v2-contracts), recording v1-owner txs with
-   `--defer-v1-owner-transactions --deferred-v1-owner-transactions-file .dev/sepolia-live/phase1-v1owner.jsonl`
-   and replaying the resolver update and reverse-adapter grants via
-   `phase execute-owner-txs --role v1Owner`.
-   Then, *(optional)* [seed the ENSv1 test fixture corpus](#ensv1-test-fixture-corpus):
-   `fixture fund-actors` → `fixture seed-v1` → `fixture verify-v1`. If the names should belong to a
-   tester, pass `--fixture-owner-key` to *both* of the first two — it decides which accounts sign the
-   seeding, so the funding step has to see it as well. **This must sit after phase 1**, which deploys
-   the `MigrationHelper` the corpus approves, **and before phase 3**, which freezes v1 registration.
-2. [Phase 2 — initial pre-migration](#phase-2-initial-pre-migration) (`--work-dir .dev/sepolia-live/premig-1`).
-   Pass the fixture label CSV alongside the real export if the corpus was seeded.
-3. [Phase 3 — freeze v1 registrations](#phase-3-disable-v1-registrars) (`--private-key $SEPOLIA_V1_OWNER_KEY`).
-4. [Phase 4 — keep names renewable](#phase-4-authorize-ethrenewerv1). With an EOA v1 owner on Sepolia
-   you can run phases 3 and 4 back-to-back, so the renewal gap is small.
-5. [Phase 5 — final sync](#phase-5-final-pre-migration-sync) from a fresh post-freeze CSV
-   (`--work-dir .dev/sepolia-live/premig-2`).
-6. [Phase 6 — enable the v2 controller](#phase-6-enable-the-v2-controller).
-7. [Phase 7 — resolution cutover](#phase-7-switch-the-universal-resolver-to-v2): sepolia is a reuse
-   network, so only `upgrade-managed-urp` + `verify-urp` run.
+- **Phase 1** cannot sign as the v1 owner, so record those transactions with
+  `--defer-v1-owner-transactions --deferred-v1-owner-transactions-file .dev/sepolia-live/phase1-v1owner.jsonl`
+  and replay them with `phase execute-owner-txs --role v1Owner`.
+- **Between phases 1 and 3**, optionally
+  [seed the ENSv1 test fixture corpus](#ensv1-test-fixture-corpus) and pass its label CSV to phases 2
+  and 5 alongside the real export.
+- **Phases 3 and 4** run back-to-back, because the v1 owner is an EOA here — so the renewal gap is
+  seconds rather than however long a multisig takes.
+- **Phase 7** skips `switch-urp-to-managed`: sepolia is a reuse network.
 
 This runbook assumes a first migration. On a repeat deploy the order is unchanged but extra steps
 apply — see
@@ -393,22 +367,18 @@ export ETHERSCAN_API_KEY=<etherscan v2 api key>   # one key covers all chains; n
 bun run verify:sepolia                            # → verify:mainnet for the mainnet set
 ```
 
-A `clean-testnet` namespace also carries the ENSv1 stack it deployed, under
-`deployments/v1/<namespace>`. Both sets are verified: the command picks up that tree whenever it
-exists and submits it as a second pass. `--skip-v1` limits the run to v2. Pass the namespace as the
-network for a clean testnet — the chain is read from the artifacts, not from a network config:
+A `clean-testnet` namespace also carries the ENSv1 stack it deployed under `deployments/v1/<namespace>`;
+both sets are verified, and `--skip-v1` limits the run to v2. Pass the namespace as the network — the
+chain is read from the artifacts, not from a network config:
 
 ```bash
 bun run verify -- --network sepolia-clean-<timestamp>
 ```
 
-Verification is idempotent and re-runnable: contracts already verified on a backend are detected and
-skipped. `--etherscan-only` and `--sourcify-only` limit the run to one backend, and
-`--sourcify-server <url>` points at a self-hosted Sourcify. Any other flag passes through to
-`rocketh-verify` (e.g. `bun run verify -- --network sepolia --etherscan-only`).
-
-A contract that fails Sourcify verification is reported by name and the command exits non-zero; the
-run continues through the rest of the set first, so one failure does not hide the others.
+Re-running is safe: contracts already verified on a backend are skipped. `--etherscan-only`,
+`--sourcify-only` and `--sourcify-server <url>` narrow or redirect the run; any other flag passes
+through to `rocketh-verify`. A failure is reported by name and exits non-zero only after the rest of
+the set has been attempted, so one failure does not hide the others.
 
 ## ENSv1 test fixture corpus
 
@@ -418,36 +388,26 @@ state — wrapped or unwrapped, particular fuses burned, particular resolver and
 claims, parent/child hierarchies — and most of the labels are then reserved on v2 by the ordinary
 pre-migration phases.
 
-The corpus seeds v1 state and gets labels reserved. It does **not** migrate names: migrating a name is
-a manual action its owner takes whenever they choose, and no phase performs it. Seeded names can be
-[registered to a tester's wallet](#choosing-who-owns-the-seeded-names) so that owner is a person
-rather than a throwaway key.
-
-This is test scaffolding. It is refused against live mainnet, and nothing in the canonical phases
-depends on it.
+It seeds and reserves; it does **not** migrate. Migrating a name is a manual action its owner takes
+whenever they choose, so seeded names can be
+[registered to a tester's wallet](#choosing-who-owns-the-seeded-names) for a person to migrate by
+hand. This is test scaffolding: it is refused against live mainnet, and nothing in the canonical
+phases depends on it.
 
 ### Input data
 
-The corpus ships with the repo as `contracts/fixtures/migration-fixture.tgz`. It expands to about
-54MB, so the archive is tracked and the working copy is not: `postinstall` unpacks it alongside the
-other CSV input, which is gitignored.
+The corpus ships as `contracts/fixtures/migration-fixture.tgz` and expands to tens of megabytes of
+scenario JSONL, so the archive is tracked and the working copy is not. `bun install` unpacks it to
+`csv-data/migration-fixture/weighted-scenarios.jsonl` — one scenario per line, and the whole corpus:
+the label list pre-migration reserves is derived from it, not shipped beside it.
 
-```
-csv-data/migration-fixture/
-  weighted-scenarios.jsonl    # one scenario per line, ~54MB
-```
-
-`bun install` does this. To unpack it by hand — after replacing the archive, or if a fresh checkout
-skipped lifecycle scripts — run `bun run fixtures:extract` from the repo root. It re-extracts only
-when the archive is newer than what was unpacked, so it is cheap to run repeatedly. To repack a
+`bun run fixtures:extract` unpacks it by hand, after replacing the archive or when a checkout skipped
+lifecycle scripts; it re-extracts only when the archive is newer than what was unpacked. To repack a
 changed corpus:
 
 ```bash
 cd contracts/csv-data && tar czf ../fixtures/migration-fixture.tgz migration-fixture
 ```
-
-The scenario file is the whole corpus — the label list pre-migration reserves is derived from it, not
-shipped beside it.
 
 ### Choosing a cohort
 
@@ -468,26 +428,26 @@ controller's minimum. `fixture verify` applies the same check offline, so a coho
 before a run starts. Every `live_now` scenario passes it.
 
 > **Reverse records are shared.** A reverse node derives from the account that claims it, so
-> scenarios claiming from the same account all write the same node and only the last survives. Which
-> claims collide therefore depends on the layout: by default an alias is an account; with a
-> [nominated wallet](#choosing-who-owns-the-seeded-names) the three owner aliases are one account, so
-> claims that were distinct now overwrite each other. Both `verify` and seeding report the overlap,
-> counted per account. Nothing else the corpus shapes or checks depends on it, and no migration route
-> reads a reverse record.
+> scenarios claiming from one account all write the same node and only the last survives. Which
+> claims collide depends on the layout: an alias is normally its own account, but a
+> [nominated wallet](#choosing-who-owns-the-seeded-names) makes the three owner aliases one, so claims
+> that were distinct start overwriting each other. `verify` and seeding both report the overlap per
+> account. Nothing else the corpus shapes or checks depends on it, and no migration route reads a
+> reverse record.
 
-`--fixture-scenarios live_now --fixture-replicas-per-vector 4` is the recommended default: it covers every scenario
-the public network can express, several times over, without the long tail of replicas that adds
-registration cost but no new behaviour.
-
-`--fixture-scenarios` filters on each scenario's `execution.scenario` — whether it can run on a public network
-at all. That is a separate axis from the v2 state a scenario declares, which is what decides
-[whether its label gets reserved](#reserving-the-fixture-labels-on-v2); neither filters the other, so
+`--fixture-scenarios live_now --fixture-replicas-per-vector 4` is the recommended default: every
+scenario the public network can express, several times over, without the long tail of replicas that
+adds registration cost but no new behaviour. It filters on whether a scenario can run on a public
+network at all — a separate axis from the v2 state a scenario declares, which is what decides
+[whether its label gets reserved](#reserving-the-fixture-labels-on-v2). Neither filters the other, so
 a `live_now` cohort still contains names meant to stay unreserved.
 
 Always dry-run the selection first. `verify` sends nothing — it parses the corpus, checks the replica
 contract, and plans every scenario's calls, so an unsupported action or an unresolvable reference
 surfaces before anything touches a chain. It still derives the actor addresses the plan refers to, so
-it needs the actor mnemonic and a network RPC variable set:
+it needs the actor mnemonic and a network RPC variable set, and the same
+[`--fixture-owner-key`](#choosing-who-owns-the-seeded-names) seeding will get — otherwise it previews
+the default layout rather than the run you are about to make.
 
 ```bash
 export MIGRATION_FIXTURE_ACTOR_MNEMONIC="<dedicated fixture mnemonic>"
@@ -497,13 +457,6 @@ bun run migration -- fixture verify --network sepolia \
   --fixture-scenarios live_now --fixture-replicas-per-vector 4
 ```
 
-**Dry-run the layout you intend to seed.** `verify` takes `--fixture-owner-key` for the same reason
-`fund-actors` does: nominating a wallet decides which accounts the owner aliases resolve to, and so
-which plan there is to preview. Pass it and the preview is the run you are about to make. Omit it and
-the preview is the [default three-owner layout](#choosing-who-owns-the-seeded-names), whatever key
-seeding is later given. The reported `owner` is the wallet the plan registers to, and `null` when no
-wallet is nominated.
-
 Planning is not a state check. It confirms every call can be *built*; whether the resulting state is
 reachable on-chain is what [`verify-v1`](#checking-the-shaped-state) answers, after seeding.
 
@@ -512,11 +465,9 @@ reachable on-chain is what [`verify-v1`](#checking-the-shaped-state) answers, af
 Requires `bun run compile` first, a funded operator key, and a dedicated actor mnemonic
 (`MIGRATION_FIXTURE_ACTOR_MNEMONIC`) — never a mnemonic used for anything else. Fixture names are
 distributed across five named actors, which need funding because a large share of the state shaping
-must be signed by the holder rather than batched. Those actors hold the names because shaping demands
-it, not because they are meant to keep them — [nominate an owner
-wallet](#choosing-who-owns-the-seeded-names) with `--fixture-owner-key` and the names are registered
-to it instead. `fund-actors` takes that key too, and needs it: it funds whichever accounts seeding
-will sign from, and nominating a wallet is what changes them.
+must be signed by the holder rather than batched. They hold the names because shaping demands it, not
+because they are meant to keep them: [nominate an owner
+wallet](#choosing-who-owns-the-seeded-names) and the names are registered to that instead.
 
 ```bash
 export MIGRATION_FIXTURE_ACTOR_MNEMONIC="<dedicated fixture mnemonic>"
@@ -542,15 +493,14 @@ and replaying setup over it would write against a name that has already moved on
 directory when that happens: it records the batcher that holds the name, and a fresh one deploys
 another and cannot reach it. Drop the name from the selection, or reseed against a fresh chain.
 
-> **Recompile first.** `seed-v1` deploys the corpus's counterparty contracts from
-> `generated/artifacts/`, which is gitignored. A tree compiled before those contracts last changed
-> fails at the first deployment with viem's `AbiEncodingLengthMismatchError` — a stale-ABI mismatch,
-> not a fault in the corpus or the chain.
+> **Recompile first.** The counterparty contracts are deployed from the gitignored
+> `generated/artifacts/`. A tree compiled before they last changed fails at the first deployment with
+> viem's `AbiEncodingLengthMismatchError` — a stale ABI, not a fault in the corpus or the chain.
 
 > **Ordering.** Seeding sits **after [phase 1](#phase-1-deploy-v2-contracts) and before
-> [phase 3](#phase-3-disable-v1-registrars)**. It cannot precede phase 1: much of the corpus approves
-> `MigrationHelper` as an operator while shaping its v1 state, and that is a v2 contract phase 1
-> deploys. It cannot follow phase 3 either, since that freezes v1 registration.
+> [phase 3](#phase-3-disable-v1-registrars)**: much of the corpus approves `MigrationHelper` while
+> shaping its v1 state, and that is a v2 contract phase 1 deploys, while phase 3 freezes the v1
+> registration seeding needs.
 
 ### Checking the shaped state
 
@@ -575,83 +525,77 @@ It takes no owner option of its own. Each actor alias is resolved against the ad
 run recorded in `<work-dir>/fixture-run.json`, so a cohort registered to a [nominated
 wallet](#choosing-who-owns-the-seeded-names) is checked against that wallet.
 
-> **Known-bad vectors — exclude them from the cohort.** Some scenarios declare `CAN_EXTEND_EXPIRY` on
-> a `.eth` 2LD, which cannot be satisfied on-chain: the fuse is parent-controlled, and `wrapETH2LD`
-> always burns `PARENT_CANNOT_CONTROL`, so nothing can set it afterwards. Fuses are compared exactly,
-> so `verify-v1` fails on any cohort containing one. `fixture verify` does not catch them — the plan
-> is buildable; only the chain rejects it.
->
-> 38 of the 761 distinct `live_now` vectors are affected; their ids all begin `3W-`, `FE-` or `PW-`
-> (most vectors under those prefixes are fine — the report names the exact ones). Because
-> `--fixture-replicas-per-vector` sorts by scenario id, `--fixture-limit` takes an alphabetical prefix that starts on
-> an affected vector: ten of the first forty. Standalone this is a report you can read past;
-> [in a rehearsal it aborts the run](#in-a-rehearsal). Until the corpus is fixed, pin the cohort with
-> `--fixture-ids` from a list the affected vectors are excluded from.
+> **Known-bad vectors — exclude them from the cohort.** A few scenarios declare `CAN_EXTEND_EXPIRY` on
+> a `.eth` 2LD, which no chain can satisfy: the fuse is parent-controlled and `wrapETH2LD` always
+> burns `PARENT_CANNOT_CONTROL`, so nothing can set it afterwards. Fuses are compared exactly, so
+> `verify-v1` fails on any cohort containing one, and `fixture verify` does not catch them — the plan
+> is buildable; only the chain rejects it. Their ids begin `3W-`, `FE-` or `PW-`, and the verification
+> report names the exact ones. A `--fixture-limit` cohort takes an alphabetical prefix of the scenario
+> ids and so tends to include some; pin the cohort with `--fixture-ids` instead. Standalone this is a
+> report you can read past — [in a rehearsal it aborts the run](#in-a-rehearsal).
 
 ### Choosing who owns the seeded names
 
 By default the corpus is owned by the five actor accounts the mnemonic derives, which is fine when
-nobody but the tooling needs to touch it. To put it in a tester's hands, nominate the wallet with
-`--fixture-owner-key` and seeding shapes every name into it rather than into a mnemonic account.
-Every command up to and including registration takes the key, and each needs it: the dry run to
-preview this layout rather than the default one, funding to top up the wallet that will sign, and
-seeding to register to it.
+nobody but the tooling needs to touch it. To put it in a tester's hands, nominate that wallet with
+`--fixture-owner-key` and seeding shapes every name into it instead.
+
+It is a **key**, not an address, and that is the whole trick. Shaping a name means signing as its
+owner — reverse claims, operator approvals, unwraps, records written after the name leaves the
+batcher — so an owner we can sign for can be the tester from the moment the batcher lets go. Nothing
+is handed over afterwards, so nothing can refuse to be: names carrying `CANNOT_TRANSFER`, which no
+transfer could ever have moved, are the tester's on the same terms as the rest, and a subname comes
+with the name above it, so it can actually be migrated.
+
+Pass it to `fixture verify`, `fund-actors` and `seed-v1` alike — it decides which accounts the owner
+aliases resolve to, so it is what the dry run previews, what funding tops up, and what registration
+registers to. `fork full` and `clean-testnet` take it too. Export `MIGRATION_FIXTURE_OWNER_KEY` to
+avoid repeating it. Nothing after registration takes it: `verify-v1` resolves each alias against the
+addresses the seeding run recorded, and no command can change who owns a name once it is seeded.
 
 ```bash
-bun run migration -- fixture verify --network sepolia \
-  --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
-  --fixture-scenarios live_now --fixture-replicas-per-vector 4 \
-  --fixture-owner-key 0x<tester key>
-
-bun run migration -- fixture fund-actors --network sepolia \
-  --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
-  --fixture-owner-key 0x<tester key>
-
 bun run migration -- fixture seed-v1 --network sepolia \
   --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
   --fixture-scenarios live_now --fixture-replicas-per-vector 4 \
   --fixture-owner-key 0x<tester key>
 ```
 
-Export `MIGRATION_FIXTURE_OWNER_KEY` instead if you would rather not repeat it; all three read it.
-Nothing after registration takes it: `verify-v1` resolves each alias against the addresses the
-seeding run recorded, and no command can change who owns a name once it is seeded.
-
-`fork full` and `clean-testnet` take the same flag. It is a **key**, not an address, and that is the
-whole trick: shaping a name means signing as its owner — reverse claims, operator approvals, unwraps,
-records written after the name leaves the batcher — so an owner we can sign for can be the tester
-from the moment the name leaves the batcher. Nothing is transferred once seeding is done with a name,
-which means nothing can refuse to be: the
-196 names carrying `CANNOT_TRANSFER`, which no transfer could ever have moved, are the tester's on
-the same terms as every other name. Subnames come with the name above them, so they can actually be
-migrated.
-
 The key covers `owner_a`, `owner_b` and `owner_c` — every alias the corpus ever names as an owner.
 `operator` and `attacker` stay on the mnemonic, because each is only meaningful as an address the
-owner is *not*.
+owner is *not*, and a key that is one of them is refused: a tenth of the corpus migrates as the
+operator or the attacker to prove that caller is turned away, and giving the owner their key would
+make those calls authorised while verification, reading the same accounts, still passed.
+
+The operator key (`--fixture-private-key`) is separate and still needed — it pays for the batcher and
+the registrations. Only ownership moves to the nominated wallet, and every name still reaches it
+through the batcher, which does the commit/reveal in bulk and passes the name on while its state is
+being shaped, before any fuse that would refuse a transfer is burned.
 
 > **What one wallet costs.** Collapsing the three owner aliases onto one account means the scenarios
-> that turn on owners differing no longer do: 356 `transfer_registrant` steps become self-transfers,
-> 2,034 scenarios name an `alternate_owner` that is now the owner itself, and 16 of the 48 helper
-> batches stop spanning more than one owner — so `MigrationHelper`'s per-owner grouping goes
-> unexercised. Nothing fails; the coverage is simply narrower. Seed without the flag when the point
-> is to exercise the migration paths rather than to hand someone a wallet.
+> that turn on owners differing no longer do: `transfer_registrant` steps become self-transfers, an
+> `alternate_owner` becomes the owner itself, and a third of the helper batches stop spanning more
+> than one owner, so `MigrationHelper`'s per-owner grouping goes unexercised. Nothing fails; the
+> coverage is simply narrower. Seed without the flag when the point is to exercise the migration
+> paths rather than to hand someone a wallet.
 
-The operator key (`--fixture-private-key`) is separate and still needed: it pays for the batcher and
-the registrations. Only ownership moves to the nominated wallet.
+> **Operator approvals belong to an account, not a name.** Some scenarios expect migration to revert
+> because the holder never approved `MigrationHelper`; many more grant it `setApprovalForAll` while
+> shaping their own state. That approval covers every name the granting account holds on the same
+> token and is never revoked, so seeding both groups together leaves the first approved and its guard
+> unexercised. This is a property of the corpus rather than of one wallet — every scenario relying on
+> the guard shares its owner alias with one that grants, so a whole-corpus run loses it with or
+> without `--fixture-owner-key`. Seed those scenarios in a cohort of their own when the guard is the
+> point; nothing else detects it, since `verify-v1` reads names, not approvals.
 
-> **Registration still goes through the batcher.** Every name is registered to the batching helper,
-> which does the commit/reveal in bulk, and moves to its owner while its state is being shaped — before
-> any fuse that would refuse a transfer is burned. The wallet therefore holds the name by the time
-> seeding finishes with it, with no handover afterwards. A run interrupted between the two leaves the
-> name on the batcher and part-shaped, which is the case the resume guard refuses above.
-
-> **Fund the nominated wallet, not the accounts it replaces.** On a live chain `fund-actors` is the
-> only thing that puts gas where seeding needs it. Give the key to `seed-v1` alone and funding tops up
-> three mnemonic accounts that will never sign anything, while the wallet that signs everything starts
-> empty: seeding then runs out of gas part-way through a name it has already registered, and that name
-> is part-shaped, which the resume guard refuses to replay. The wallet is funded to three times
-> `--floor` for the same reason — one account is now doing three actors' work.
+> **Fund the wallet that signs.** On a live chain `fund-actors` is the only thing that puts gas where
+> seeding needs it, and it needs the owner key to know where that is. Give the key to `seed-v1` alone
+> and funding tops up three mnemonic accounts that will never sign anything while the wallet doing the
+> work starts empty — seeding then runs out of gas part-way through a name it has already registered,
+> leaving it part-shaped, which the resume guard refuses to replay. The wallet is funded to three
+> times `--floor` for the same reason: one account is now doing three actors' work. Nominating the
+> operator key itself is allowed, but then there is nowhere to fund it from — `fund-actors` reports
+> the shortfall and stops rather than sending an account its own money, so top that one up from
+> outside the run.
 
 ### Reserving the fixture labels on v2
 
@@ -699,33 +643,28 @@ bun run migration -- fork full --network sepolia \
   --fixture-scenarios live_now --fixture-replicas-per-vector 1 --fixture-limit 40
 ```
 
-The fixture flags are spelled exactly as they are standalone — every one carries the `--fixture-`
-prefix, so a cohort selected on one is selected the same way on the other, and none of them can be
-mistaken for the rehearsal's own `--initial-limit`, `--finish-limit` or signer options. That includes
-`--fixture-owner-key <key>`, which
-[registers the cohort to a tester's wallet](#choosing-who-owns-the-seeded-names).
-Keep a rehearsal cohort small:
-every name is a real commit/reveal registration plus its state-shaping calls, so the whole corpus
-costs far more wall-clock than the rest of the rehearsal put together.
+Every fixture flag is spelled as it is standalone, `--fixture-` prefix and all, so a cohort is
+selected the same way either way and none of them can be mistaken for the rehearsal's own
+`--initial-limit`, `--finish-limit` or signer options. Keep a rehearsal cohort small: every name is a
+real commit/reveal registration plus its state-shaping calls, so the whole corpus costs far more
+wall-clock than the rest of the rehearsal put together.
 
-A rehearsal prepends the fixture labels to its own transformed CSV rather than passing
-`fixture-premigration.csv` to a second pre-migration run, but it reserves the same set. The written
-file is still there for inspection under `<work-dir>/fixture/`. Because both phases read that one CSV,
-a `--resume-from-phase 2` run skips reseeding and keeps the labels the earlier run already prepended.
+A rehearsal prepends the fixture labels to its own transformed CSV rather than running pre-migration
+a second time, reserving the same set. `fixture-premigration.csv` is still written under
+`<work-dir>/fixture/` for inspection, and because both phases read the one CSV, a
+`--resume-from-phase 2` run keeps the labels the earlier run prepended instead of reseeding.
 
-Against a state-controlled RPC (a local fork or a Tenderly virtual testnet) the operator key and the
-actor mnemonic are generated per run and funded directly, so no funded keys are needed; both are
-written under `<work-dir>/fixture/` so a resumed run addresses the same accounts. Generating them also
-avoids the EIP-7702 delegations that the well-known test accounts carry on live chains, which would
-otherwise make ERC-1155 receipt fail. On an RPC without state controls, pass `--fixture-private-key`
-and `--fixture-actor-mnemonic` (or their environment equivalents).
+Against a state-controlled RPC — a local fork or a Tenderly virtual testnet — the operator key and
+actor mnemonic are generated per run, funded directly, and written under `<work-dir>/fixture/` so a
+resumed run addresses the same accounts. No funded keys are needed, and generating them avoids the
+EIP-7702 delegations the well-known test accounts carry on live chains, which would otherwise make
+ERC-1155 receipt fail. Without state controls, pass `--fixture-private-key` and
+`--fixture-actor-mnemonic`.
 
 > **The state check is fatal here.** Standalone, `verify-v1` reports mismatches and exits non-zero,
-> leaving you to decide. In a rehearsal it runs inside the seed stage, so one mismatch throws and
-> takes the whole run down before phase 2 — including a
-> [known-bad vector](#checking-the-shaped-state). The `--fixture-limit 40` cohort above trips it. Pin
-> the cohort with `--fixture-ids` instead; a 60-vector cohort built that way runs end-to-end, with
-> `verify-v1` passing and phases 2 and 5 reserving the labels.
+> leaving you to decide. In a rehearsal it runs inside the seed stage, so one mismatch takes the whole
+> run down before phase 2 — a [known-bad vector](#checking-the-shaped-state) included, which the
+> `--fixture-limit 40` cohort above will contain. Pin the cohort with `--fixture-ids` instead.
 
 ## Rehearsals
 
@@ -831,8 +770,8 @@ Mainnet works the same way (`--network mainnet`; it is a bootstrap URP network).
 - **Phased deploy scripts** — the scripts under [`deploy/`](../deploy/) carry migration tags
   (`migration:phase1:deploy-v2`, `migration:phase5:switch-urp-to-managed`,
   `migration:phase6:upgrade-managed-urp`, `migration:post-cutover:direct-urp-to-v2`) so each on-chain
-  change is bound to a deploy step. The tag strings are stable identifiers and do not track the phase
-  numbering.
+  change is bound to a deploy step. The tags are stable identifiers; the numbers in them are not the
+  phase numbers above.
 
 ### Common options
 
@@ -879,17 +818,17 @@ and idempotency rules.
 | `premigration resume` | Resume pre-migration from the checkpoint |
 | `premigration status` | Print the current pre-migration checkpoint JSON (local; `--work-dir` only) |
 | `premigration verify` | Verify eligible CSV names were reserved or registered on v2 |
-| `fixture verify` | Offline: validate a fixture selection and plan every scenario's calls. Takes the same `--fixture-owner-key` as `seed-v1`, so the previewed plan is the one seeding will execute |
-| `fixture fund-actors` | Top up the fixture actor accounts from the operator key. Takes the same `--fixture-owner-key` as `seed-v1`, so the wallet that will own the names is the one funded; `--floor` (default 0.5 ETH) is charged per alias, so an account carrying all three owner aliases is topped up to three floors |
+| `fixture verify` | Offline: validate a fixture selection and plan every scenario's calls |
+| `fixture fund-actors` | Top up the accounts seeding will sign from, to `--floor` (default 0.5 ETH) per alias |
 | `fixture deploy-fixtures` | Deploy the fixture batcher and the corpus counterparty contracts |
-| `fixture seed-v1` | Register the ENSv1 fixture corpus, shape each name's pre-migration state, and emit the label subset pre-migration reserves (after phase 1, before phase 3) |
-| `fixture verify-v1` | Read the shaped v1 state back and check it against each scenario (after `seed-v1`) |
-| `phase deploy-v2` | Phase 1: deploy the v2 migration contracts, reverse-registrar adapters, and enabled HCA infrastructure with the registrar deferred; archives any existing namespace and deploys fresh by default (`--resume` continues an interrupted deploy) |
-| `phase reclaim-v1-registrar-ownership` | Re-migration only: reclaim v1 `BaseRegistrar` ownership from a prior deployment's `ETHRenewerV1` back to the v1 owner (run before the phase-1 deferred-tx replay on an already-migrated chain) |
-| `phase disable-v1-registrars` | Phase 3: revoke every v1 authorization (BaseRegistrar + reverse registrars) the active deployment did not grant |
+| `fixture seed-v1` | Register the corpus, shape each name's v1 state, and emit the labels pre-migration reserves |
+| `fixture verify-v1` | Read the shaped v1 state back and check it against each scenario |
+| `phase deploy-v2` | Phase 1: deploy the v2 contracts, reverse adapters and HCA stack, with the registrar grant deferred |
+| `phase reclaim-v1-registrar-ownership` | Re-migration only: reclaim v1 `BaseRegistrar` ownership from a prior `ETHRenewerV1` |
+| `phase disable-v1-registrars` | Phase 3: revoke every v1 authorization the active deployment did not grant |
 | `phase set-v1-reverse-default-resolver` | Point the v1 `ReverseRegistrar` default resolver at the v1 `PublicResolver` (v1-owner write) |
 | `phase verify-v1-registrars-disabled` | Verify no v1 authorization outside the active deployment is enabled |
-| `phase authorize-v1-renewer` | Phase 4: authorize `ETHRenewerV1` as a v1 controller so unmigrated names stay renewable |
+| `phase authorize-v1-renewer` | Phase 4: authorize `ETHRenewerV1` so unmigrated names stay renewable |
 | `phase execute-owner-txs` | Execute prepared owner transactions from a JSONL file (optionally filtered by `--role`) |
 | `phase disable-batch-registrar` | Phase 6: revoke registrar/renew roles from `BatchRegistrar` |
 | `phase verify-batch-registrar-disabled` | Verify `BatchRegistrar` no longer has registrar/renew roles |
@@ -897,11 +836,11 @@ and idempotency rules.
 | `phase activate-v1-handoff-controllers` | Phase 6: authorize `Graveyard` + testnet helper as v1 controllers |
 | `phase activate-v1-graveyard` | Phase 6 (individual): authorize `Graveyard` only |
 | `phase authorize-testnet-v1-premigration-registrar` | Phase 6 (individual, testnet): authorize the testnet premigration helper |
-| `phase activate-v1-renewer` | Phase 6: transfer v1 `BaseRegistrar` ownership to `ETHRenewerV1` (final lock-down) |
+| `phase activate-v1-renewer` | Phase 6: transfer v1 `BaseRegistrar` ownership to `ETHRenewerV1` |
 | `phase enable-v2-registrar` | Phase 6: grant registrar/renew roles to `ETHRegistrar` |
 | `phase verify-v2-registrar` | Verify `ETHRegistrar` has registrar/renew roles |
 | `phase switch-urp-to-managed` | Phase 7 (bootstrap only): point the top URP at the managed URP |
-| `phase upgrade-managed-urp` | Phase 7: upgrade the managed URP to `UniversalResolverV2` (resolution cutover) |
+| `phase upgrade-managed-urp` | Phase 7: upgrade the managed URP to `UniversalResolverV2` — the resolution cutover |
 | `phase verify-urp` | Verify top and managed URP implementations |
 | `fork full` | Run the full phased migration rehearsal against an Anvil fork (or a Tenderly fork with `--direct`) |
 | `clean-testnet` | Deploy fresh testnet v1 contracts and run the full phased migration (sepolia only) |
@@ -965,7 +904,7 @@ role-specific variables are tried in order.
   CSV format, continuity expiry, checkpoints, verification.
 - [universalResolver.md](./universalResolver.md) — the URP proxy chain behind phase 7, and the
   post-cutover step.
-- [prepareMigration.md](./prepareMigration.md) — the non-phased, all-at-once role hand-off script that
-  phase 6 supersedes.
+- [prepareMigration.md](./prepareMigration.md) — the non-phased, all-at-once role hand-off; phase 6 is
+  the phased equivalent.
 - [deployments/README.md](../deployments/README.md) — deployment artifact layout, namespace naming,
   and the idempotency rule for fresh re-deploys.

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -60,6 +60,7 @@
     "coverage:hardhat": "hardhat compile --coverage && COVERAGE=1 vitest run",
     "coverage:reports": "bun ./script/coverage.ts",
     "coverage:upload": "bun ./script/uploadCoverage.ts",
+    "coverage:notify": "bun ./script/uploadCoverage.ts --notify",
     "coverage": "bun run coverage:forge && bun run coverage:hardhat && bun run coverage:reports",
     "clean": "forge clean && hardhat clean && rm -rf coverage/",
     "devnet": "bun run compile && bun ./script/runDevnet.ts",

--- a/contracts/script/abis.ts
+++ b/contracts/script/abis.ts
@@ -1,0 +1,140 @@
+import { Artifact_BaseRegistrarImplementation } from "generated/artifacts/BaseRegistrarImplementation.js";
+import { Artifact_ENSRegistry } from "generated/artifacts/ENSRegistry.js";
+import { Artifact_ETHRegistrarController } from "generated/artifacts/ETHRegistrarController.js";
+import { Artifact_ETHRenewerV1 } from "generated/artifacts/ETHRenewerV1.js";
+import { Artifact_NameWrapper } from "generated/artifacts/NameWrapper.js";
+import { Artifact_PermissionedRegistry } from "generated/artifacts/PermissionedRegistry.js";
+import { Artifact_PublicResolver } from "generated/artifacts/PublicResolver.js";
+import { Artifact_ReverseRegistrar } from "generated/artifacts/ReverseRegistrar.js";
+
+/// Single function fragments, taken from the compiled contracts.
+///
+/// The scripts cannot hand a whole artifact ABI to `multicall`: viem infers the
+/// return tuple across every entry of a batch, and a batch of full ABIs
+/// exhausts TypeScript's instantiation budget — the checker abandons the call
+/// and every decoded result downstream degrades to `unknown`. So each call site
+/// gets an ABI holding only what it calls.
+///
+/// Narrow does not have to mean hand-written. `pick` cuts the fragment out of
+/// the generated artifact and keeps its literal type, so arguments and return
+/// values stay precisely typed, the compiled contract remains the only
+/// definition, and a function renamed in Solidity resolves to `never` and fails
+/// the build rather than surviving as a decode error at run time.
+///
+/// Compose with a spread, which preserves those literal types:
+///
+///     const ABI = [...NameWrapper.getData, ...BaseRegistrar.ownerOf] as const;
+function pick<const abi extends readonly unknown[], name extends string>(
+  abi: abi,
+  name: name,
+  /// Required only where the contract overloads the name, since viem cannot
+  /// choose between two arities from one ABI.
+  inputs?: number,
+) {
+  const matches = (abi as readonly any[]).filter(
+    (entry) =>
+      entry.type === "function" &&
+      entry.name === name &&
+      (inputs === undefined || entry.inputs.length === inputs),
+  );
+  // The type says the name exists; this says exactly one shape of it does.
+  // Without it an overload picked by the wrong arity would type fine here and
+  // fail on the first call.
+  if (matches.length !== 1) {
+    throw new Error(
+      `expected exactly one "${name}"${inputs === undefined ? "" : `/${inputs}`} fragment, found ${matches.length}`,
+    );
+  }
+  return matches as Extract<abi[number], { name: name; type: "function" }>[];
+}
+
+const BASE_REGISTRAR = Artifact_BaseRegistrarImplementation.abi;
+const NAME_WRAPPER = Artifact_NameWrapper.abi;
+const REGISTRY = Artifact_ENSRegistry.abi;
+const RESOLVER = Artifact_PublicResolver.abi;
+const CONTROLLER = Artifact_ETHRegistrarController.abi;
+const REVERSE = Artifact_ReverseRegistrar.abi;
+const RENEWER = Artifact_ETHRenewerV1.abi;
+const V2_REGISTRY = Artifact_PermissionedRegistry.abi;
+
+/// The v1 `.eth` registrar: an ERC-721 plus its own registration surface.
+export const BaseRegistrar = {
+  ownerOf: pick(BASE_REGISTRAR, "ownerOf"),
+  transferFrom: pick(BASE_REGISTRAR, "transferFrom"),
+  safeTransferFrom: pick(BASE_REGISTRAR, "safeTransferFrom", 3),
+  setApprovalForAll: pick(BASE_REGISTRAR, "setApprovalForAll"),
+  isApprovedForAll: pick(BASE_REGISTRAR, "isApprovedForAll"),
+  nameExpires: pick(BASE_REGISTRAR, "nameExpires"),
+  /// Points the registry record at an owner. Authorised by the token, so the
+  /// holder can aim it anywhere — including at an address that never signs.
+  reclaim: pick(BASE_REGISTRAR, "reclaim"),
+} as const;
+
+export const NameWrapper = {
+  /// Owner, fuses and expiry in one read, all three normalised for expiry —
+  /// which is the reading the wrapper's own transfer guard acts on.
+  getData: pick(NAME_WRAPPER, "getData"),
+  ownerOf: pick(NAME_WRAPPER, "ownerOf"),
+  safeTransferFrom: pick(NAME_WRAPPER, "safeTransferFrom", 5),
+  setApprovalForAll: pick(NAME_WRAPPER, "setApprovalForAll"),
+  isApprovedForAll: pick(NAME_WRAPPER, "isApprovedForAll"),
+  supportsInterface: pick(NAME_WRAPPER, "supportsInterface"),
+  wrapETH2LD: pick(NAME_WRAPPER, "wrapETH2LD"),
+  unwrapETH2LD: pick(NAME_WRAPPER, "unwrapETH2LD"),
+  setSubnodeRecord: pick(NAME_WRAPPER, "setSubnodeRecord"),
+  setFuses: pick(NAME_WRAPPER, "setFuses"),
+  approve: pick(NAME_WRAPPER, "approve"),
+  setResolver: pick(NAME_WRAPPER, "setResolver"),
+  setTTL: pick(NAME_WRAPPER, "setTTL"),
+} as const;
+
+export const EnsRegistry = {
+  owner: pick(REGISTRY, "owner"),
+  resolver: pick(REGISTRY, "resolver"),
+  ttl: pick(REGISTRY, "ttl"),
+  setResolver: pick(REGISTRY, "setResolver"),
+  setTTL: pick(REGISTRY, "setTTL"),
+} as const;
+
+/// The v1 PublicResolver. `addr` and `setAddr` are overloaded, so each arity is
+/// picked separately and a call site takes only the one it means.
+export const PublicResolver = {
+  addr: pick(RESOLVER, "addr", 1),
+  addrMulticoin: pick(RESOLVER, "addr", 2),
+  text: pick(RESOLVER, "text"),
+  contenthash: pick(RESOLVER, "contenthash"),
+  setAddr: pick(RESOLVER, "setAddr", 2),
+  setAddrMulticoin: pick(RESOLVER, "setAddr", 3),
+  setText: pick(RESOLVER, "setText"),
+  setContenthash: pick(RESOLVER, "setContenthash"),
+} as const;
+
+export const EthRegistrarController = {
+  renew: pick(CONTROLLER, "renew"),
+  rentPrice: pick(CONTROLLER, "rentPrice"),
+} as const;
+
+export const ReverseRegistrar = {
+  setName: pick(REVERSE, "setName", 1),
+} as const;
+
+/// Whatever currently owns the v1 BaseRegistrar — the v1 owner directly, or a
+/// renewer holding it on their behalf.
+export const RegistrarOwnership = {
+  owner: pick(RENEWER, "owner"),
+  transferRegistrarOwnership: pick(RENEWER, "transferRegistrarOwnership"),
+} as const;
+
+/// The registrar-ownership pair, composed once because both the phase runner
+/// and the fixture seeder walk the same chain of owners to re-enable the v1
+/// controller.
+export const RegistrarOwnershipAbi = [
+  ...RegistrarOwnership.owner,
+  ...RegistrarOwnership.transferRegistrarOwnership,
+] as const;
+
+/// The v2 registry, as the pre-migration verification reads it.
+export const PermissionedRegistry = {
+  getState: pick(V2_REGISTRY, "getState"),
+  getResolver: pick(V2_REGISTRY, "getResolver"),
+} as const;

--- a/contracts/script/forkBootstrap.ts
+++ b/contracts/script/forkBootstrap.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile, mkdir, copyFile } from "node:fs/promises";
 import { join } from "node:path";
 import { type Address, parseEther } from "viem";
+import { RegistrarOwnership } from "./abis.js";
 
 // v1 contracts on canonical mainnet that v2 deploys and `setup.ts` reference
 // by name through rocketh's `get()`. Pre-populated into the devnet deployments
@@ -56,15 +57,7 @@ const LEGACY_ETH_REGISTRAR_CONTROLLER_ARCHIVE = join(
   "ETHRegistrarController_mainnet_9380471.json",
 );
 
-const OWNER_ABI = [
-  {
-    type: "function",
-    name: "owner",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [{ type: "address" }],
-  },
-] as const;
+const OWNER_ABI = RegistrarOwnership.owner;
 
 type ClientLike = {
   readContract: (args: {

--- a/contracts/script/migration.ts
+++ b/contracts/script/migration.ts
@@ -4657,20 +4657,20 @@ async function fixtureRunOptions(
     deploymentNetwork: base.deploymentNetwork,
     v1DeploymentsDir: base.v1DeploymentsDir,
     v1DeploymentNetwork: base.v1DeploymentNetwork,
-    privateKey,
-    actorMnemonic,
+    fixturePrivateKey: privateKey,
+    fixtureActorMnemonic: actorMnemonic,
     // Seeding registers through the v1 controller. On a chain a previous
     // migration already froze, the corpus cannot be created until that
     // controller is re-authorised, which only the v1 owner can do.
     v1Owner: base.v1Owner,
     v1OwnerKey: opts.v1OwnerPrivateKey,
-    limit: opts.fixtureLimit,
-    tiers: opts.fixtureTiers,
-    scenarios: opts.fixtureScenarios,
-    ids: opts.fixtureIds,
-    replicasPerVector: opts.fixtureReplicasPerVector,
+    fixtureLimit: opts.fixtureLimit,
+    fixtureTiers: opts.fixtureTiers,
+    fixtureScenarios: opts.fixtureScenarios,
+    fixtureIds: opts.fixtureIds,
+    fixtureReplicasPerVector: opts.fixtureReplicasPerVector,
     rpcStateControls: base.useRpcStateControls,
-    handoverTo: opts.fixtureHandoverTo,
+    fixtureHandoverTo: opts.fixtureHandoverTo,
   };
 }
 

--- a/contracts/script/migration.ts
+++ b/contracts/script/migration.ts
@@ -46,7 +46,6 @@ import {
 } from "viem/accounts";
 import { mainnet, sepolia } from "viem/chains";
 import type { AccountDefinition, AccountType, UserConfig } from "rocketh/types";
-import { Artifact_BaseRegistrarImplementation } from "generated/artifacts/BaseRegistrarImplementation.js";
 import { Artifact_BatchRegistrar } from "generated/artifacts/BatchRegistrar.js";
 import { Artifact_PermissionedRegistry } from "generated/artifacts/PermissionedRegistry.js";
 import { Artifact_UpgradableUniversalResolverProxy } from "generated/artifacts/UpgradableUniversalResolverProxy.js";
@@ -1317,6 +1316,53 @@ async function printPreMigrationStatus(opts: { workDir?: string }) {
   }
 }
 
+/// Single-function ABIs for the three reads this verification batches.
+///
+/// The generated artifact ABIs carry every entry the contract declares, and
+/// inferring a multicall's return tuple across a whole batch of them exhausts
+/// the type instantiation budget — the checker gives up on the call and every
+/// result downstream degrades to `unknown`. Naming only the function being
+/// called keeps the inference shallow, and keeps the decoded shape honest
+/// rather than cast into place afterwards.
+const NAME_EXPIRES_ABI = [
+  {
+    type: "function",
+    name: "nameExpires",
+    stateMutability: "view",
+    inputs: [{ name: "id", type: "uint256" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;
+
+const REGISTRY_STATE_ABI = [
+  {
+    type: "function",
+    name: "getState",
+    stateMutability: "view",
+    inputs: [{ name: "anyId", type: "uint256" }],
+    outputs: [
+      {
+        name: "state",
+        type: "tuple",
+        components: [
+          { name: "status", type: "uint8" },
+          { name: "expiry", type: "uint64" },
+          { name: "latestOwner", type: "address" },
+          { name: "tokenId", type: "uint256" },
+          { name: "resource", type: "uint256" },
+        ],
+      },
+    ],
+  },
+  {
+    type: "function",
+    name: "getResolver",
+    stateMutability: "view",
+    inputs: [{ name: "label", type: "string" }],
+    outputs: [{ name: "", type: "address" }],
+  },
+] as const;
+
 async function verifyPreMigration(opts: {
   network: MigrationNetwork;
   rpcUrl: string;
@@ -1392,7 +1438,7 @@ async function verifyPreMigration(opts: {
       allowFailure: true,
       contracts: validBatch.map((label) => ({
         address: baseRegistrar,
-        abi: Artifact_BaseRegistrarImplementation.abi,
+        abi: NAME_EXPIRES_ABI,
         functionName: "nameExpires",
         args: [labelId(label)],
       })),
@@ -1401,7 +1447,7 @@ async function verifyPreMigration(opts: {
       allowFailure: true,
       contracts: validBatch.map((label) => ({
         address: registry.address,
-        abi: Artifact_PermissionedRegistry.abi,
+        abi: REGISTRY_STATE_ABI,
         functionName: "getState",
         args: [labelId(label)],
       })),
@@ -1481,7 +1527,7 @@ async function verifyPreMigration(opts: {
         allowFailure: true,
         contracts: resolverChecks.map((label) => ({
           address: registry.address,
-          abi: Artifact_PermissionedRegistry.abi,
+          abi: REGISTRY_STATE_ABI,
           functionName: "getResolver",
           args: [label],
         })),

--- a/contracts/script/migration.ts
+++ b/contracts/script/migration.ts
@@ -65,6 +65,21 @@ import {
   addFixtureSubcommands,
   runFixtureSeedStage,
 } from "./migrationFixture.js";
+import {
+  BaseRegistrar as BaseRegistrarFragments,
+  PermissionedRegistry as PermissionedRegistryFragments,
+  RegistrarOwnershipAbi,
+} from "./abis.js";
+
+/// v1 and v2 surfaces the phases read and write, each as narrow as its use.
+/// The pre-migration checks batch theirs through multicall, where a full
+/// artifact ABI costs the type checker its inference.
+const NAME_EXPIRES_ABI = BaseRegistrarFragments.nameExpires;
+const REGISTRY_STATE_ABI = [
+  ...PermissionedRegistryFragments.getState,
+  ...PermissionedRegistryFragments.getResolver,
+] as const;
+const PRIOR_RENEWER_ABI = RegistrarOwnershipAbi;
 import { ACTOR_ALIASES, bufferedGas } from "./migrationFixture/config.js";
 import { resolveRegistrarControlRoute } from "./registrarControl.js";
 import {
@@ -1316,53 +1331,6 @@ async function printPreMigrationStatus(opts: { workDir?: string }) {
   }
 }
 
-/// Single-function ABIs for the three reads this verification batches.
-///
-/// The generated artifact ABIs carry every entry the contract declares, and
-/// inferring a multicall's return tuple across a whole batch of them exhausts
-/// the type instantiation budget — the checker gives up on the call and every
-/// result downstream degrades to `unknown`. Naming only the function being
-/// called keeps the inference shallow, and keeps the decoded shape honest
-/// rather than cast into place afterwards.
-const NAME_EXPIRES_ABI = [
-  {
-    type: "function",
-    name: "nameExpires",
-    stateMutability: "view",
-    inputs: [{ name: "id", type: "uint256" }],
-    outputs: [{ name: "", type: "uint256" }],
-  },
-] as const;
-
-const REGISTRY_STATE_ABI = [
-  {
-    type: "function",
-    name: "getState",
-    stateMutability: "view",
-    inputs: [{ name: "anyId", type: "uint256" }],
-    outputs: [
-      {
-        name: "state",
-        type: "tuple",
-        components: [
-          { name: "status", type: "uint8" },
-          { name: "expiry", type: "uint64" },
-          { name: "latestOwner", type: "address" },
-          { name: "tokenId", type: "uint256" },
-          { name: "resource", type: "uint256" },
-        ],
-      },
-    ],
-  },
-  {
-    type: "function",
-    name: "getResolver",
-    stateMutability: "view",
-    inputs: [{ name: "label", type: "string" }],
-    outputs: [{ name: "", type: "address" }],
-  },
-] as const;
-
 async function verifyPreMigration(opts: {
   network: MigrationNetwork;
   rpcUrl: string;
@@ -2493,25 +2461,6 @@ async function activateV1HandoffControllers(opts: {
 
   await activateV1Graveyard(opts);
 }
-
-// Minimal interface of a prior migration's ETHRenewerV1, which holds v1
-// BaseRegistrar ownership once a migration has completed.
-const PRIOR_RENEWER_ABI = [
-  {
-    type: "function",
-    name: "owner",
-    inputs: [],
-    outputs: [{ type: "address" }],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "transferRegistrarOwnership",
-    inputs: [{ name: "newOwner", type: "address" }],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-] as const;
 
 // On a chain that has already completed a migration, the v1 BaseRegistrar is
 // owned by the previous deployment's ETHRenewerV1 contract, so the EOA-signed

--- a/contracts/script/migration.ts
+++ b/contracts/script/migration.ts
@@ -4527,7 +4527,7 @@ export type FixtureRehearsalOptions = {
   fixtureReplicasPerVector?: string;
   fixtureActorMnemonic?: string;
   fixturePrivateKey?: string;
-  fixtureHandoverTo?: string;
+  fixtureOwnerKey?: string;
 };
 
 // The corpus needs an operator account and a set of actor accounts. On a
@@ -4619,7 +4619,7 @@ async function fixtureRunOptions(
     fixtureIds: opts.fixtureIds,
     fixtureReplicasPerVector: opts.fixtureReplicasPerVector,
     rpcStateControls: base.useRpcStateControls,
-    fixtureHandoverTo: opts.fixtureHandoverTo,
+    fixtureOwnerKey: opts.fixtureOwnerKey,
   };
 }
 
@@ -5646,8 +5646,8 @@ function addFixtureRehearsalOptions(
       `Fixture operator key (generated per run ${wording.generated})`,
     )
     .option(
-      "--fixture-handover-to <address>",
-      "Give the seeded fixture names to this wallet once they are checked",
+      "--fixture-owner-key <key>",
+      "Private key of the wallet that should own every seeded fixture name",
     );
 }
 

--- a/contracts/script/migration.ts
+++ b/contracts/script/migration.ts
@@ -4667,7 +4667,7 @@ async function fixtureRunOptions(
     limit: opts.fixtureLimit,
     tiers: opts.fixtureTiers,
     scenarios: opts.fixtureScenarios,
-    fixtureIds: opts.fixtureIds,
+    ids: opts.fixtureIds,
     replicasPerVector: opts.fixtureReplicasPerVector,
     rpcStateControls: base.useRpcStateControls,
     handoverTo: opts.fixtureHandoverTo,
@@ -5659,6 +5659,47 @@ export async function runCleanTestnetFull(opts: RunCleanTestnetFullOptions) {
     ]),
     resumeFromPhase: undefined,
   });
+}
+
+/// The fixture-corpus options a rehearsal accepts.
+///
+/// Defined once because `fork full` and `clean-testnet` take the same set. Two
+/// hand-kept copies drift, and an option that reaches only one of them is
+/// unusable on the other without anyone noticing. The `--fixture-` prefix
+/// stays: a rehearsal has its own `--limit` and its own several keys, so an
+/// unprefixed `--limit` or `--private-key` here would not say which it meant.
+function addFixtureRehearsalOptions(
+  command: Command,
+  wording: { stage: string; generated: string },
+): Command {
+  return command
+    .option(
+      "--fixture-root <path>",
+      `Seed the ENSv1 fixture corpus from this bundle as part of the ${wording.stage}`,
+    )
+    .option(
+      "--fixture-scenarios <list>",
+      "Fixture execution scenarios to include, e.g. live_now",
+    )
+    .option("--fixture-tiers <list>", "Fixture popularity tiers to include")
+    .option("--fixture-ids <list>", "Explicit fixture IDs to include")
+    .option("--fixture-limit <count>", "Cap the number of fixture names")
+    .option(
+      "--fixture-replicas-per-vector <count>",
+      "Keep at most N replicas of each fixture scenario",
+    )
+    .option(
+      "--fixture-actor-mnemonic <mnemonic>",
+      `Dedicated fixture actor mnemonic (generated per run ${wording.generated})`,
+    )
+    .option(
+      "--fixture-private-key <key>",
+      `Fixture operator key (generated per run ${wording.generated})`,
+    )
+    .option(
+      "--fixture-handover-to <address>",
+      "Give the seeded fixture names to this wallet once they are checked",
+    );
 }
 
 function addNetworkOptions(command: Command): Command {
@@ -6829,92 +6870,62 @@ export async function main(argv = process.argv): Promise<void> {
   fork.addCommand(
     addV1DeploymentOptions(
       addDeploymentOptions(
-        addNetworkOptions(
-          new Command("full")
-            .description(
-              "Run the full phased migration rehearsal against an Anvil fork",
-            )
-            .option(
-              "--direct",
-              "Use --rpc-url directly instead of starting Anvil",
-              false,
-            )
-            .option("--port <port>", "Local Anvil port")
-            .requiredOption("--csv-file <path>", "Registration CSV")
-            .option("--batch-size <number>", "Names per pre-migration batch")
-            .option(
-              "--initial-limit <count>",
-              "Optional cap before disabling v1 registrars",
-            )
-            .option(
-              "--finish-limit <count>",
-              "Optional cap after disabling v1 registrars",
-            )
-            .option(
-              "--work-dir <path>",
-              "Directory for fork logs, checkpoints, and generated CSV",
-            )
-            .option(
-              "--resume-from-phase <phase>",
-              "Resume the full rehearsal from phase 2",
-            )
-            .option(
-              "--save-deployments",
-              "Persist deployment JSON files",
-              false,
-            )
-            .option(
-              "--include-testnet-premigration-registrar",
-              "Deploy the testnet v1 premigration registrar helper",
-              false,
-            )
-            .option(
-              "--fixture-root <path>",
-              "Seed the ENSv1 fixture corpus from this bundle as part of the rehearsal",
-            )
-            .option(
-              "--fixture-scenarios <list>",
-              "Fixture execution scenarios to include, e.g. live_now",
-            )
-            .option(
-              "--fixture-tiers <list>",
-              "Fixture popularity tiers to include",
-            )
-            .option("--fixture-ids <list>", "Explicit fixture IDs to include")
-            .option(
-              "--fixture-limit <count>",
-              "Cap the number of fixture names",
-            )
-            .option(
-              "--fixture-replicas-per-vector <count>",
-              "Keep at most N replicas of each fixture scenario",
-            )
-            .option(
-              "--fixture-actor-mnemonic <mnemonic>",
-              "Dedicated fixture actor mnemonic (generated per run on a fork)",
-            )
-            .option(
-              "--fixture-private-key <key>",
-              "Fixture operator key (generated per run on a fork)",
-            )
-            .option(
-              "--fixture-handover-to <address>",
-              "Give the seeded fixture names to this wallet once they are checked",
-            )
-            .option(
-              "--snapshot-file <path>",
-              "Optional file to write a pre-rehearsal snapshot id",
-            )
-            .option("--deployer <address>", "Migration deployer address")
-            .option("--owner <address>", "Migration owner/admin address")
-            .option("--v1-owner <address>", "V1 owner address")
-            .option("--ur-manager <address>", "Managed URP admin address")
-            .option("--debug-rpc", "Log JSON-RPC error responses", false)
-            .option(
-              "--keep-anvil",
-              "Leave the local Anvil process running",
-              false,
-            ),
+        addFixtureRehearsalOptions(
+          addNetworkOptions(
+            new Command("full")
+              .description(
+                "Run the full phased migration rehearsal against an Anvil fork",
+              )
+              .option(
+                "--direct",
+                "Use --rpc-url directly instead of starting Anvil",
+                false,
+              )
+              .option("--port <port>", "Local Anvil port")
+              .requiredOption("--csv-file <path>", "Registration CSV")
+              .option("--batch-size <number>", "Names per pre-migration batch")
+              .option(
+                "--initial-limit <count>",
+                "Optional cap before disabling v1 registrars",
+              )
+              .option(
+                "--finish-limit <count>",
+                "Optional cap after disabling v1 registrars",
+              )
+              .option(
+                "--work-dir <path>",
+                "Directory for fork logs, checkpoints, and generated CSV",
+              )
+              .option(
+                "--resume-from-phase <phase>",
+                "Resume the full rehearsal from phase 2",
+              )
+              .option(
+                "--save-deployments",
+                "Persist deployment JSON files",
+                false,
+              )
+              .option(
+                "--include-testnet-premigration-registrar",
+                "Deploy the testnet v1 premigration registrar helper",
+                false,
+              )
+              .option(
+                "--snapshot-file <path>",
+                "Optional file to write a pre-rehearsal snapshot id",
+              )
+              .option("--deployer <address>", "Migration deployer address")
+              .option("--owner <address>", "Migration owner/admin address")
+              .option("--v1-owner <address>", "V1 owner address")
+              .option("--ur-manager <address>", "Managed URP admin address")
+              .option("--debug-rpc", "Log JSON-RPC error responses", false)
+              .option(
+                "--keep-anvil",
+                "Leave the local Anvil process running",
+                false,
+              ),
+          ),
+          { stage: "rehearsal", generated: "on a fork" },
         ),
       ),
     ).action(async (opts: ForkFullCliOptions) => {
@@ -6951,70 +6962,40 @@ export async function main(argv = process.argv): Promise<void> {
   program.addCommand(
     addV1DeploymentOptions(
       addDeploymentOptions(
-        addNetworkOptions(
-          new Command("clean-testnet")
-            .description(
-              "Deploy fresh testnet v1 contracts and run the full phased migration",
-            )
-            .option(
-              "--csv-file <path>",
-              "Optional registration CSV to seed in addition to generated smoke labels",
-            )
-            .option("--batch-size <number>", "Names per pre-migration batch")
-            .option(
-              "--initial-limit <count>",
-              "Optional cap before disabling v1 registrars",
-            )
-            .option(
-              "--finish-limit <count>",
-              "Optional cap after disabling v1 registrars",
-            )
-            .option(
-              "--work-dir <path>",
-              "Directory for clean deploy logs, checkpoints, and generated CSV",
-            )
-            .option(
-              "--fixture-root <path>",
-              "Seed the ENSv1 fixture corpus from this bundle as part of the run",
-            )
-            .option(
-              "--fixture-scenarios <list>",
-              "Fixture execution scenarios to include, e.g. live_now",
-            )
-            .option(
-              "--fixture-tiers <list>",
-              "Fixture popularity tiers to include",
-            )
-            .option("--fixture-ids <list>", "Explicit fixture IDs to include")
-            .option(
-              "--fixture-limit <count>",
-              "Cap the number of fixture names",
-            )
-            .option(
-              "--fixture-replicas-per-vector <count>",
-              "Keep at most N replicas of each fixture scenario",
-            )
-            .option(
-              "--fixture-actor-mnemonic <mnemonic>",
-              "Dedicated fixture actor mnemonic (generated per run when impersonating)",
-            )
-            .option(
-              "--fixture-private-key <key>",
-              "Fixture operator key (generated per run when impersonating)",
-            )
-            .option(
-              "--fixture-handover-to <address>",
-              "Give the seeded fixture names to this wallet once they are checked",
-            )
-            .option(
-              "--snapshot-file <path>",
-              "Optional file to write a pre-phase snapshot id after v1 deployment",
-            )
-            .option("--deployer <address>", "Migration deployer address")
-            .option("--owner <address>", "Migration owner/admin address")
-            .option("--v1-owner <address>", "V1 owner address")
-            .option("--ur-manager <address>", "Managed URP admin address")
-            .option("--debug-rpc", "Log JSON-RPC error responses", false),
+        addFixtureRehearsalOptions(
+          addNetworkOptions(
+            new Command("clean-testnet")
+              .description(
+                "Deploy fresh testnet v1 contracts and run the full phased migration",
+              )
+              .option(
+                "--csv-file <path>",
+                "Optional registration CSV to seed in addition to generated smoke labels",
+              )
+              .option("--batch-size <number>", "Names per pre-migration batch")
+              .option(
+                "--initial-limit <count>",
+                "Optional cap before disabling v1 registrars",
+              )
+              .option(
+                "--finish-limit <count>",
+                "Optional cap after disabling v1 registrars",
+              )
+              .option(
+                "--work-dir <path>",
+                "Directory for clean deploy logs, checkpoints, and generated CSV",
+              )
+              .option(
+                "--snapshot-file <path>",
+                "Optional file to write a pre-phase snapshot id after v1 deployment",
+              )
+              .option("--deployer <address>", "Migration deployer address")
+              .option("--owner <address>", "Migration owner/admin address")
+              .option("--v1-owner <address>", "V1 owner address")
+              .option("--ur-manager <address>", "Managed URP admin address")
+              .option("--debug-rpc", "Log JSON-RPC error responses", false),
+          ),
+          { stage: "run", generated: "when impersonating" },
         ),
       ),
     ).action(async (opts: CleanTestnetCliOptions) => {

--- a/contracts/script/migration.ts
+++ b/contracts/script/migration.ts
@@ -4532,6 +4532,7 @@ export type FixtureRehearsalOptions = {
   fixtureReplicasPerVector?: string;
   fixtureActorMnemonic?: string;
   fixturePrivateKey?: string;
+  fixtureHandoverTo?: string;
 };
 
 // The corpus needs an operator account and a set of actor accounts. On a
@@ -4623,6 +4624,7 @@ async function fixtureRunOptions(
     fixtureIds: opts.fixtureIds,
     replicasPerVector: opts.fixtureReplicasPerVector,
     rpcStateControls: base.useRpcStateControls,
+    handoverTo: opts.fixtureHandoverTo,
   };
 }
 
@@ -6850,6 +6852,10 @@ export async function main(argv = process.argv): Promise<void> {
               "Fixture operator key (generated per run on a fork)",
             )
             .option(
+              "--fixture-handover-to <address>",
+              "Give the seeded fixture names to this wallet once they are checked",
+            )
+            .option(
               "--snapshot-file <path>",
               "Optional file to write a pre-rehearsal snapshot id",
             )
@@ -6949,6 +6955,10 @@ export async function main(argv = process.argv): Promise<void> {
             .option(
               "--fixture-private-key <key>",
               "Fixture operator key (generated per run when impersonating)",
+            )
+            .option(
+              "--fixture-handover-to <address>",
+              "Give the seeded fixture names to this wallet once they are checked",
             )
             .option(
               "--snapshot-file <path>",

--- a/contracts/script/migrationFixture.ts
+++ b/contracts/script/migrationFixture.ts
@@ -528,28 +528,45 @@ export function assertSeedable(rows: FixtureEnvelope[]): void {
 
 /// Reports the reverse claims a selection cannot all express.
 ///
-/// A reverse node derives from the claimant, and each actor alias is one
-/// account, so every scenario claiming from the same alias writes the same node
-/// and only the last survives. Nothing reads a reverse record back, so this
-/// would otherwise be invisible; it is reported rather than refused because the
-/// overlap is inherent to a fixed actor pool and touches no other state the
-/// corpus shapes or checks.
-function reportReverseClaimOverlap(rows: FixtureEnvelope[]): void {
-  const byClaimant = new Map<string, number>();
+/// A reverse node derives from the claimant account, so every scenario claiming
+/// from the same account writes the same node and only the last survives.
+/// Claims are counted per resolved account rather than per alias: nominating an
+/// owner wallet puts several aliases on one account, and claims those aliases
+/// would have kept apart then collide. Nothing reads a reverse record back, so
+/// this would otherwise be invisible; it is reported rather than refused
+/// because the overlap is inherent to a fixed actor pool and touches no other
+/// state the corpus shapes or checks.
+export function reportReverseClaimOverlap(
+  rows: FixtureEnvelope[],
+  actors: FixtureActor[],
+): void {
+  const addressOf = new Map(
+    actors.map((a) => [a.alias, getAddress(a.account.address)]),
+  );
+  const byAccount = new Map<string, { aliases: string[]; claims: number }>();
   for (const row of rows) {
     for (const step of row.scenario.v1.setup_steps) {
       if (step.action !== "set_reverse_claim") continue;
-      const claimant = String(step.address_actor ?? "").replace("actor.", "");
-      byClaimant.set(claimant, (byClaimant.get(claimant) ?? 0) + 1);
+      const alias = String(step.address_actor ?? "").replace("actor.", "");
+      // An alias outside the actor set shares an account with nothing, so it
+      // is counted under its own name rather than folded in with the others.
+      const key = addressOf.get(alias) ?? `actor.${alias}`;
+      const entry = byAccount.get(key);
+      if (entry) {
+        if (!entry.aliases.includes(alias)) entry.aliases.push(alias);
+        entry.claims += 1;
+      } else {
+        byAccount.set(key, { aliases: [alias], claims: 1 });
+      }
     }
   }
-  const overlapping = [...byClaimant.entries()].filter(([, n]) => n > 1);
+  const overlapping = [...byAccount.values()].filter((e) => e.claims > 1);
   if (!overlapping.length) return;
   const detail = overlapping
-    .map(([claimant, n]) => `${claimant} (${n})`)
+    .map((e) => `${e.aliases.join("+")} (${e.claims})`)
     .join(", ");
   console.warn(
-    `warning: ${overlapping.reduce((a, [, n]) => a + n, 0)} reverse claims share ${overlapping.length} ` +
+    `warning: ${overlapping.reduce((a, e) => a + e.claims, 0)} reverse claims share ${overlapping.length} ` +
       `actor accounts, so only the last claim per account survives: ${detail}`,
   );
 }
@@ -558,7 +575,8 @@ async function verify(opts: CommonOptions): Promise<void> {
   const rows = loadFixture(opts);
   if (!rows.length) throw new Error("fixture selection is empty");
   assertSeedable(rows);
-  reportReverseClaimOverlap(rows);
+  const actors = accounts(opts);
+  reportReverseClaimOverlap(rows, actors);
 
   const ids = new Set<string>();
   const labels = new Set<string>();
@@ -581,9 +599,7 @@ async function verify(opts: CommonOptions): Promise<void> {
   const placeholder = (n: number) =>
     `0x${n.toString(16).padStart(40, "0")}` as Address;
   const ctx: PlanContext = {
-    actors: new Map(
-      accounts(opts).map((a, i) => [a.alias, placeholder(0x1000 + i)]),
-    ),
+    actors: new Map(actors.map((a, i) => [a.alias, placeholder(0x1000 + i)])),
     fixtureContracts: Object.fromEntries(
       FIXTURE_ARTIFACTS.map((f, i) => [f.name, placeholder(0x2000 + i)]),
     ),
@@ -698,9 +714,10 @@ export async function seedV1(
   const rows = loadFixture(opts);
   if (!rows.length) throw new Error("fixture selection is empty");
   assertSeedable(rows);
-  reportReverseClaimOverlap(rows);
 
   const actors = accounts(opts);
+  reportReverseClaimOverlap(rows, actors);
+
   const { chain, client, wallet } = clients(opts);
 
   // Checked before the controller re-enable, which is the run's first write.

--- a/contracts/script/migrationFixture.ts
+++ b/contracts/script/migrationFixture.ts
@@ -131,12 +131,22 @@ function v1Addresses(opts: CommonOptions) {
   };
 }
 
-function refContext(
+/// Resolves the symbolic names the corpus is written in.
+///
+/// Actor identities are taken from `actorAddresses` when the caller holds the
+/// record a seeded run leaves behind. Nominating an owner wallet collapses the
+/// owner aliases onto that one account, so deriving them from the mnemonic
+/// again afterwards would resolve every owner reference to an address the run
+/// never used.
+export function refContext(
   opts: CommonOptions,
   fixtureContracts: Record<string, Address>,
+  actorAddresses?: Record<string, Address>,
 ): RefContext {
   return {
-    actors: new Map(accounts(opts).map((a) => [a.alias, a.account.address])),
+    actors: actorAddresses
+      ? new Map(Object.entries(actorAddresses))
+      : new Map(accounts(opts).map((a) => [a.alias, a.account.address])),
     fixtureContracts,
     v1Address: (name) => v1Deployment(opts, name).address,
     v2Address: (name) => v2Deployment(opts, name).address,
@@ -703,11 +713,13 @@ export async function seedV1(
     existing?.fixtureContracts ?? {},
   );
 
-  // Record the deployed batcher and counterparty contracts before registering
-  // anything. Seeding registers each name to the batcher first, so a run that
-  // fails partway leaves names owned by it; without this the next run would
-  // deploy a second batcher, fail to recognise the first as its own, and refuse
-  // to continue against names it had itself created.
+  // Record the deployed batcher, counterparty contracts and actor identities
+  // before registering anything. Seeding registers each name to the batcher
+  // first, so a run that fails partway leaves names owned by it; without this
+  // the next run would deploy a second batcher, fail to recognise the first as
+  // its own, and refuse to continue against names it had itself created. The
+  // identities are what a resumed run is held to, and what a later read-back
+  // resolves the corpus's actor aliases against.
   const startedAt = new Date().toISOString();
   const seeded: FixtureRunState = existing ?? {
     version: 2,
@@ -723,6 +735,9 @@ export async function seedV1(
   };
   seeded.batcher = batcher;
   seeded.fixtureContracts = fixtureContracts;
+  seeded.actorAddresses = Object.fromEntries(
+    actors.map((a) => [a.alias, a.account.address]),
+  );
   saveRunState(opts, seeded);
 
   const v1 = v1Addresses(opts);
@@ -950,9 +965,6 @@ export async function seedV1(
 
   const state = seeded;
   state.fixtureDigest = fixtureDigest(rows);
-  state.actorAddresses = Object.fromEntries(
-    actors.map((a) => [a.alias, a.account.address]),
-  );
   saveRunState(opts, state);
   const csv = writePremigrationCsv(opts, rows, state);
 
@@ -997,12 +1009,21 @@ export async function verifyV1(opts: CommonOptions): Promise<void> {
       "no seeded names in this selection; widen the selection or seed it first",
     );
   }
+  // Aliases resolve to the accounts the seeding run put the names on, read back
+  // from its record. Deriving them here instead would report every name of an
+  // owner-key run as owned by the wrong address, since that key is nominated on
+  // `seed-v1` alone.
+  if (!Object.keys(state.actorAddresses).length) {
+    throw new Error(
+      `${runStatePath(opts)} records no actor addresses; re-run "fixture seed-v1", which resumes and records them`,
+    );
+  }
 
   const v1 = v1Addresses(opts);
   const result = await verifySeededV1State(
     client,
     rows,
-    refContext(opts, state.fixtureContracts),
+    refContext(opts, state.fixtureContracts, state.actorAddresses),
     {
       registry: v1.registry.address,
       baseRegistrar: v1.base.address,

--- a/contracts/script/migrationFixture.ts
+++ b/contracts/script/migrationFixture.ts
@@ -13,7 +13,6 @@ import {
   getAddress,
   http,
   keccak256,
-  namehash,
   stringToHex,
   zeroAddress,
   zeroHash,
@@ -41,12 +40,11 @@ import {
   loadFixture,
   networkChain,
   optionalV1Deployment,
+  ownerAddress,
   parseNumber,
   readJson,
   receipt,
-  requireHandoverTarget,
   rpc,
-  sameAddress,
   runStatePath,
   v1Deployment,
   v2Deployment,
@@ -57,18 +55,14 @@ import { resolveRegistrarControlRoute } from "./registrarControl.js";
 import {
   executionScenario,
   expectedResult,
-  isChild,
   migrationRoute,
   preMigrationOwnerAlias,
-  v1Form,
   wrapperState,
   type RefContext,
 } from "./migrationFixture/scenario.js";
 import {
-  planHandover,
   planSetupSteps,
   tokenIdOf,
-  type HandoverState,
   type PlanContext,
   type PlannedCall,
 } from "./migrationFixture/plan.js";
@@ -79,7 +73,6 @@ import {
   partitionMigration,
 } from "./migrationFixture/migrate.js";
 import {
-  actorWallet,
   executePlannedCalls,
   fundActors,
   assertStateControls,
@@ -89,18 +82,7 @@ import {
 
 import { BaseRegistrar, NameWrapper, RegistrarOwnershipAbi } from "./abis.js";
 
-/// Reads and writes the handover makes, and the registrar-ownership surface the
-/// v1 controller check walks.
-/// The approval pair is declared once but sent to both v1 registrars: ERC-721
-/// and ERC-1155 spell it identically, so one fragment addresses either.
-const HANDOVER_ABI = [
-  ...NameWrapper.supportsInterface,
-  ...NameWrapper.getData,
-  ...BaseRegistrar.ownerOf,
-  ...BaseRegistrar.nameExpires,
-  ...BaseRegistrar.isApprovedForAll,
-  ...BaseRegistrar.setApprovalForAll,
-] as const;
+/// The registrar-ownership surface the v1 controller check walks.
 const PRIOR_RENEWER_ABI = RegistrarOwnershipAbi;
 import {
   type CommonOptions,
@@ -975,6 +957,15 @@ export async function seedV1(
   const csv = writePremigrationCsv(opts, rows, state);
 
   console.log(`seeded ${state.names.length} fixture names on v1`);
+  // An owner key makes owner_a, owner_b and owner_c one account, so a run says
+  // whose the names are and what distinction it gave up to put them there.
+  const owner = ownerAddress(opts);
+  if (owner) {
+    console.log(
+      `owner: ${owner} (owner_a, owner_b and owner_c are this one account, ` +
+        "so scenarios that turn on the owners differing no longer do)",
+    );
+  }
   console.log(`batcher: ${batcher}`);
   console.log(`run state: ${runStatePath(opts)}`);
   console.log(
@@ -1017,16 +1008,6 @@ export async function verifyV1(opts: CommonOptions): Promise<void> {
       baseRegistrar: v1.base.address,
       nameWrapper: v1.wrapper.address,
     },
-    // A name that has been given away is expected on its recipient rather than
-    // on the actor the corpus names, so a run stays checkable after handover.
-    new Map(
-      state.names
-        .filter((n) => n.handedOverTo)
-        .map((n) => [
-          n.fixtureId,
-          { to: n.handedOverTo!, from: n.handedOverFrom },
-        ]),
-    ),
   );
 
   const byForm: Record<string, { names: number; failing: number }> = {};
@@ -1049,7 +1030,6 @@ export async function verifyV1(opts: CommonOptions): Promise<void> {
       {
         names: result.names,
         checks: result.checks,
-        relaxedOwnerChecks: result.relaxedOwnerChecks,
         byForm,
         issues: result.issues,
       },
@@ -1063,7 +1043,6 @@ export async function verifyV1(opts: CommonOptions): Promise<void> {
       {
         names: result.names,
         checks: result.checks,
-        relaxedOwnerChecks: result.relaxedOwnerChecks,
         failingNames: failingIds.size,
         issues: result.issues.length,
         byField: result.byField,
@@ -1088,449 +1067,7 @@ export async function verifyV1(opts: CommonOptions): Promise<void> {
       `${failingIds.size}/${result.names} seeded names do not match their declared pre-migration state`,
     );
   }
-  // Saying only "matches its declared state" after a handover would hide that
-  // the ownership assertions were answered by the recipient instead.
-  console.log(
-    result.relaxedOwnerChecks
-      ? "all seeded names match their declared pre-migration state " +
-          `(${result.relaxedOwnerChecks} ownership checks satisfied against the ` +
-          "handover recipient rather than the declared actor)"
-      : "all seeded names match their declared pre-migration state",
-  );
-}
-
-const ERC1155_RECEIVER_INTERFACE_ID = "0x4e2312e0" as Hex;
-
-/// Refuses a recipient that cannot hold a wrapped name.
-///
-/// The wrapper mints ERC-1155 tokens, so an account carrying code has to answer
-/// the receipt hook. That rules out ordinary contracts, and also the EIP-7702
-/// delegations the well-known test accounts carry on live chains, whose
-/// delegate reverts with no data. One check here turns what would otherwise be
-/// a cohort's worth of identical mid-run reverts into a single message.
-async function assertCanReceiveNames(
-  client: any,
-  target: Address,
-): Promise<void> {
-  const code = await client.getCode({ address: target });
-  if (!code || code === "0x") return;
-  try {
-    const accepted = (await client.readContract({
-      address: target,
-      abi: HANDOVER_ABI,
-      functionName: "supportsInterface",
-      args: [ERC1155_RECEIVER_INTERFACE_ID],
-    })) as boolean;
-    if (accepted) return;
-  } catch {
-    // An account that cannot answer the question is refused like one that says no.
-  }
-  throw new Error(
-    `${target} carries code but does not accept ERC-1155 tokens, so wrapped names cannot be ` +
-      "transferred to it; use a plain EOA, or clear an EIP-7702 delegation first",
-  );
-}
-
-/// Lets the batcher move names on the holders' behalf.
-///
-/// Without this every transfer would be its own transaction from the account
-/// holding the name — thousands for a full cohort. One approval per holder per
-/// registry instead lets the whole cohort travel in the batcher's batches. An
-/// approval is scoped to the account that gave it, so it confers nothing over a
-/// name once that name has reached its recipient.
-async function approveBatcherAsOperator(
-  ex: Executor,
-  holders: Set<Address>,
-  registrars: Address[],
-): Promise<void> {
-  const byAddress = new Map(
-    [...ex.actors.values()].map((a) => [getAddress(a.account.address), a]),
-  );
-  for (const holder of holders) {
-    // The batcher signs for itself, and nothing else should be holding a name.
-    if (getAddress(holder) === getAddress(ex.batcher)) continue;
-    const actor = byAddress.get(getAddress(holder));
-    if (!actor) {
-      throw new Error(
-        `${holder} holds a seeded name but is not a fixture actor of this run`,
-      );
-    }
-    // `actorWallet` tops the actor up before handing back a signer. Building a
-    // client here instead would leave the approval unfunded on any run that
-    // never had to pay an actor during seeding.
-    const wallet = await actorWallet(ex, actor.alias);
-    for (const registrar of registrars) {
-      const approved = (await ex.client.readContract({
-        address: registrar,
-        abi: HANDOVER_ABI,
-        functionName: "isApprovedForAll",
-        args: [actor.account.address, ex.batcher],
-      })) as boolean;
-      if (approved) continue;
-      const hash = await wallet.writeContract({
-        address: registrar,
-        abi: HANDOVER_ABI,
-        functionName: "setApprovalForAll",
-        args: [ex.batcher, true],
-      });
-      await receipt(ex.client, hash, `${actor.alias} approves the batcher`);
-    }
-  }
-}
-
-/// Reads what each selected name currently looks like on chain, which is what
-/// the handover plans against.
-///
-/// The reads are split by whether a failure carries meaning. `getData` and
-/// `nameExpires` are total — they answer for an id that was never registered —
-/// so a failure there is the endpoint faltering and must be loud. `ownerOf`
-/// genuinely reverts once a registration lapses, so it is allowed to fail, but
-/// only where the expiry already says the name is gone. Reading a transport
-/// error as "the name is not there" would turn one rate-limited chunk into a
-/// batch of names silently reported as left behind.
-async function readHandoverState(
-  client: any,
-  rows: FixtureEnvelope[],
-  addresses: { baseRegistrar: Address; wrapper: Address },
-  now: bigint,
-  batchSize = 400,
-): Promise<Map<string, HandoverState>> {
-  const wrapperCall = (node: Hex) => ({
-    address: addresses.wrapper,
-    abi: HANDOVER_ABI,
-    functionName: "getData",
-    args: [BigInt(node)],
-  });
-  const registrarCall = (functionName: string, tokenId: bigint) => ({
-    address: addresses.baseRegistrar,
-    abi: HANDOVER_ABI,
-    functionName,
-    args: [tokenId],
-  });
-
-  const states = new Map<string, HandoverState>();
-  const total: {
-    fixtureId: string;
-    slot: "name" | "parent" | "expiry";
-    call: Record<string, unknown>;
-  }[] = [];
-  const owners: { fixtureId: string; call: Record<string, unknown> }[] = [];
-
-  for (const row of rows) {
-    const scenario = row.scenario;
-    states.set(row.fixture_id, {
-      wrapperOwner: zeroAddress,
-      wrapperFuses: 0,
-      wrapperExpiry: 0n,
-      registrant: zeroAddress,
-      now,
-    });
-    total.push({
-      fixtureId: row.fixture_id,
-      slot: "name",
-      call: wrapperCall(namehash(scenario.name) as Hex),
-    });
-    if (isChild(v1Form(scenario))) {
-      total.push({
-        fixtureId: row.fixture_id,
-        slot: "parent",
-        call: wrapperCall(namehash(`${scenario.top_level_label}.eth`) as Hex),
-      });
-      continue;
-    }
-    const tokenId = tokenIdOf(scenario.top_level_label);
-    total.push({
-      fixtureId: row.fixture_id,
-      slot: "expiry",
-      call: registrarCall("nameExpires", tokenId),
-    });
-    owners.push({
-      fixtureId: row.fixture_id,
-      call: registrarCall("ownerOf", tokenId),
-    });
-  }
-
-  const registrationExpiry = new Map<string, bigint>();
-  for (let i = 0; i < total.length; i += batchSize) {
-    const slice = total.slice(i, i + batchSize);
-    const results = await client.multicall({
-      contracts: slice.map((r) => r.call),
-      allowFailure: false,
-    });
-    for (const [index, read] of slice.entries()) {
-      const state = states.get(read.fixtureId)!;
-      if (read.slot === "expiry") {
-        registrationExpiry.set(read.fixtureId, BigInt(results[index]));
-        continue;
-      }
-      const [owner, fuses, expiry] = results[index] as [
-        Address,
-        number,
-        bigint,
-      ];
-      if (read.slot === "name") {
-        state.wrapperOwner = getAddress(owner);
-        state.wrapperFuses = Number(fuses);
-        state.wrapperExpiry = BigInt(expiry);
-      } else {
-        state.parentWrapperOwner = getAddress(owner);
-        state.parentWrapperFuses = Number(fuses);
-        state.parentWrapperExpiry = BigInt(expiry);
-      }
-    }
-  }
-
-  const unreadable: string[] = [];
-  for (let i = 0; i < owners.length; i += batchSize) {
-    const slice = owners.slice(i, i + batchSize);
-    const results = await client.multicall({
-      contracts: slice.map((r) => r.call),
-      allowFailure: true,
-    });
-    for (const [index, read] of slice.entries()) {
-      const outcome = results[index];
-      if (outcome.status === "success") {
-        states.get(read.fixtureId)!.registrant = getAddress(
-          outcome.result as Address,
-        );
-        continue;
-      }
-      // A lapsed registration has no owner, which the expiry already told us.
-      // Anything else is a read that did not happen.
-      const expiry = registrationExpiry.get(read.fixtureId) ?? 0n;
-      if (expiry === 0n || expiry <= now) continue;
-      unreadable.push(read.fixtureId);
-    }
-  }
-  if (unreadable.length) {
-    throw new Error(
-      `could not read the current owner of ${unreadable.length} unexpired name(s) ` +
-        `(${unreadable.slice(0, 5).join(", ")}${unreadable.length > 5 ? ", ..." : ""}); ` +
-        "the endpoint failed rather than the names being gone, so nothing was moved",
-    );
-  }
-  return states;
-}
-
-/// Gives every seeded name in the selection to one wallet, so a tester holds
-/// them on V1 and can drive the migration from the app.
-///
-/// Run it after `verify-v1`. The corpus declares which actor holds each name,
-/// so the shaped state is proved as written first and only then given away;
-/// afterwards `verify-v1` expects the recipient instead, which it reads from
-/// the run state.
-///
-/// Names the wrapper refuses to move — `CANNOT_TRANSFER` burned, or an
-/// emancipated name past its expiry — stay with their actor and are reported
-/// rather than failing the run. Operator approvals a scenario granted while
-/// shaping do not survive either, because an approval is scoped to the owner
-/// that gave it; a recipient migrating through the helper grants their own,
-/// which is what the app asks for anyway.
-export async function handover(opts: CommonOptions): Promise<void> {
-  await requireWriteableChain(opts);
-  const target = requireHandoverTarget(opts);
-  const state = loadRunState(opts);
-  if (!state) {
-    throw new Error(
-      `no fixture run state at ${runStatePath(opts)}; run "fixture seed-v1" first`,
-    );
-  }
-
-  const actors = accounts(opts);
-  const { chain, client, wallet } = clients(opts);
-  assertRunStateCompatible(opts, state, chain.id, actors);
-
-  const prior = state.names.find((n) => n.handedOverTo)?.handedOverTo;
-  if (prior && getAddress(prior) !== target) {
-    throw new Error(
-      `${runStatePath(opts)} already handed names to ${prior}; a second recipient would split ` +
-        "the cohort across wallets, so use a fresh --work-dir",
-    );
-  }
-
-  const byId = new Map(state.names.map((n) => [n.fixtureId, n]));
-  const selected = loadFixture(opts).filter(
-    (r) => byId.get(r.fixture_id)?.setupComplete,
-  );
-  if (!selected.length) {
-    throw new Error(
-      "no fully seeded names in this selection; widen the selection or seed it first",
-    );
-  }
-
-  await assertCanReceiveNames(client, target);
-
-  const v1 = v1Addresses(opts);
-  const ctx = planContext(opts, state.fixtureContracts, state.batcher);
-  const executor: Executor = {
-    opts,
-    chain,
-    client,
-    wallet,
-    batcher: state.batcher,
-    actors: new Map(actors.map((a) => [a.alias, a])),
-  };
-
-  const { timestamp } = await client.getBlock();
-  const current = await readHandoverState(
-    client,
-    selected,
-    { baseRegistrar: v1.base.address, wrapper: v1.wrapper.address },
-    BigInt(timestamp),
-  );
-
-  const perName = new Map<string, PlannedCall[]>();
-  const skipped: { fixtureId: string; subject: string; reason: string }[] = [];
-  const holders = new Set<Address>();
-  // Names the recipient does not end up holding, which is decided by the name's
-  // own transfer rather than by anything planned around it.
-  const stayed = new Set<string>();
-  const nameHolder = new Map<string, Address>();
-  for (const row of selected) {
-    const plan = planHandover(row, ctx, target, current.get(row.fixture_id)!);
-    for (const skip of plan.skips) {
-      skipped.push({ fixtureId: row.fixture_id, ...skip });
-      if (skip.subject === row.scenario.name) stayed.add(row.fixture_id);
-    }
-    for (const holder of plan.holders) holders.add(holder);
-    nameHolder.set(row.fixture_id, plan.nameHolder);
-    if (plan.calls.length) perName.set(row.fixture_id, plan.calls);
-  }
-
-  // Every selected name lands in exactly one of these, so the counts reported
-  // at the end add up to the selection.
-  const rowById = new Map(selected.map((r) => [r.fixture_id, r]));
-  const movedIds = [...perName.keys()].filter((id) => !stayed.has(id));
-  const alreadyHeld = selected.filter(
-    (r) => !perName.has(r.fixture_id) && !stayed.has(r.fixture_id),
-  ).length;
-
-  await approveBatcherAsOperator(executor, holders, [
-    v1.base.address,
-    v1.wrapper.address,
-  ]);
-
-  // Where a name came from is knowable now and never again: once it has moved,
-  // the chain only says it is the recipient's. So the origin is recorded before
-  // any batch runs, and never overwritten — a resumed run that finds a name
-  // already at the recipient must not conclude that is where it started.
-  //
-  // A name with no recorded origin and nothing left to move is one whose
-  // history we genuinely do not have. It stays unset, which reads as "unknown"
-  // rather than "came from the recipient", so its ownership check still relaxes.
-  //
-  // The destination is recorded as each name's calls land, except for a name
-  // the plan asks nothing of, which is already there.
-  for (const row of selected) {
-    if (stayed.has(row.fixture_id)) continue;
-    const run = byId.get(row.fixture_id)!;
-    const holder = nameHolder.get(row.fixture_id);
-    if (
-      run.handedOverFrom === undefined &&
-      holder &&
-      !sameAddress(holder, target)
-    ) {
-      run.handedOverFrom = holder;
-    }
-    if (!perName.has(row.fixture_id)) run.handedOverTo = target;
-  }
-  saveRunState(opts, state);
-
-  const reportPath = join(resolve(opts.workDir), "fixture-handover.json");
-  const transactions = new Map<string, Hex[]>();
-  /// Names whose every call landed. A name arrives here only when the executor
-  /// says it is finished, so a run that stops partway reports what actually
-  /// moved rather than what it set out to move.
-  const landed = new Set<string>();
-  let completed = false;
-
-  // The report is the only durable record of which transactions moved what, so
-  // it is written whether or not the batches finished, and merged with any
-  // earlier run's rather than replacing it.
-  const writeReport = () => {
-    const previous = existsSync(reportPath)
-      ? readJson<{ moved?: { fixtureId: string; transactions: Hex[] }[] }>(
-          reportPath,
-        )
-      : {};
-    const merged = new Map<string, Hex[]>(
-      (previous.moved ?? []).map((m) => [m.fixtureId, m.transactions ?? []]),
-    );
-    for (const fixtureId of landed) {
-      merged.set(fixtureId, [
-        ...new Set([
-          ...(merged.get(fixtureId) ?? []),
-          ...(transactions.get(fixtureId) ?? []),
-        ]),
-      ]);
-    }
-    writeFileSync(
-      reportPath,
-      `${JSON.stringify(
-        {
-          target,
-          selected: selected.length,
-          completed,
-          planned: movedIds.length,
-          moved: [...merged.entries()].map(([fixtureId, hashes]) => ({
-            fixtureId,
-            transactions: hashes,
-          })),
-          skipped,
-        },
-        null,
-        2,
-      )}\n`,
-    );
-  };
-
-  try {
-    await executePlannedCalls(
-      executor,
-      perName,
-      (fixtureId, hash) => {
-        transactions.set(fixtureId, [
-          ...(transactions.get(fixtureId) ?? []),
-          hash,
-        ]);
-      },
-      (fixtureId) => {
-        const run = byId.get(fixtureId);
-        if (run && !stayed.has(fixtureId)) {
-          landed.add(fixtureId);
-          run.handedOverTo = target;
-        }
-        saveRunState(opts, state);
-      },
-    );
-    completed = true;
-  } finally {
-    writeReport();
-  }
-
-  const reasons: Record<string, number> = {};
-  for (const skip of skipped) {
-    reasons[skip.reason] = (reasons[skip.reason] ?? 0) + 1;
-  }
-  console.log(
-    JSON.stringify(
-      {
-        target,
-        selected: selected.length,
-        moved: landed.size,
-        stayed: stayed.size,
-        alreadyHeld,
-        skipped: skipped.length,
-        skippedByReason: reasons,
-        report: reportPath,
-      },
-      null,
-      2,
-    ),
-  );
-  console.log(
-    `next: bun run migration -- fixture verify-v1 --work-dir ${opts.workDir}`,
-  );
+  console.log("all seeded names match their declared pre-migration state");
 }
 
 async function fundActorAccounts(
@@ -1573,24 +1110,10 @@ async function fundActorAccounts(
 export async function runFixtureSeedStage(
   opts: CommonOptions,
 ): Promise<{ labels: string[]; premigrationCsv: string }> {
-  // A bad recipient must fail now, not after hours of seeding: on a rehearsal
-  // the fork is torn down when the run ends, taking the corpus with it.
-  if (opts.fixtureHandoverTo) {
-    const target = requireHandoverTarget(opts);
-    await assertCanReceiveNames(clients(opts).client, target);
-  }
-
   console.log("fixture: seeding the ENSv1 corpus");
   const { path: premigrationCsv, labels } = await seedV1(opts);
   console.log("fixture: verifying the shaped V1 state");
   await verifyV1(opts);
-  // Giving the names away comes last, so the state is proved as the corpus
-  // declares it before the owner it declares stops being the one holding it.
-  if (opts.fixtureHandoverTo) {
-    console.log(`fixture: handing the corpus to ${opts.fixtureHandoverTo}`);
-    await handover(opts);
-  }
-
   return { labels, premigrationCsv };
 }
 
@@ -1637,13 +1160,13 @@ function addCommon(command: Command): Command {
     );
 }
 
-/// Names the wallet a run gives its seeded names to. Only the two commands that
-/// act on it take it: accepted-and-ignored elsewhere it reads as a way to
-/// select the recipient, which on `verify-v1` in particular would be a trap.
-function addHandoverOption(command: Command): Command {
+/// Nominates the wallet that owns every seeded name. Only the command that
+/// registers names takes it: on any other it would read as a way to change who
+/// owns them, which nothing after seeding can do.
+function addOwnerKeyOption(command: Command): Command {
   return command.option(
-    "--fixture-handover-to <address>",
-    "Give the seeded names to this wallet once their state is checked",
+    "--fixture-owner-key <key>",
+    "Private key of the wallet that should own every seeded name",
   );
 }
 
@@ -1709,19 +1232,14 @@ export function addFixtureSubcommands(program: Command): Command {
     ).action((raw) => deployFixtures(normalizeOptions(raw))),
   );
   program.addCommand(
-    addHandoverOption(
+    addOwnerKeyOption(
       addCommon(
         new Command("seed-v1").description(
           "Register the corpus on v1 and shape each name's pre-migration state (before phase 3)",
         ),
       ),
     ).action(async (raw) => {
-      const opts = normalizeOptions(raw);
-      // Asking for a handover asks for the checks that have to precede it: the
-      // corpus declares which actor holds each name, so the shaped state is
-      // proved as written before that owner stops being the one holding it.
-      if (opts.fixtureHandoverTo) await runFixtureSeedStage(opts);
-      else await seedV1(opts);
+      await seedV1(normalizeOptions(raw));
     }),
   );
   program.addCommand(
@@ -1730,15 +1248,6 @@ export function addFixtureSubcommands(program: Command): Command {
         "After seed-v1: read the shaped V1 state back and check it against each scenario",
       ),
     ).action((raw) => verifyV1(normalizeOptions(raw))),
-  );
-  program.addCommand(
-    addHandoverOption(
-      addCommon(
-        new Command("handover").description(
-          "After verify-v1: give every seeded name in the selection to one wallet",
-        ),
-      ),
-    ).action((raw) => handover(normalizeOptions(raw))),
   );
   return program;
 }

--- a/contracts/script/migrationFixture.ts
+++ b/contracts/script/migrationFixture.ts
@@ -78,6 +78,7 @@ import {
   partitionMigration,
 } from "./migrationFixture/migrate.js";
 import {
+  actorWallet,
   executePlannedCalls,
   fundActors,
   assertStateControls,
@@ -820,10 +821,6 @@ export async function seedV1(
           batcher,
           v1.wrapper.address,
           ...actors.map((a) => a.account.address),
-          // A name already given to a tester is still one of ours; without
-          // this a reseed against a handed-over work directory would report
-          // the recipient as a stranger.
-          ...seeded.names.flatMap((n) => n.handedOverTo ?? []),
         ].map((a) => getAddress(a)),
       );
       if (!ours.has(owner)) {
@@ -1025,7 +1022,10 @@ export async function verifyV1(opts: CommonOptions): Promise<void> {
     new Map(
       state.names
         .filter((n) => n.handedOverTo)
-        .map((n) => [n.fixtureId, n.handedOverTo!]),
+        .map((n) => [
+          n.fixtureId,
+          { to: n.handedOverTo!, from: n.handedOverFrom },
+        ]),
     ),
   );
 
@@ -1049,6 +1049,7 @@ export async function verifyV1(opts: CommonOptions): Promise<void> {
       {
         names: result.names,
         checks: result.checks,
+        relaxedOwnerChecks: result.relaxedOwnerChecks,
         byForm,
         issues: result.issues,
       },
@@ -1062,6 +1063,7 @@ export async function verifyV1(opts: CommonOptions): Promise<void> {
       {
         names: result.names,
         checks: result.checks,
+        relaxedOwnerChecks: result.relaxedOwnerChecks,
         failingNames: failingIds.size,
         issues: result.issues.length,
         byField: result.byField,
@@ -1086,7 +1088,15 @@ export async function verifyV1(opts: CommonOptions): Promise<void> {
       `${failingIds.size}/${result.names} seeded names do not match their declared pre-migration state`,
     );
   }
-  console.log("all seeded names match their declared pre-migration state");
+  // Saying only "matches its declared state" after a handover would hide that
+  // the ownership assertions were answered by the recipient instead.
+  console.log(
+    result.relaxedOwnerChecks
+      ? "all seeded names match their declared pre-migration state " +
+          `(${result.relaxedOwnerChecks} ownership checks satisfied against the ` +
+          "handover recipient rather than the declared actor)"
+      : "all seeded names match their declared pre-migration state",
+  );
 }
 
 const ERC1155_RECEIVER_INTERFACE_ID = "0x4e2312e0" as Hex;
@@ -1116,6 +1126,13 @@ const HANDOVER_ABI = [
     stateMutability: "view",
     inputs: [{ name: "tokenId", type: "uint256" }],
     outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "nameExpires",
+    stateMutability: "view",
+    inputs: [{ name: "id", type: "uint256" }],
+    outputs: [{ name: "", type: "uint256" }],
   },
   {
     type: "function",
@@ -1193,11 +1210,10 @@ async function approveBatcherAsOperator(
         `${holder} holds a seeded name but is not a fixture actor of this run`,
       );
     }
-    const wallet = createWalletClient({
-      chain: ex.chain,
-      account: actor.account,
-      transport: http(ex.opts.rpcUrl),
-    });
+    // `actorWallet` tops the actor up before handing back a signer. Building a
+    // client here instead would leave the approval unfunded on any run that
+    // never had to pay an actor during seeding.
+    const wallet = await actorWallet(ex, actor.alias);
     for (const registrar of registrars) {
       const approved = (await ex.client.readContract({
         address: registrar,
@@ -1219,6 +1235,14 @@ async function approveBatcherAsOperator(
 
 /// Reads what each selected name currently looks like on chain, which is what
 /// the handover plans against.
+///
+/// The reads are split by whether a failure carries meaning. `getData` and
+/// `nameExpires` are total — they answer for an id that was never registered —
+/// so a failure there is the endpoint faltering and must be loud. `ownerOf`
+/// genuinely reverts once a registration lapses, so it is allowed to fail, but
+/// only where the expiry already says the name is gone. Reading a transport
+/// error as "the name is not there" would turn one rate-limited chunk into a
+/// batch of names silently reported as left behind.
 async function readHandoverState(
   client: any,
   rows: FixtureEnvelope[],
@@ -1226,49 +1250,29 @@ async function readHandoverState(
   now: bigint,
   batchSize = 400,
 ): Promise<Map<string, HandoverState>> {
-  type Read = {
-    fixtureId: string;
-    slot: "name" | "parent" | "registrant";
-    call: Record<string, unknown>;
-  };
   const wrapperCall = (node: Hex) => ({
     address: addresses.wrapper,
     abi: HANDOVER_ABI,
     functionName: "getData",
     args: [BigInt(node)],
   });
-
-  const reads: Read[] = [];
-  for (const row of rows) {
-    const scenario = row.scenario;
-    const child = isChild(v1Form(scenario));
-    reads.push({
-      fixtureId: row.fixture_id,
-      slot: "name",
-      call: wrapperCall(namehash(scenario.name) as Hex),
-    });
-    if (child) {
-      reads.push({
-        fixtureId: row.fixture_id,
-        slot: "parent",
-        call: wrapperCall(namehash(`${scenario.top_level_label}.eth`) as Hex),
-      });
-    } else {
-      reads.push({
-        fixtureId: row.fixture_id,
-        slot: "registrant",
-        call: {
-          address: addresses.baseRegistrar,
-          abi: HANDOVER_ABI,
-          functionName: "ownerOf",
-          args: [tokenIdOf(scenario.top_level_label)],
-        },
-      });
-    }
-  }
+  const registrarCall = (functionName: string, tokenId: bigint) => ({
+    address: addresses.baseRegistrar,
+    abi: HANDOVER_ABI,
+    functionName,
+    args: [tokenId],
+  });
 
   const states = new Map<string, HandoverState>();
+  const total: {
+    fixtureId: string;
+    slot: "name" | "parent" | "expiry";
+    call: Record<string, unknown>;
+  }[] = [];
+  const owners: { fixtureId: string; call: Record<string, unknown> }[] = [];
+
   for (const row of rows) {
+    const scenario = row.scenario;
     states.set(row.fixture_id, {
       wrapperOwner: zeroAddress,
       wrapperFuses: 0,
@@ -1276,29 +1280,45 @@ async function readHandoverState(
       registrant: zeroAddress,
       now,
     });
+    total.push({
+      fixtureId: row.fixture_id,
+      slot: "name",
+      call: wrapperCall(namehash(scenario.name) as Hex),
+    });
+    if (isChild(v1Form(scenario))) {
+      total.push({
+        fixtureId: row.fixture_id,
+        slot: "parent",
+        call: wrapperCall(namehash(`${scenario.top_level_label}.eth`) as Hex),
+      });
+      continue;
+    }
+    const tokenId = tokenIdOf(scenario.top_level_label);
+    total.push({
+      fixtureId: row.fixture_id,
+      slot: "expiry",
+      call: registrarCall("nameExpires", tokenId),
+    });
+    owners.push({
+      fixtureId: row.fixture_id,
+      call: registrarCall("ownerOf", tokenId),
+    });
   }
 
-  for (let i = 0; i < reads.length; i += batchSize) {
-    const slice = reads.slice(i, i + batchSize);
+  const registrationExpiry = new Map<string, bigint>();
+  for (let i = 0; i < total.length; i += batchSize) {
+    const slice = total.slice(i, i + batchSize);
     const results = await client.multicall({
       contracts: slice.map((r) => r.call),
-      allowFailure: true,
+      allowFailure: false,
     });
     for (const [index, read] of slice.entries()) {
-      const outcome = results[index];
-      // A failed read means the name is not there — expired out of its
-      // registration, or never created. The zero left in place skips it.
-      if (outcome.status !== "success") continue;
       const state = states.get(read.fixtureId)!;
-      if (read.slot === "registrant") {
-        state.registrant = getAddress(outcome.result as Address);
+      if (read.slot === "expiry") {
+        registrationExpiry.set(read.fixtureId, BigInt(results[index]));
         continue;
       }
-      const [owner, fuses, expiry] = outcome.result as [
-        Address,
-        number,
-        bigint,
-      ];
+      const [owner, fuses, expiry] = results[index] as [Address, number, bigint];
       if (read.slot === "name") {
         state.wrapperOwner = getAddress(owner);
         state.wrapperFuses = Number(fuses);
@@ -1309,6 +1329,36 @@ async function readHandoverState(
         state.parentWrapperExpiry = BigInt(expiry);
       }
     }
+  }
+
+  const unreadable: string[] = [];
+  for (let i = 0; i < owners.length; i += batchSize) {
+    const slice = owners.slice(i, i + batchSize);
+    const results = await client.multicall({
+      contracts: slice.map((r) => r.call),
+      allowFailure: true,
+    });
+    for (const [index, read] of slice.entries()) {
+      const outcome = results[index];
+      if (outcome.status === "success") {
+        states.get(read.fixtureId)!.registrant = getAddress(
+          outcome.result as Address,
+        );
+        continue;
+      }
+      // A lapsed registration has no owner, which the expiry already told us.
+      // Anything else is a read that did not happen.
+      const expiry = registrationExpiry.get(read.fixtureId) ?? 0n;
+      if (expiry === 0n || expiry <= now) continue;
+      unreadable.push(read.fixtureId);
+    }
+  }
+  if (unreadable.length) {
+    throw new Error(
+      `could not read the current owner of ${unreadable.length} unexpired name(s) ` +
+        `(${unreadable.slice(0, 5).join(", ")}${unreadable.length > 5 ? ", ..." : ""}); ` +
+        "the endpoint failed rather than the names being gone, so nothing was moved",
+    );
   }
   return states;
 }
@@ -1383,9 +1433,8 @@ export async function handover(opts: CommonOptions): Promise<void> {
   const perName = new Map<string, PlannedCall[]>();
   const skipped: { fixtureId: string; subject: string; reason: string }[] = [];
   const holders = new Set<Address>();
-  // Names that stay where they are. A child whose parent cannot move is not one
-  // of them: the child itself still reaches the recipient, and the report says
-  // separately that its parent did not.
+  // Names the recipient does not end up holding, which is decided by the name's
+  // own transfer rather than by anything planned around it.
   const stayed = new Set<string>();
   for (const row of selected) {
     const plan = planHandover(row, ctx, target, current.get(row.fixture_id)!);
@@ -1397,53 +1446,101 @@ export async function handover(opts: CommonOptions): Promise<void> {
     if (plan.calls.length) perName.set(row.fixture_id, plan.calls);
   }
 
+  // Every selected name lands in exactly one of these, so the counts reported
+  // at the end add up to the selection.
+  const rowById = new Map(selected.map((r) => [r.fixture_id, r]));
+  const movedIds = [...perName.keys()].filter((id) => !stayed.has(id));
+  const alreadyHeld = selected.filter(
+    (r) => !perName.has(r.fixture_id) && !stayed.has(r.fixture_id),
+  ).length;
+
   await approveBatcherAsOperator(executor, holders, [
     v1.base.address,
     v1.wrapper.address,
   ]);
 
-  // A name the plan asks nothing of is already the recipient's. Recording that
-  // before the batches run keeps an interrupted handover resumable.
+  // A name the plan asks nothing of is already the recipient's, so it can be
+  // recorded before any batch runs. Everything else is recorded as its calls
+  // land: the batches are all batcher-signed, so a name is only finished once
+  // the whole run is, and an interrupt leaves the rest to a rerun — which
+  // replans from the chain and is a no-op for whatever did land.
   for (const row of selected) {
     if (perName.has(row.fixture_id) || stayed.has(row.fixture_id)) continue;
     byId.get(row.fixture_id)!.handedOverTo = target;
+    byId.get(row.fixture_id)!.handedOverFrom = preMigrationOwnerAlias(
+      row.scenario,
+    );
   }
   saveRunState(opts, state);
 
-  const transactions = new Map<string, Hex[]>();
-  await executePlannedCalls(
-    executor,
-    perName,
-    (fixtureId, hash) => {
-      transactions.set(fixtureId, [
-        ...(transactions.get(fixtureId) ?? []),
-        hash,
-      ]);
-    },
-    (fixtureId) => {
-      const run = byId.get(fixtureId);
-      if (run && !stayed.has(fixtureId)) run.handedOverTo = target;
-      saveRunState(opts, state);
-    },
-  );
-
   const reportPath = join(resolve(opts.workDir), "fixture-handover.json");
-  writeFileSync(
-    reportPath,
-    `${JSON.stringify(
-      {
-        target,
-        selected: selected.length,
-        moved: [...perName.keys()].map((fixtureId) => ({
-          fixtureId,
-          transactions: transactions.get(fixtureId) ?? [],
-        })),
-        skipped,
+  const transactions = new Map<string, Hex[]>();
+  let completed = false;
+
+  // The report is the only durable record of which transactions moved what, so
+  // it is written whether or not the batches finished, and merged with any
+  // earlier run's rather than replacing it.
+  const writeReport = () => {
+    const previous = existsSync(reportPath)
+      ? readJson<{ moved?: { fixtureId: string; transactions: Hex[] }[] }>(
+          reportPath,
+        )
+      : {};
+    const merged = new Map<string, Hex[]>(
+      (previous.moved ?? []).map((m) => [m.fixtureId, m.transactions ?? []]),
+    );
+    for (const fixtureId of movedIds) {
+      merged.set(fixtureId, [
+        ...new Set([
+          ...(merged.get(fixtureId) ?? []),
+          ...(transactions.get(fixtureId) ?? []),
+        ]),
+      ]);
+    }
+    writeFileSync(
+      reportPath,
+      `${JSON.stringify(
+        {
+          target,
+          selected: selected.length,
+          completed,
+          moved: [...merged.entries()].map(([fixtureId, hashes]) => ({
+            fixtureId,
+            transactions: hashes,
+          })),
+          skipped,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  };
+
+  try {
+    await executePlannedCalls(
+      executor,
+      perName,
+      (fixtureId, hash) => {
+        transactions.set(fixtureId, [
+          ...(transactions.get(fixtureId) ?? []),
+          hash,
+        ]);
       },
-      null,
-      2,
-    )}\n`,
-  );
+      (fixtureId) => {
+        const run = byId.get(fixtureId);
+        if (run && !stayed.has(fixtureId)) {
+          run.handedOverTo = target;
+          run.handedOverFrom = preMigrationOwnerAlias(
+            rowById.get(fixtureId)!.scenario,
+          );
+        }
+        saveRunState(opts, state);
+      },
+    );
+    completed = true;
+  } finally {
+    writeReport();
+  }
 
   const reasons: Record<string, number> = {};
   for (const skip of skipped) {
@@ -1454,9 +1551,9 @@ export async function handover(opts: CommonOptions): Promise<void> {
       {
         target,
         selected: selected.length,
-        moved: perName.size,
+        moved: movedIds.length,
         stayed: stayed.size,
-        alreadyHeld: selected.length - perName.size - stayed.size,
+        alreadyHeld,
         skipped: skipped.length,
         skippedByReason: reasons,
         report: reportPath,
@@ -1510,6 +1607,13 @@ async function fundActorAccounts(
 export async function runFixtureSeedStage(
   opts: CommonOptions,
 ): Promise<{ labels: string[]; premigrationCsv: string }> {
+  // A bad recipient must fail now, not after hours of seeding: on a rehearsal
+  // the fork is torn down when the run ends, taking the corpus with it.
+  if (opts.handoverTo) {
+    const target = requireHandoverTarget(opts);
+    await assertCanReceiveNames(clients(opts).client, target);
+  }
+
   console.log("fixture: seeding the ENSv1 corpus");
   const { path: premigrationCsv, labels } = await seedV1(opts);
   console.log("fixture: verifying the shaped V1 state");
@@ -1561,11 +1665,17 @@ function addCommon(command: Command): Command {
       "--rpc-state-controls",
       "Enable impersonation/time control RPC methods",
       false,
-    )
-    .option(
-      "--handover-to <address>",
-      "Give the seeded names to this wallet once their state is checked",
     );
+}
+
+/// Names the wallet a run gives its seeded names to. Only the two commands that
+/// act on it take it: accepted-and-ignored elsewhere it reads as a way to
+/// select the recipient, which on `verify-v1` in particular would be a trap.
+function addHandoverOption(command: Command): Command {
+  return command.option(
+    "--handover-to <address>",
+    "Give the seeded names to this wallet once their state is checked",
+  );
 }
 
 /// Gate every fixture action that writes to the chain.
@@ -1630,9 +1740,11 @@ export function addFixtureSubcommands(program: Command): Command {
     ).action((raw) => deployFixtures(normalizeOptions(raw))),
   );
   program.addCommand(
-    addCommon(
-      new Command("seed-v1").description(
-        "Register the corpus on v1 and shape each name's pre-migration state (before phase 3)",
+    addHandoverOption(
+      addCommon(
+        new Command("seed-v1").description(
+          "Register the corpus on v1 and shape each name's pre-migration state (before phase 3)",
+        ),
       ),
     ).action(async (raw) => {
       const opts = normalizeOptions(raw);
@@ -1651,9 +1763,11 @@ export function addFixtureSubcommands(program: Command): Command {
     ).action((raw) => verifyV1(normalizeOptions(raw))),
   );
   program.addCommand(
-    addCommon(
-      new Command("handover").description(
-        "After verify-v1: give every seeded name in the selection to one wallet",
+    addHandoverOption(
+      addCommon(
+        new Command("handover").description(
+          "After verify-v1: give every seeded name in the selection to one wallet",
+        ),
       ),
     ).action((raw) => handover(normalizeOptions(raw))),
   );

--- a/contracts/script/migrationFixture.ts
+++ b/contracts/script/migrationFixture.ts
@@ -1318,7 +1318,11 @@ async function readHandoverState(
         registrationExpiry.set(read.fixtureId, BigInt(results[index]));
         continue;
       }
-      const [owner, fuses, expiry] = results[index] as [Address, number, bigint];
+      const [owner, fuses, expiry] = results[index] as [
+        Address,
+        number,
+        bigint,
+      ];
       if (read.slot === "name") {
         state.wrapperOwner = getAddress(owner);
         state.wrapperFuses = Number(fuses);

--- a/contracts/script/migrationFixture.ts
+++ b/contracts/script/migrationFixture.ts
@@ -46,6 +46,7 @@ import {
   receipt,
   requireHandoverTarget,
   rpc,
+  sameAddress,
   runStatePath,
   v1Deployment,
   v2Deployment,
@@ -1409,20 +1410,38 @@ export async function handover(opts: CommonOptions): Promise<void> {
     v1.wrapper.address,
   ]);
 
-  // A name the plan asks nothing of is already the recipient's, so it can be
-  // recorded before any batch runs. Everything else is recorded as its calls
-  // land: the batches are all batcher-signed, so a name is only finished once
-  // the whole run is, and an interrupt leaves the rest to a rerun — which
-  // replans from the chain and is a no-op for whatever did land.
+  // Where a name came from is knowable now and never again: once it has moved,
+  // the chain only says it is the recipient's. So the origin is recorded before
+  // any batch runs, and never overwritten — a resumed run that finds a name
+  // already at the recipient must not conclude that is where it started.
+  //
+  // A name with no recorded origin and nothing left to move is one whose
+  // history we genuinely do not have. It stays unset, which reads as "unknown"
+  // rather than "came from the recipient", so its ownership check still relaxes.
+  //
+  // The destination is recorded as each name's calls land, except for a name
+  // the plan asks nothing of, which is already there.
   for (const row of selected) {
-    if (perName.has(row.fixture_id) || stayed.has(row.fixture_id)) continue;
-    byId.get(row.fixture_id)!.handedOverTo = target;
-    byId.get(row.fixture_id)!.handedOverFrom = nameHolder.get(row.fixture_id);
+    if (stayed.has(row.fixture_id)) continue;
+    const run = byId.get(row.fixture_id)!;
+    const holder = nameHolder.get(row.fixture_id);
+    if (
+      run.handedOverFrom === undefined &&
+      holder &&
+      !sameAddress(holder, target)
+    ) {
+      run.handedOverFrom = holder;
+    }
+    if (!perName.has(row.fixture_id)) run.handedOverTo = target;
   }
   saveRunState(opts, state);
 
   const reportPath = join(resolve(opts.workDir), "fixture-handover.json");
   const transactions = new Map<string, Hex[]>();
+  /// Names whose every call landed. A name arrives here only when the executor
+  /// says it is finished, so a run that stops partway reports what actually
+  /// moved rather than what it set out to move.
+  const landed = new Set<string>();
   let completed = false;
 
   // The report is the only durable record of which transactions moved what, so
@@ -1437,7 +1456,7 @@ export async function handover(opts: CommonOptions): Promise<void> {
     const merged = new Map<string, Hex[]>(
       (previous.moved ?? []).map((m) => [m.fixtureId, m.transactions ?? []]),
     );
-    for (const fixtureId of movedIds) {
+    for (const fixtureId of landed) {
       merged.set(fixtureId, [
         ...new Set([
           ...(merged.get(fixtureId) ?? []),
@@ -1452,6 +1471,7 @@ export async function handover(opts: CommonOptions): Promise<void> {
           target,
           selected: selected.length,
           completed,
+          planned: movedIds.length,
           moved: [...merged.entries()].map(([fixtureId, hashes]) => ({
             fixtureId,
             transactions: hashes,
@@ -1477,8 +1497,8 @@ export async function handover(opts: CommonOptions): Promise<void> {
       (fixtureId) => {
         const run = byId.get(fixtureId);
         if (run && !stayed.has(fixtureId)) {
+          landed.add(fixtureId);
           run.handedOverTo = target;
-          run.handedOverFrom = nameHolder.get(fixtureId);
         }
         saveRunState(opts, state);
       },
@@ -1497,7 +1517,7 @@ export async function handover(opts: CommonOptions): Promise<void> {
       {
         target,
         selected: selected.length,
-        moved: movedIds.length,
+        moved: landed.size,
         stayed: stayed.size,
         alreadyHeld,
         skipped: skipped.length,

--- a/contracts/script/migrationFixture.ts
+++ b/contracts/script/migrationFixture.ts
@@ -44,6 +44,7 @@ import {
   parseNumber,
   readJson,
   receipt,
+  requireHandoverTarget,
   rpc,
   runStatePath,
   v1Deployment,
@@ -55,14 +56,18 @@ import { resolveRegistrarControlRoute } from "./registrarControl.js";
 import {
   executionScenario,
   expectedResult,
+  isChild,
   migrationRoute,
   preMigrationOwnerAlias,
+  v1Form,
   wrapperState,
   type RefContext,
 } from "./migrationFixture/scenario.js";
 import {
+  planHandover,
   planSetupSteps,
   tokenIdOf,
+  type HandoverState,
   type PlanContext,
   type PlannedCall,
 } from "./migrationFixture/plan.js";
@@ -815,6 +820,10 @@ export async function seedV1(
           batcher,
           v1.wrapper.address,
           ...actors.map((a) => a.account.address),
+          // A name already given to a tester is still one of ours; without
+          // this a reseed against a handed-over work directory would report
+          // the recipient as a stranger.
+          ...seeded.names.flatMap((n) => n.handedOverTo ?? []),
         ].map((a) => getAddress(a)),
       );
       if (!ours.has(owner)) {
@@ -1011,6 +1020,13 @@ export async function verifyV1(opts: CommonOptions): Promise<void> {
       baseRegistrar: v1.base.address,
       nameWrapper: v1.wrapper.address,
     },
+    // A name that has been given away is expected on its recipient rather than
+    // on the actor the corpus names, so a run stays checkable after handover.
+    new Map(
+      state.names
+        .filter((n) => n.handedOverTo)
+        .map((n) => [n.fixtureId, n.handedOverTo!]),
+    ),
   );
 
   const byForm: Record<string, { names: number; failing: number }> = {};
@@ -1073,6 +1089,387 @@ export async function verifyV1(opts: CommonOptions): Promise<void> {
   console.log("all seeded names match their declared pre-migration state");
 }
 
+const ERC1155_RECEIVER_INTERFACE_ID = "0x4e2312e0" as Hex;
+
+const HANDOVER_ABI = [
+  {
+    type: "function",
+    name: "supportsInterface",
+    stateMutability: "view",
+    inputs: [{ name: "interfaceId", type: "bytes4" }],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "getData",
+    stateMutability: "view",
+    inputs: [{ name: "id", type: "uint256" }],
+    outputs: [
+      { name: "owner", type: "address" },
+      { name: "fuses", type: "uint32" },
+      { name: "expiry", type: "uint64" },
+    ],
+  },
+  {
+    type: "function",
+    name: "ownerOf",
+    stateMutability: "view",
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "isApprovedForAll",
+    stateMutability: "view",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "operator", type: "address" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "setApprovalForAll",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "operator", type: "address" },
+      { name: "approved", type: "bool" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+/// Refuses a recipient that cannot hold a wrapped name.
+///
+/// The wrapper mints ERC-1155 tokens, so an account carrying code has to answer
+/// the receipt hook. That rules out ordinary contracts, and also the EIP-7702
+/// delegations the well-known test accounts carry on live chains, whose
+/// delegate reverts with no data. One check here turns what would otherwise be
+/// a cohort's worth of identical mid-run reverts into a single message.
+async function assertCanReceiveNames(
+  client: any,
+  target: Address,
+): Promise<void> {
+  const code = await client.getCode({ address: target });
+  if (!code || code === "0x") return;
+  try {
+    const accepted = (await client.readContract({
+      address: target,
+      abi: HANDOVER_ABI,
+      functionName: "supportsInterface",
+      args: [ERC1155_RECEIVER_INTERFACE_ID],
+    })) as boolean;
+    if (accepted) return;
+  } catch {
+    // An account that cannot answer the question is refused like one that says no.
+  }
+  throw new Error(
+    `${target} carries code but does not accept ERC-1155 tokens, so wrapped names cannot be ` +
+      "transferred to it; use a plain EOA, or clear an EIP-7702 delegation first",
+  );
+}
+
+/// Lets the batcher move names on the holders' behalf.
+///
+/// Without this every transfer would be its own transaction from the account
+/// holding the name — thousands for a full cohort. One approval per holder per
+/// registry instead lets the whole cohort travel in the batcher's batches. An
+/// approval is scoped to the account that gave it, so it confers nothing over a
+/// name once that name has reached its recipient.
+async function approveBatcherAsOperator(
+  ex: Executor,
+  holders: Set<Address>,
+  registrars: Address[],
+): Promise<void> {
+  const byAddress = new Map(
+    [...ex.actors.values()].map((a) => [getAddress(a.account.address), a]),
+  );
+  for (const holder of holders) {
+    // The batcher signs for itself, and nothing else should be holding a name.
+    if (getAddress(holder) === getAddress(ex.batcher)) continue;
+    const actor = byAddress.get(getAddress(holder));
+    if (!actor) {
+      throw new Error(
+        `${holder} holds a seeded name but is not a fixture actor of this run`,
+      );
+    }
+    const wallet = createWalletClient({
+      chain: ex.chain,
+      account: actor.account,
+      transport: http(ex.opts.rpcUrl),
+    });
+    for (const registrar of registrars) {
+      const approved = (await ex.client.readContract({
+        address: registrar,
+        abi: HANDOVER_ABI,
+        functionName: "isApprovedForAll",
+        args: [actor.account.address, ex.batcher],
+      })) as boolean;
+      if (approved) continue;
+      const hash = await wallet.writeContract({
+        address: registrar,
+        abi: HANDOVER_ABI,
+        functionName: "setApprovalForAll",
+        args: [ex.batcher, true],
+      });
+      await receipt(ex.client, hash, `${actor.alias} approves the batcher`);
+    }
+  }
+}
+
+/// Reads what each selected name currently looks like on chain, which is what
+/// the handover plans against.
+async function readHandoverState(
+  client: any,
+  rows: FixtureEnvelope[],
+  addresses: { baseRegistrar: Address; wrapper: Address },
+  now: bigint,
+  batchSize = 400,
+): Promise<Map<string, HandoverState>> {
+  type Read = {
+    fixtureId: string;
+    slot: "name" | "parent" | "registrant";
+    call: Record<string, unknown>;
+  };
+  const wrapperCall = (node: Hex) => ({
+    address: addresses.wrapper,
+    abi: HANDOVER_ABI,
+    functionName: "getData",
+    args: [BigInt(node)],
+  });
+
+  const reads: Read[] = [];
+  for (const row of rows) {
+    const scenario = row.scenario;
+    const child = isChild(v1Form(scenario));
+    reads.push({
+      fixtureId: row.fixture_id,
+      slot: "name",
+      call: wrapperCall(namehash(scenario.name) as Hex),
+    });
+    if (child) {
+      reads.push({
+        fixtureId: row.fixture_id,
+        slot: "parent",
+        call: wrapperCall(namehash(`${scenario.top_level_label}.eth`) as Hex),
+      });
+    } else {
+      reads.push({
+        fixtureId: row.fixture_id,
+        slot: "registrant",
+        call: {
+          address: addresses.baseRegistrar,
+          abi: HANDOVER_ABI,
+          functionName: "ownerOf",
+          args: [tokenIdOf(scenario.top_level_label)],
+        },
+      });
+    }
+  }
+
+  const states = new Map<string, HandoverState>();
+  for (const row of rows) {
+    states.set(row.fixture_id, {
+      wrapperOwner: zeroAddress,
+      wrapperFuses: 0,
+      wrapperExpiry: 0n,
+      registrant: zeroAddress,
+      now,
+    });
+  }
+
+  for (let i = 0; i < reads.length; i += batchSize) {
+    const slice = reads.slice(i, i + batchSize);
+    const results = await client.multicall({
+      contracts: slice.map((r) => r.call),
+      allowFailure: true,
+    });
+    for (const [index, read] of slice.entries()) {
+      const outcome = results[index];
+      // A failed read means the name is not there — expired out of its
+      // registration, or never created. The zero left in place skips it.
+      if (outcome.status !== "success") continue;
+      const state = states.get(read.fixtureId)!;
+      if (read.slot === "registrant") {
+        state.registrant = getAddress(outcome.result as Address);
+        continue;
+      }
+      const [owner, fuses, expiry] = outcome.result as [
+        Address,
+        number,
+        bigint,
+      ];
+      if (read.slot === "name") {
+        state.wrapperOwner = getAddress(owner);
+        state.wrapperFuses = Number(fuses);
+        state.wrapperExpiry = BigInt(expiry);
+      } else {
+        state.parentWrapperOwner = getAddress(owner);
+        state.parentWrapperFuses = Number(fuses);
+        state.parentWrapperExpiry = BigInt(expiry);
+      }
+    }
+  }
+  return states;
+}
+
+/// Gives every seeded name in the selection to one wallet, so a tester holds
+/// them on V1 and can drive the migration from the app.
+///
+/// Run it after `verify-v1`. The corpus declares which actor holds each name,
+/// so the shaped state is proved as written first and only then given away;
+/// afterwards `verify-v1` expects the recipient instead, which it reads from
+/// the run state.
+///
+/// Names the wrapper refuses to move — `CANNOT_TRANSFER` burned, or an
+/// emancipated name past its expiry — stay with their actor and are reported
+/// rather than failing the run. Operator approvals a scenario granted while
+/// shaping do not survive either, because an approval is scoped to the owner
+/// that gave it; a recipient migrating through the helper grants their own,
+/// which is what the app asks for anyway.
+export async function handover(opts: CommonOptions): Promise<void> {
+  await requireWriteableChain(opts);
+  const target = requireHandoverTarget(opts);
+  const state = loadRunState(opts);
+  if (!state) {
+    throw new Error(
+      `no fixture run state at ${runStatePath(opts)}; run "fixture seed-v1" first`,
+    );
+  }
+
+  const actors = accounts(opts);
+  const { chain, client, wallet } = clients(opts);
+  assertRunStateCompatible(opts, state, chain.id, actors);
+
+  const prior = state.names.find((n) => n.handedOverTo)?.handedOverTo;
+  if (prior && getAddress(prior) !== target) {
+    throw new Error(
+      `${runStatePath(opts)} already handed names to ${prior}; a second recipient would split ` +
+        "the cohort across wallets, so use a fresh --work-dir",
+    );
+  }
+
+  const byId = new Map(state.names.map((n) => [n.fixtureId, n]));
+  const selected = loadFixture(opts).filter(
+    (r) => byId.get(r.fixture_id)?.setupComplete,
+  );
+  if (!selected.length) {
+    throw new Error(
+      "no fully seeded names in this selection; widen the selection or seed it first",
+    );
+  }
+
+  await assertCanReceiveNames(client, target);
+
+  const v1 = v1Addresses(opts);
+  const ctx = planContext(opts, state.fixtureContracts, state.batcher);
+  const executor: Executor = {
+    opts,
+    chain,
+    client,
+    wallet,
+    batcher: state.batcher,
+    actors: new Map(actors.map((a) => [a.alias, a])),
+  };
+
+  const { timestamp } = await client.getBlock();
+  const current = await readHandoverState(
+    client,
+    selected,
+    { baseRegistrar: v1.base.address, wrapper: v1.wrapper.address },
+    BigInt(timestamp),
+  );
+
+  const perName = new Map<string, PlannedCall[]>();
+  const skipped: { fixtureId: string; subject: string; reason: string }[] = [];
+  const holders = new Set<Address>();
+  // Names that stay where they are. A child whose parent cannot move is not one
+  // of them: the child itself still reaches the recipient, and the report says
+  // separately that its parent did not.
+  const stayed = new Set<string>();
+  for (const row of selected) {
+    const plan = planHandover(row, ctx, target, current.get(row.fixture_id)!);
+    for (const skip of plan.skips) {
+      skipped.push({ fixtureId: row.fixture_id, ...skip });
+      if (skip.subject === row.scenario.name) stayed.add(row.fixture_id);
+    }
+    for (const holder of plan.holders) holders.add(holder);
+    if (plan.calls.length) perName.set(row.fixture_id, plan.calls);
+  }
+
+  await approveBatcherAsOperator(executor, holders, [
+    v1.base.address,
+    v1.wrapper.address,
+  ]);
+
+  // A name the plan asks nothing of is already the recipient's. Recording that
+  // before the batches run keeps an interrupted handover resumable.
+  for (const row of selected) {
+    if (perName.has(row.fixture_id) || stayed.has(row.fixture_id)) continue;
+    byId.get(row.fixture_id)!.handedOverTo = target;
+  }
+  saveRunState(opts, state);
+
+  const transactions = new Map<string, Hex[]>();
+  await executePlannedCalls(
+    executor,
+    perName,
+    (fixtureId, hash) => {
+      transactions.set(fixtureId, [
+        ...(transactions.get(fixtureId) ?? []),
+        hash,
+      ]);
+    },
+    (fixtureId) => {
+      const run = byId.get(fixtureId);
+      if (run && !stayed.has(fixtureId)) run.handedOverTo = target;
+      saveRunState(opts, state);
+    },
+  );
+
+  const reportPath = join(resolve(opts.workDir), "fixture-handover.json");
+  writeFileSync(
+    reportPath,
+    `${JSON.stringify(
+      {
+        target,
+        selected: selected.length,
+        moved: [...perName.keys()].map((fixtureId) => ({
+          fixtureId,
+          transactions: transactions.get(fixtureId) ?? [],
+        })),
+        skipped,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const reasons: Record<string, number> = {};
+  for (const skip of skipped) {
+    reasons[skip.reason] = (reasons[skip.reason] ?? 0) + 1;
+  }
+  console.log(
+    JSON.stringify(
+      {
+        target,
+        selected: selected.length,
+        moved: perName.size,
+        stayed: stayed.size,
+        alreadyHeld: selected.length - perName.size - stayed.size,
+        skipped: skipped.length,
+        skippedByReason: reasons,
+        report: reportPath,
+      },
+      null,
+      2,
+    ),
+  );
+  console.log(
+    `next: bun run migration -- fixture verify-v1 --work-dir ${opts.workDir}`,
+  );
+}
+
 async function fundActorAccounts(
   opts: CommonOptions,
   floor: string,
@@ -1117,6 +1514,12 @@ export async function runFixtureSeedStage(
   const { path: premigrationCsv, labels } = await seedV1(opts);
   console.log("fixture: verifying the shaped V1 state");
   await verifyV1(opts);
+  // Giving the names away comes last, so the state is proved as the corpus
+  // declares it before the owner it declares stops being the one holding it.
+  if (opts.handoverTo) {
+    console.log(`fixture: handing the corpus to ${opts.handoverTo}`);
+    await handover(opts);
+  }
 
   return { labels, premigrationCsv };
 }
@@ -1158,6 +1561,10 @@ function addCommon(command: Command): Command {
       "--rpc-state-controls",
       "Enable impersonation/time control RPC methods",
       false,
+    )
+    .option(
+      "--handover-to <address>",
+      "Give the seeded names to this wallet once their state is checked",
     );
 }
 
@@ -1228,7 +1635,12 @@ export function addFixtureSubcommands(program: Command): Command {
         "Register the corpus on v1 and shape each name's pre-migration state (before phase 3)",
       ),
     ).action(async (raw) => {
-      await seedV1(normalizeOptions(raw));
+      const opts = normalizeOptions(raw);
+      // Asking for a handover asks for the checks that have to precede it: the
+      // corpus declares which actor holds each name, so the shaped state is
+      // proved as written before that owner stops being the one holding it.
+      if (opts.handoverTo) await runFixtureSeedStage(opts);
+      else await seedV1(opts);
     }),
   );
   program.addCommand(
@@ -1237,6 +1649,13 @@ export function addFixtureSubcommands(program: Command): Command {
         "After seed-v1: read the shaped V1 state back and check it against each scenario",
       ),
     ).action((raw) => verifyV1(normalizeOptions(raw))),
+  );
+  program.addCommand(
+    addCommon(
+      new Command("handover").description(
+        "After verify-v1: give every seeded name in the selection to one wallet",
+      ),
+    ).action((raw) => handover(normalizeOptions(raw))),
   );
   return program;
 }

--- a/contracts/script/migrationFixture.ts
+++ b/contracts/script/migrationFixture.ts
@@ -36,6 +36,7 @@ import {
   bufferedGas,
   clients,
   fixtureDigest,
+  fundingTargets,
   loadDotEnv,
   loadFixture,
   networkChain,
@@ -1109,9 +1110,15 @@ async function fundActorAccounts(
     },
     floor,
   );
-  for (const a of actors) {
-    const balance = await client.getBalance({ address: a.account.address });
-    console.log(`  ${a.alias} ${a.account.address} ${balance}`);
+  // Reported per account rather than per alias. Three identical rows under
+  // three alias names read as three funded accounts, which is the misreading a
+  // nominated owner wallet invites, and the requirement is no longer the same
+  // on every row.
+  for (const target of fundingTargets(actors, floor)) {
+    const balance = await client.getBalance({ address: target.address });
+    console.log(
+      `  ${target.aliases.join("+")} ${target.address} ${balance} (needs ${target.required})`,
+    );
   }
 }
 
@@ -1181,9 +1188,12 @@ function addCommon(command: Command): Command {
     );
 }
 
-/// Nominates the wallet that owns every seeded name. Only the command that
-/// registers names takes it: on any other it would read as a way to change who
-/// owns them, which nothing after seeding can do.
+/// Nominates the wallet that will own every seeded name. The commands up to and
+/// including registration take it: seeding registers to that wallet, and funding
+/// has to top up the accounts seeding will sign from, which once a wallet is
+/// nominated are that wallet rather than the mnemonic's owner accounts. Nothing
+/// after registration takes it, where it would instead read as a way to change
+/// who owns the names, which no command can do.
 function addOwnerKeyOption(command: Command): Command {
   return command.option(
     "--fixture-owner-key <key>",
@@ -1237,12 +1247,14 @@ export function addFixtureSubcommands(program: Command): Command {
     ).action((raw) => verify(normalizeOptions(raw))),
   );
   program.addCommand(
-    addCommon(
-      new Command("fund-actors").description(
-        "Top up the fixture actor accounts",
+    addOwnerKeyOption(
+      addCommon(
+        new Command("fund-actors").description(
+          "Top up the fixture actor accounts",
+        ),
       ),
     )
-      .option("--floor <eth>", "Minimum balance per actor", "0.5")
+      .option("--floor <eth>", "Minimum balance per actor alias", "0.5")
       .action((raw) => fundActorAccounts(normalizeOptions(raw), raw.floor)),
   );
   program.addCommand(

--- a/contracts/script/migrationFixture.ts
+++ b/contracts/script/migrationFixture.ts
@@ -1440,6 +1440,7 @@ export async function handover(opts: CommonOptions): Promise<void> {
   // Names the recipient does not end up holding, which is decided by the name's
   // own transfer rather than by anything planned around it.
   const stayed = new Set<string>();
+  const nameHolder = new Map<string, Address>();
   for (const row of selected) {
     const plan = planHandover(row, ctx, target, current.get(row.fixture_id)!);
     for (const skip of plan.skips) {
@@ -1447,6 +1448,7 @@ export async function handover(opts: CommonOptions): Promise<void> {
       if (skip.subject === row.scenario.name) stayed.add(row.fixture_id);
     }
     for (const holder of plan.holders) holders.add(holder);
+    nameHolder.set(row.fixture_id, plan.nameHolder);
     if (plan.calls.length) perName.set(row.fixture_id, plan.calls);
   }
 
@@ -1471,9 +1473,7 @@ export async function handover(opts: CommonOptions): Promise<void> {
   for (const row of selected) {
     if (perName.has(row.fixture_id) || stayed.has(row.fixture_id)) continue;
     byId.get(row.fixture_id)!.handedOverTo = target;
-    byId.get(row.fixture_id)!.handedOverFrom = preMigrationOwnerAlias(
-      row.scenario,
-    );
+    byId.get(row.fixture_id)!.handedOverFrom = nameHolder.get(row.fixture_id);
   }
   saveRunState(opts, state);
 
@@ -1534,9 +1534,7 @@ export async function handover(opts: CommonOptions): Promise<void> {
         const run = byId.get(fixtureId);
         if (run && !stayed.has(fixtureId)) {
           run.handedOverTo = target;
-          run.handedOverFrom = preMigrationOwnerAlias(
-            rowById.get(fixtureId)!.scenario,
-          );
+          run.handedOverFrom = nameHolder.get(fixtureId);
         }
         saveRunState(opts, state);
       },
@@ -1660,7 +1658,7 @@ function addCommon(command: Command): Command {
       "--scenarios <scenarios>",
       "Comma-separated execution scenarios, e.g. live_now",
     )
-    .option("--fixture-ids <ids>", "Comma-separated fixture IDs")
+    .option("--ids <ids>", "Comma-separated fixture IDs")
     .option(
       "--replicas-per-vector <count>",
       "Keep at most N replicas of each source scenario",

--- a/contracts/script/migrationFixture.ts
+++ b/contracts/script/migrationFixture.ts
@@ -85,6 +85,22 @@ import {
   impersonateAccount,
   type Executor,
 } from "./migrationFixture/execute.js";
+
+import { BaseRegistrar, NameWrapper, RegistrarOwnershipAbi } from "./abis.js";
+
+/// Reads and writes the handover makes, and the registrar-ownership surface the
+/// v1 controller check walks.
+/// The approval pair is declared once but sent to both v1 registrars: ERC-721
+/// and ERC-1155 spell it identically, so one fragment addresses either.
+const HANDOVER_ABI = [
+  ...NameWrapper.supportsInterface,
+  ...NameWrapper.getData,
+  ...BaseRegistrar.ownerOf,
+  ...BaseRegistrar.nameExpires,
+  ...BaseRegistrar.isApprovedForAll,
+  ...BaseRegistrar.setApprovalForAll,
+] as const;
+const PRIOR_RENEWER_ABI = RegistrarOwnershipAbi;
 import {
   type CommonOptions,
   type FixtureEnvelope,
@@ -165,23 +181,6 @@ function planContext(
     },
   };
 }
-
-const PRIOR_RENEWER_ABI = [
-  {
-    type: "function",
-    name: "owner",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [{ type: "address" }],
-  },
-  {
-    type: "function",
-    name: "transferRegistrarOwnership",
-    stateMutability: "nonpayable",
-    inputs: [{ type: "address", name: "newOwner" }],
-    outputs: [],
-  },
-] as const;
 
 async function ownerWallet(opts: CommonOptions, owner: Address) {
   const chain = networkChain(opts.network, opts.rpcUrl, opts.chainId);
@@ -1100,61 +1099,6 @@ export async function verifyV1(opts: CommonOptions): Promise<void> {
 }
 
 const ERC1155_RECEIVER_INTERFACE_ID = "0x4e2312e0" as Hex;
-
-const HANDOVER_ABI = [
-  {
-    type: "function",
-    name: "supportsInterface",
-    stateMutability: "view",
-    inputs: [{ name: "interfaceId", type: "bytes4" }],
-    outputs: [{ name: "", type: "bool" }],
-  },
-  {
-    type: "function",
-    name: "getData",
-    stateMutability: "view",
-    inputs: [{ name: "id", type: "uint256" }],
-    outputs: [
-      { name: "owner", type: "address" },
-      { name: "fuses", type: "uint32" },
-      { name: "expiry", type: "uint64" },
-    ],
-  },
-  {
-    type: "function",
-    name: "ownerOf",
-    stateMutability: "view",
-    inputs: [{ name: "tokenId", type: "uint256" }],
-    outputs: [{ name: "", type: "address" }],
-  },
-  {
-    type: "function",
-    name: "nameExpires",
-    stateMutability: "view",
-    inputs: [{ name: "id", type: "uint256" }],
-    outputs: [{ name: "", type: "uint256" }],
-  },
-  {
-    type: "function",
-    name: "isApprovedForAll",
-    stateMutability: "view",
-    inputs: [
-      { name: "owner", type: "address" },
-      { name: "operator", type: "address" },
-    ],
-    outputs: [{ name: "", type: "bool" }],
-  },
-  {
-    type: "function",
-    name: "setApprovalForAll",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "operator", type: "address" },
-      { name: "approved", type: "bool" },
-    ],
-    outputs: [],
-  },
-] as const;
 
 /// Refuses a recipient that cannot hold a wrapped name.
 ///

--- a/contracts/script/migrationFixture.ts
+++ b/contracts/script/migrationFixture.ts
@@ -596,10 +596,16 @@ async function verify(opts: CommonOptions): Promise<void> {
 
   // Placeholder addresses are enough to prove every action resolves, and keep
   // the check runnable without deployments or an RPC.
+  //
+  // The actors are the exception: they are derived, not deployed, so the plan
+  // is built against the very addresses a run will use. A placeholder per alias
+  // would give the three owner aliases three addresses even when a nominated
+  // wallet has collapsed them onto one, which is the difference between the
+  // preview and the run that a dry run exists to rule out.
   const placeholder = (n: number) =>
     `0x${n.toString(16).padStart(40, "0")}` as Address;
   const ctx: PlanContext = {
-    actors: new Map(actors.map((a, i) => [a.alias, placeholder(0x1000 + i)])),
+    actors: new Map(actors.map((a) => [a.alias, a.account.address])),
     fixtureContracts: Object.fromEntries(
       FIXTURE_ARTIFACTS.map((f, i) => [f.name, placeholder(0x2000 + i)]),
     ),
@@ -649,6 +655,9 @@ async function verify(opts: CommonOptions): Promise<void> {
     JSON.stringify(
       {
         selected: rows.length,
+        // Null unless a wallet is nominated, so a preview says whose the names
+        // will be rather than leaving it to be read off the command line.
+        owner: ownerAddress(opts),
         sourceScenarios: perVector.size,
         replicasPerVector: {
           min: Math.min(...perVector.values()),
@@ -1205,12 +1214,14 @@ function addCommon(command: Command): Command {
     );
 }
 
-/// Nominates the wallet that will own every seeded name. The commands up to and
-/// including registration take it: seeding registers to that wallet, and funding
-/// has to top up the accounts seeding will sign from, which once a wallet is
-/// nominated are that wallet rather than the mnemonic's owner accounts. Nothing
-/// after registration takes it, where it would instead read as a way to change
-/// who owns the names, which no command can do.
+/// Nominates the wallet that will own every seeded name. Every command up to and
+/// including registration takes it, because each resolves the owner aliases:
+/// planning resolves them to preview the layout seeding will register rather
+/// than the default three-owner one, seeding registers to that wallet, and
+/// funding has to top up the accounts seeding will sign from, which once a
+/// wallet is nominated are that wallet rather than the mnemonic's owner
+/// accounts. Nothing after registration takes it, where it would instead read as
+/// a way to change who owns the names, which no command can do.
 function addOwnerKeyOption(command: Command): Command {
   return command.option(
     "--fixture-owner-key <key>",
@@ -1257,9 +1268,11 @@ function normalizeOptions(raw: any): CommonOptions {
 /// drift apart on options or behaviour.
 export function addFixtureSubcommands(program: Command): Command {
   program.addCommand(
-    addCommon(
-      new Command("verify").description(
-        "Offline: validate the selection and plan every scenario's calls",
+    addOwnerKeyOption(
+      addCommon(
+        new Command("verify").description(
+          "Offline: validate the selection and plan every scenario's calls",
+        ),
       ),
     ).action((raw) => verify(normalizeOptions(raw))),
   );

--- a/contracts/script/migrationFixture.ts
+++ b/contracts/script/migrationFixture.ts
@@ -1611,7 +1611,7 @@ export async function runFixtureSeedStage(
 ): Promise<{ labels: string[]; premigrationCsv: string }> {
   // A bad recipient must fail now, not after hours of seeding: on a rehearsal
   // the fork is torn down when the run ends, taking the corpus with it.
-  if (opts.handoverTo) {
+  if (opts.fixtureHandoverTo) {
     const target = requireHandoverTarget(opts);
     await assertCanReceiveNames(clients(opts).client, target);
   }
@@ -1622,8 +1622,8 @@ export async function runFixtureSeedStage(
   await verifyV1(opts);
   // Giving the names away comes last, so the state is proved as the corpus
   // declares it before the owner it declares stops being the one holding it.
-  if (opts.handoverTo) {
-    console.log(`fixture: handing the corpus to ${opts.handoverTo}`);
+  if (opts.fixtureHandoverTo) {
+    console.log(`fixture: handing the corpus to ${opts.fixtureHandoverTo}`);
     await handover(opts);
   }
 
@@ -1645,22 +1645,25 @@ function addCommon(command: Command): Command {
     .option("--deployment-network <name>", "V2 deployment namespace")
     .option("--v1-deployments-dir <path>", "V1 deployments root")
     .option("--v1-deployment-network <name>", "V1 deployment namespace")
-    .option("--private-key <key>", "Fixture operator private key")
+    .option("--fixture-private-key <key>", "Fixture operator private key")
     .option("--v1-owner <address>", "Canonical V1 owner address")
     .option(
       "--v1-owner-key <key>",
       "V1 owner / prior renewer owner private key",
     )
-    .option("--actor-mnemonic <mnemonic>", "Dedicated fixture actor mnemonic")
-    .option("--limit <count>", "Limit selected fixture instances")
-    .option("--tiers <tiers>", "Comma-separated popularity tiers")
     .option(
-      "--scenarios <scenarios>",
+      "--fixture-actor-mnemonic <mnemonic>",
+      "Dedicated fixture actor mnemonic",
+    )
+    .option("--fixture-limit <count>", "Limit selected fixture instances")
+    .option("--fixture-tiers <tiers>", "Comma-separated popularity tiers")
+    .option(
+      "--fixture-scenarios <scenarios>",
       "Comma-separated execution scenarios, e.g. live_now",
     )
-    .option("--ids <ids>", "Comma-separated fixture IDs")
+    .option("--fixture-ids <ids>", "Comma-separated fixture IDs")
     .option(
-      "--replicas-per-vector <count>",
+      "--fixture-replicas-per-vector <count>",
       "Keep at most N replicas of each source scenario",
     )
     .option(
@@ -1675,7 +1678,7 @@ function addCommon(command: Command): Command {
 /// select the recipient, which on `verify-v1` in particular would be a trap.
 function addHandoverOption(command: Command): Command {
   return command.option(
-    "--handover-to <address>",
+    "--fixture-handover-to <address>",
     "Give the seeded names to this wallet once their state is checked",
   );
 }
@@ -1753,7 +1756,7 @@ export function addFixtureSubcommands(program: Command): Command {
       // Asking for a handover asks for the checks that have to precede it: the
       // corpus declares which actor holds each name, so the shaped state is
       // proved as written before that owner stops being the one holding it.
-      if (opts.handoverTo) await runFixtureSeedStage(opts);
+      if (opts.fixtureHandoverTo) await runFixtureSeedStage(opts);
       else await seedV1(opts);
     }),
   );

--- a/contracts/script/migrationFixture/config.ts
+++ b/contracts/script/migrationFixture/config.ts
@@ -210,9 +210,9 @@ export function fixtureDigest(rows: FixtureEnvelope[]): Hex {
   return keccak256(stringToHex(rows.map((r) => r.fixture_id).join("\n")));
 }
 
-/// The aliases the corpus ever names as a name's owner. Measured across all
-/// 7,104 scenarios, a terminal owner is only ever one of these three;
-/// `operator` and `attacker` appear solely as counterparties.
+/// The aliases the corpus ever names as a name's owner. Across every scenario a
+/// terminal owner is only ever one of these three; `operator` and `attacker`
+/// appear solely as counterparties.
 const OWNER_ALIASES = new Set(["owner_a", "owner_b", "owner_c"]);
 
 /// Builds the named actor set. Unlike the previous hash-derived scheme, an alias

--- a/contracts/script/migrationFixture/config.ts
+++ b/contracts/script/migrationFixture/config.ts
@@ -162,7 +162,7 @@ export function loadFixture(opts: CommonOptions): FixtureEnvelope[] {
   if (!existsSync(file)) throw new Error(`missing fixture file: ${file}`);
 
   const tiers = splitList(opts.tiers);
-  const ids = splitList(opts.fixtureIds);
+  const ids = splitList(opts.ids);
   const scenarios = splitList(opts.scenarios);
 
   let rows = readFileSync(file, "utf8")

--- a/contracts/script/migrationFixture/config.ts
+++ b/contracts/script/migrationFixture/config.ts
@@ -244,6 +244,12 @@ export function requirePrivateKey(opts: CommonOptions): Hex {
 /// name moves. There is deliberately no environment fallback: giving the corpus
 /// away is irreversible, so the recipient is named on the command line every
 /// time rather than inherited from a shell.
+/// Case-insensitive address comparison, for the many places one address read
+/// off the chain has to be matched against another that was checksummed
+/// elsewhere.
+export const sameAddress = (a: Address, b: Address): boolean =>
+  a.toLowerCase() === b.toLowerCase();
+
 export function requireHandoverTarget(opts: CommonOptions): Address {
   const value = opts.fixtureHandoverTo ?? "";
   if (!isAddress(value)) {

--- a/contracts/script/migrationFixture/config.ts
+++ b/contracts/script/migrationFixture/config.ts
@@ -161,9 +161,9 @@ export function loadFixture(opts: CommonOptions): FixtureEnvelope[] {
   const file = fixtureFile(opts);
   if (!existsSync(file)) throw new Error(`missing fixture file: ${file}`);
 
-  const tiers = splitList(opts.tiers);
-  const ids = splitList(opts.ids);
-  const scenarios = splitList(opts.scenarios);
+  const tiers = splitList(opts.fixtureTiers);
+  const ids = splitList(opts.fixtureIds);
+  const scenarios = splitList(opts.fixtureScenarios);
 
   let rows = readFileSync(file, "utf8")
     .split(/\r?\n/)
@@ -176,7 +176,7 @@ export function loadFixture(opts: CommonOptions): FixtureEnvelope[] {
     rows = rows.filter((r) => scenarios.has(r.scenario.execution.scenario));
   }
 
-  const perVector = parseNumber(opts.replicasPerVector, 0);
+  const perVector = parseNumber(opts.fixtureReplicasPerVector, 0);
   if (perVector > 0) {
     const seen = new Map<string, number>();
     rows = rows
@@ -194,7 +194,7 @@ export function loadFixture(opts: CommonOptions): FixtureEnvelope[] {
       });
   }
 
-  const limit = parseNumber(opts.limit, 0);
+  const limit = parseNumber(opts.fixtureLimit, 0);
   if (limit > 0) rows = rows.slice(0, limit);
 
   const seenIds = new Set<string>();
@@ -215,10 +215,10 @@ export function fixtureDigest(rows: FixtureEnvelope[]): Hex {
 /// maps to a fixed mnemonic index so `owner_b` is the same account everywhere.
 export function accounts(opts: CommonOptions): FixtureActor[] {
   const mnemonic =
-    opts.actorMnemonic ?? process.env.MIGRATION_FIXTURE_ACTOR_MNEMONIC;
+    opts.fixtureActorMnemonic ?? process.env.MIGRATION_FIXTURE_ACTOR_MNEMONIC;
   if (!mnemonic) {
     throw new Error(
-      "missing --actor-mnemonic or MIGRATION_FIXTURE_ACTOR_MNEMONIC; use a dedicated fixture mnemonic",
+      "missing --fixture-actor-mnemonic or MIGRATION_FIXTURE_ACTOR_MNEMONIC; use a dedicated fixture mnemonic",
     );
   }
   return ACTOR_ALIASES.map((alias, accountIndex) => ({
@@ -229,10 +229,12 @@ export function accounts(opts: CommonOptions): FixtureActor[] {
 
 export function requirePrivateKey(opts: CommonOptions): Hex {
   const key =
-    opts.privateKey ??
+    opts.fixturePrivateKey ??
     (process.env.MIGRATION_FIXTURE_PRIVATE_KEY as Hex | undefined);
   if (!key)
-    throw new Error("missing --private-key or MIGRATION_FIXTURE_PRIVATE_KEY");
+    throw new Error(
+      "missing --fixture-private-key or MIGRATION_FIXTURE_PRIVATE_KEY",
+    );
   return key;
 }
 
@@ -243,7 +245,7 @@ export function requirePrivateKey(opts: CommonOptions): Hex {
 /// away is irreversible, so the recipient is named on the command line every
 /// time rather than inherited from a shell.
 export function requireHandoverTarget(opts: CommonOptions): Address {
-  const value = opts.handoverTo ?? "";
+  const value = opts.fixtureHandoverTo ?? "";
   if (!isAddress(value)) {
     throw new Error(`missing or malformed handover recipient: "${value}"`);
   }

--- a/contracts/script/migrationFixture/config.ts
+++ b/contracts/script/migrationFixture/config.ts
@@ -5,9 +5,12 @@ import {
   createPublicClient,
   createWalletClient,
   defineChain,
+  getAddress,
   http,
+  isAddress,
   keccak256,
   stringToHex,
+  type Address,
   type Chain,
   type Hex,
 } from "viem";
@@ -231,6 +234,20 @@ export function requirePrivateKey(opts: CommonOptions): Hex {
   if (!key)
     throw new Error("missing --private-key or MIGRATION_FIXTURE_PRIVATE_KEY");
   return key;
+}
+
+/// The wallet a handover gives the cohort to.
+///
+/// Checksummed here so a typo in a hand-copied address is caught before any
+/// name moves. There is deliberately no environment fallback: giving the corpus
+/// away is irreversible, so the recipient is named on the command line every
+/// time rather than inherited from a shell.
+export function requireHandoverTarget(opts: CommonOptions): Address {
+  const value = opts.handoverTo ?? "";
+  if (!isAddress(value)) {
+    throw new Error(`missing or malformed handover recipient: "${value}"`);
+  }
+  return getAddress(value);
 }
 
 export function clients(opts: CommonOptions) {

--- a/contracts/script/migrationFixture/config.ts
+++ b/contracts/script/migrationFixture/config.ts
@@ -5,9 +5,7 @@ import {
   createPublicClient,
   createWalletClient,
   defineChain,
-  getAddress,
   http,
-  isAddress,
   keccak256,
   stringToHex,
   type Address,
@@ -211,8 +209,19 @@ export function fixtureDigest(rows: FixtureEnvelope[]): Hex {
   return keccak256(stringToHex(rows.map((r) => r.fixture_id).join("\n")));
 }
 
+/// The aliases the corpus ever names as a name's owner. Measured across all
+/// 7,104 scenarios, a terminal owner is only ever one of these three;
+/// `operator` and `attacker` appear solely as counterparties.
+const OWNER_ALIASES = new Set(["owner_a", "owner_b", "owner_c"]);
+
 /// Builds the named actor set. Unlike the previous hash-derived scheme, an alias
 /// maps to a fixed mnemonic index so `owner_b` is the same account everywhere.
+///
+/// An owner key collapses the three owner aliases onto the one account it
+/// controls, which is what lets a tester own every seeded name from the moment
+/// it is registered rather than receiving it afterwards. The counterparties stay
+/// on the mnemonic: an operator or an attacker is only meaningful as an address
+/// the owner is *not*.
 export function accounts(opts: CommonOptions): FixtureActor[] {
   const mnemonic =
     opts.fixtureActorMnemonic ?? process.env.MIGRATION_FIXTURE_ACTOR_MNEMONIC;
@@ -221,10 +230,43 @@ export function accounts(opts: CommonOptions): FixtureActor[] {
       "missing --fixture-actor-mnemonic or MIGRATION_FIXTURE_ACTOR_MNEMONIC; use a dedicated fixture mnemonic",
     );
   }
+  const owner = optionalOwnerKey(opts);
+  const ownerAccount = owner ? privateKeyToAccount(owner) : null;
   return ACTOR_ALIASES.map((alias, accountIndex) => ({
     alias,
-    account: mnemonicToAccount(mnemonic, { accountIndex }),
+    account:
+      ownerAccount && OWNER_ALIASES.has(alias)
+        ? ownerAccount
+        : mnemonicToAccount(mnemonic, { accountIndex }),
   }));
+}
+
+/// The wallet that owns every seeded name, when one is nominated.
+///
+/// Supplying a key rather than an address is what removes the need to transfer
+/// anything: the shaping calls a name's owner has to sign — reverse claims,
+/// operator approvals, unwraps, records written after the name leaves the
+/// batcher — can be signed as the owner, so the owner can be the tester from
+/// the start. Names the wrapper would refuse to move, `CANNOT_TRANSFER` among
+/// them, are theirs on the same terms as any other.
+export function optionalOwnerKey(opts: CommonOptions): Hex | null {
+  const key =
+    opts.fixtureOwnerKey ??
+    (process.env.MIGRATION_FIXTURE_OWNER_KEY as Hex | undefined);
+  if (!key) return null;
+  if (!/^0x[0-9a-fA-F]{64}$/.test(key)) {
+    throw new Error(
+      "malformed --fixture-owner-key: expected a 32-byte hex private key",
+    );
+  }
+  return key;
+}
+
+/// The address the owner key controls, for reporting which account a run put
+/// the corpus on.
+export function ownerAddress(opts: CommonOptions): Address | null {
+  const key = optionalOwnerKey(opts);
+  return key ? privateKeyToAccount(key).address : null;
 }
 
 export function requirePrivateKey(opts: CommonOptions): Hex {
@@ -236,26 +278,6 @@ export function requirePrivateKey(opts: CommonOptions): Hex {
       "missing --fixture-private-key or MIGRATION_FIXTURE_PRIVATE_KEY",
     );
   return key;
-}
-
-/// The wallet a handover gives the cohort to.
-///
-/// Checksummed here so a typo in a hand-copied address is caught before any
-/// name moves. There is deliberately no environment fallback: giving the corpus
-/// away is irreversible, so the recipient is named on the command line every
-/// time rather than inherited from a shell.
-/// Case-insensitive address comparison, for the many places one address read
-/// off the chain has to be matched against another that was checksummed
-/// elsewhere.
-export const sameAddress = (a: Address, b: Address): boolean =>
-  a.toLowerCase() === b.toLowerCase();
-
-export function requireHandoverTarget(opts: CommonOptions): Address {
-  const value = opts.fixtureHandoverTo ?? "";
-  if (!isAddress(value)) {
-    throw new Error(`missing or malformed handover recipient: "${value}"`);
-  }
-  return getAddress(value);
 }
 
 export function clients(opts: CommonOptions) {

--- a/contracts/script/migrationFixture/config.ts
+++ b/contracts/script/migrationFixture/config.ts
@@ -215,6 +215,29 @@ export function fixtureDigest(rows: FixtureEnvelope[]): Hex {
 /// appear solely as counterparties.
 const OWNER_ALIASES = new Set(["owner_a", "owner_b", "owner_c"]);
 
+/// Rejects an owner key that already belongs to a counterparty.
+///
+/// A counterparty is only ever meaningful as an address the owner is not: a
+/// tenth of the corpus migrates as the operator or the attacker precisely to
+/// prove that caller is refused. Nominating one of their keys as the owner makes
+/// those calls owner-authorised and the scenarios assert nothing, and since
+/// verification reads the same collapsed actor map, every one of them still
+/// passes. No run wants this, and nothing downstream would reveal it.
+function assertOwnerKeyIsNotCounterparty(
+  owner: Address,
+  mnemonic: string,
+): void {
+  for (const [accountIndex, alias] of ACTOR_ALIASES.entries()) {
+    if (OWNER_ALIASES.has(alias)) continue;
+    const counterparty = mnemonicToAccount(mnemonic, { accountIndex });
+    if (counterparty.address.toLowerCase() !== owner.toLowerCase()) continue;
+    throw new Error(
+      `--fixture-owner-key is the "${alias}" account ${owner}, which the corpus ` +
+        "needs as a non-owner; nominate a wallet outside the actor mnemonic",
+    );
+  }
+}
+
 /// Builds the named actor set. Unlike the previous hash-derived scheme, an alias
 /// maps to a fixed mnemonic index so `owner_b` is the same account everywhere.
 ///
@@ -233,6 +256,9 @@ export function accounts(opts: CommonOptions): FixtureActor[] {
   }
   const owner = optionalOwnerKey(opts);
   const ownerAccount = owner ? privateKeyToAccount(owner) : null;
+  if (ownerAccount) {
+    assertOwnerKeyIsNotCounterparty(ownerAccount.address, mnemonic);
+  }
   return ACTOR_ALIASES.map((alias, accountIndex) => ({
     alias,
     account:

--- a/contracts/script/migrationFixture/config.ts
+++ b/contracts/script/migrationFixture/config.ts
@@ -7,6 +7,7 @@ import {
   defineChain,
   http,
   keccak256,
+  parseEther,
   stringToHex,
   type Address,
   type Chain,
@@ -239,6 +240,45 @@ export function accounts(opts: CommonOptions): FixtureActor[] {
         ? ownerAccount
         : mnemonicToAccount(mnemonic, { accountIndex }),
   }));
+}
+
+/// One account a funding run has to top up, and what it needs.
+export type FundingTarget = {
+  address: Address;
+  /// Every alias that resolved to this account, in actor order.
+  aliases: string[];
+  /// The floor, counted once per alias sharing the account.
+  required: bigint;
+};
+
+/// Groups the actors by the account each alias actually resolves to.
+///
+/// An alias is not an account. Nominating an owner wallet puts the three owner
+/// aliases on one address, and that address then signs all three aliases' share
+/// of the seeding traffic, so a single floor funds a third of what it is about
+/// to spend. Charging the floor per alias and topping the account up to their
+/// sum leaves the default case, where every alias is its own account, exactly
+/// where it was.
+export function fundingTargets(
+  actors: Iterable<FixtureActor>,
+  floorEth: string,
+): FundingTarget[] {
+  const floor = parseEther(floorEth);
+  const targets = new Map<string, FundingTarget>();
+  for (const actor of actors) {
+    const address = actor.account.address;
+    // Grouped case-insensitively: the addresses come from two derivation paths,
+    // and case is not part of what makes two of them the same account.
+    const key = address.toLowerCase();
+    const target = targets.get(key);
+    if (target) {
+      target.aliases.push(actor.alias);
+      target.required += floor;
+    } else {
+      targets.set(key, { address, aliases: [actor.alias], required: floor });
+    }
+  }
+  return [...targets.values()];
 }
 
 /// The wallet that owns every seeded name, when one is nominated.

--- a/contracts/script/migrationFixture/execute.ts
+++ b/contracts/script/migrationFixture/execute.ts
@@ -2,7 +2,6 @@ import {
   createWalletClient,
   encodeFunctionData,
   http,
-  parseEther,
   type Address,
   type Chain,
   type Hex,
@@ -12,6 +11,7 @@ import { Artifact_MigrationFixtureBatcher } from "generated/artifacts/MigrationF
 
 import {
   bufferedGas,
+  fundingTargets,
   receipt,
   rpcAny,
   v1Deployment,
@@ -294,21 +294,24 @@ export async function assertStateControls(opts: CommonOptions): Promise<void> {
 /// Tops every fixture actor up to a floor balance from the operator key. Actor
 /// transactions are a large share of seeding, so they need funding before a run
 /// rather than failing part-way through.
+///
+/// Funding is per account, not per alias: aliases can share an account, and a
+/// shared one has to arrive holding every alias's floor. Topping up per alias
+/// would stop at the first, because the account already clears the check the
+/// others are measured against.
 export async function fundActors(
   ex: Executor,
   floorEth: string,
 ): Promise<void> {
-  const floor = parseEther(floorEth);
-  for (const [alias, actor] of ex.actors) {
+  for (const target of fundingTargets(ex.actors.values(), floorEth)) {
     const balance = (await ex.client.getBalance({
-      address: actor.account.address,
+      address: target.address,
     })) as bigint;
-    if (balance >= floor) continue;
-    const topUp = floor - balance;
+    if (balance >= target.required) continue;
     const hash = await ex.wallet.sendTransaction({
-      to: actor.account.address,
-      value: topUp,
+      to: target.address,
+      value: target.required - balance,
     });
-    await receipt(ex.client, hash, `fund ${alias}`);
+    await receipt(ex.client, hash, `fund ${target.aliases.join("+")}`);
   }
 }

--- a/contracts/script/migrationFixture/execute.ts
+++ b/contracts/script/migrationFixture/execute.ts
@@ -17,6 +17,7 @@ import {
   v1Deployment,
   withPriceBuffer,
 } from "./config.js";
+import { EthRegistrarController } from "../abis.js";
 import type { PlannedCall, Signer } from "./plan.js";
 import type { CommonOptions, FixtureActor } from "./types.js";
 
@@ -133,26 +134,7 @@ export async function executePlannedCalls(
   }
 }
 
-const RENT_PRICE_ABI = [
-  {
-    type: "function",
-    name: "rentPrice",
-    stateMutability: "view",
-    inputs: [
-      { name: "name", type: "string" },
-      { name: "duration", type: "uint256" },
-    ],
-    outputs: [
-      {
-        type: "tuple",
-        components: [
-          { name: "base", type: "uint256" },
-          { name: "premium", type: "uint256" },
-        ],
-      },
-    ],
-  },
-] as const;
+const RENT_PRICE_ABI = EthRegistrarController.rentPrice;
 
 /// Resolves any quoted price into the value the call must carry.
 async function resolveCallValue(

--- a/contracts/script/migrationFixture/execute.ts
+++ b/contracts/script/migrationFixture/execute.ts
@@ -299,15 +299,30 @@ export async function assertStateControls(opts: CommonOptions): Promise<void> {
 /// shared one has to arrive holding every alias's floor. Topping up per alias
 /// would stop at the first, because the account already clears the check the
 /// others are measured against.
+///
+/// An alias can also resolve to the account paying for the top-ups, which a
+/// nominated owner wallet does when it holds the operator key too. Nothing can
+/// be sent to it: a transfer out of an account and back leaves it poorer by the
+/// gas. It is reported as a shortfall to fund elsewhere instead, which is the
+/// same promise the command makes for every other account — that what the run
+/// needs is there before the first name is registered.
 export async function fundActors(
   ex: Executor,
   floorEth: string,
 ): Promise<void> {
+  const funder = String(ex.wallet.account.address).toLowerCase();
   for (const target of fundingTargets(ex.actors.values(), floorEth)) {
     const balance = (await ex.client.getBalance({
       address: target.address,
     })) as bigint;
     if (balance >= target.required) continue;
+    if (target.address.toLowerCase() === funder) {
+      throw new Error(
+        `${target.aliases.join("+")} is the funding account ${target.address}, ` +
+          `which holds ${balance} of the ${target.required} wei this selection needs ` +
+          "of it; fund it from outside the run",
+      );
+    }
     const hash = await ex.wallet.sendTransaction({
       to: target.address,
       value: target.required - balance,

--- a/contracts/script/migrationFixture/plan.ts
+++ b/contracts/script/migrationFixture/plan.ts
@@ -1209,6 +1209,8 @@ export function planHandover(
   const skips: HandoverSkip[] = [];
   const holders: Address[] = [];
 
+  /// Returns whether the subject ends up with the recipient — either because a
+  /// transfer was planned, or because it is already there.
   const move = (args: {
     subject: string;
     wrapped: boolean;
@@ -1217,23 +1219,23 @@ export function planHandover(
     expiry: bigint;
     tokenId: bigint;
     node: Hex;
-  }): void => {
+  }): boolean => {
     const { subject, wrapped, holder, fuses, expiry, tokenId, node } = args;
-    if (sameAddress(holder, to)) return;
+    if (sameAddress(holder, to)) return true;
     if (holder === zeroAddress) {
       skips.push({ subject, reason: "no v1 holder" });
-      return;
+      return false;
     }
     if (!wrapped && sameAddress(holder, ctx.addresses.wrapper)) {
       skips.push({ subject, reason: "held by the NameWrapper" });
-      return;
+      return false;
     }
     const blocked = wrapped
       ? wrapperTransferBlock(fuses, expiry, state.now)
       : null;
     if (blocked) {
       skips.push({ subject, reason: blocked });
-      return;
+      return false;
     }
     holders.push(holder);
     calls.push(
@@ -1251,11 +1253,12 @@ export function planHandover(
             : `${row.fixture_id} handover (${subject})`,
       }),
     );
+    return true;
   };
 
   const topLabel = scenario.top_level_label;
   const wrapped = isWrapped(form);
-  move({
+  const moved = move({
     subject: scenario.name,
     wrapped,
     holder: wrapped ? state.wrapperOwner : state.registrant,
@@ -1265,16 +1268,26 @@ export function planHandover(
     node: namehash(scenario.name) as Hex,
   });
 
+  // The parent travels only with a child that travels. Moving it alone splits a
+  // pair whose whole reason for going together is that neither wallet can drive
+  // the scenario without the other: the recipient could not migrate a subname it
+  // does not hold, and the actor left holding the subname could no longer
+  // migrate the parent above it.
   if (isChild(form)) {
-    move({
-      subject: `${topLabel}.eth`,
-      wrapped: true,
-      holder: state.parentWrapperOwner ?? zeroAddress,
-      fuses: state.parentWrapperFuses ?? 0,
-      expiry: state.parentWrapperExpiry ?? 0n,
-      tokenId: tokenIdOf(topLabel),
-      node: namehash(`${topLabel}.eth`) as Hex,
-    });
+    const parent = `${topLabel}.eth`;
+    if (moved) {
+      move({
+        subject: parent,
+        wrapped: true,
+        holder: state.parentWrapperOwner ?? zeroAddress,
+        fuses: state.parentWrapperFuses ?? 0,
+        expiry: state.parentWrapperExpiry ?? 0n,
+        tokenId: tokenIdOf(topLabel),
+        node: namehash(parent) as Hex,
+      });
+    } else {
+      skips.push({ subject: parent, reason: "its child stayed" });
+    }
   }
 
   return { calls, skips, holders };

--- a/contracts/script/migrationFixture/plan.ts
+++ b/contracts/script/migrationFixture/plan.ts
@@ -28,6 +28,7 @@ import {
   type SetupStep,
 } from "./types.js";
 
+import { sameAddress } from "./config.js";
 import {
   BaseRegistrar,
   EnsRegistry,
@@ -969,9 +970,6 @@ export type HandoverPlan = {
   /// compare against, since it may not be the actor the corpus declares.
   nameHolder: Address;
 };
-
-const sameAddress = (a: Address, b: Address): boolean =>
-  a.toLowerCase() === b.toLowerCase();
 
 /// Mirrors `NameWrapper._beforeTransfer`: an emancipated name is frozen once it
 /// expires, and a live one is frozen by `CANNOT_TRANSFER`. Reproducing the rule

--- a/contracts/script/migrationFixture/plan.ts
+++ b/contracts/script/migrationFixture/plan.ts
@@ -930,16 +930,14 @@ export function planSetupSteps(
     );
   }
 
-  // A subname's parent goes to its owner too. Creating the child needs the
-  // batcher to hold the parent, so the parent is wrapped to the batcher and
-  // would otherwise stay there — leaving a holder who can never migrate the
-  // subname, because `MigrationHelper` refuses one whose parent has not
-  // migrated and only the parent's owner can migrate the parent.
+  // A subname's parent goes to an owner too. Creating the child needs the
+  // batcher to hold the parent, so leaving it there would leave a holder who can
+  // never migrate the subname: `MigrationHelper` refuses a child whose parent
+  // has not migrated, and only the parent's owner can migrate the parent.
   //
-  // The corpus declares whose it should be and the planner has always ignored
-  // it, defaulting to the batcher; use the declared owner, falling back to the
-  // child's. The parent carries `CANNOT_UNWRAP` and never `CANNOT_TRANSFER`, so
-  // this always moves.
+  // The owner is the one the corpus declares for the parent, or the child's when
+  // it declares none. The parent carries `CANNOT_UNWRAP` and never
+  // `CANNOT_TRANSFER`, so this always moves.
   if (child) {
     const parentOwner = stripActorPrefix(
       scenario.v1.parent_fixture?.owner_actor ?? terminalOwner,

--- a/contracts/script/migrationFixture/plan.ts
+++ b/contracts/script/migrationFixture/plan.ts
@@ -28,7 +28,6 @@ import {
   type SetupStep,
 } from "./types.js";
 
-import { sameAddress } from "./config.js";
 import {
   BaseRegistrar,
   EnsRegistry,
@@ -132,7 +131,7 @@ export function tokenIdOf(label: string): bigint {
 /// `signer` and `from` are separate because an approved operator may send on
 /// the holder's behalf, which is how a whole cohort moves in batches instead of
 /// one transaction per name.
-export function transferNameCalls(args: {
+function transferNameCalls(args: {
   wrapped: boolean;
   signer: Signer;
   from: Address;
@@ -926,178 +925,38 @@ export function planSetupSteps(
         tokenId,
         node,
         addresses: ctx.addresses,
-        label: `${row.fixture_id} handover`,
+        label: `${row.fixture_id} owner transfer`,
+      }),
+    );
+  }
+
+  // A subname's parent goes to its owner too. Creating the child needs the
+  // batcher to hold the parent, so the parent is wrapped to the batcher and
+  // would otherwise stay there — leaving a holder who can never migrate the
+  // subname, because `MigrationHelper` refuses one whose parent has not
+  // migrated and only the parent's owner can migrate the parent.
+  //
+  // The corpus declares whose it should be and the planner has always ignored
+  // it, defaulting to the batcher; use the declared owner, falling back to the
+  // child's. The parent carries `CANNOT_UNWRAP` and never `CANNOT_TRANSFER`, so
+  // this always moves.
+  if (child) {
+    const parentOwner = stripActorPrefix(
+      scenario.v1.parent_fixture?.owner_actor ?? terminalOwner,
+    );
+    calls.push(
+      ...transferNameCalls({
+        wrapped: true,
+        signer: BATCHER,
+        from: ctx.batcher,
+        to: resolveRef(parentOwner, ctx),
+        tokenId,
+        node: topNode,
+        addresses: ctx.addresses,
+        label: `${row.fixture_id} parent owner transfer`,
       }),
     );
   }
 
   return calls;
-}
-
-/// The wrapper treats a `.eth` 2LD as expiring when its grace period opens,
-/// which is what decides whether a transfer is refused.
-const WRAPPER_GRACE_PERIOD = 90n * 86_400n;
-
-/// What a name looks like on chain when a handover is planned, read once per
-/// name rather than replayed from the seeding plan — a name may have moved
-/// between actors during setup, and a rerun must see where it actually is.
-export type HandoverState = {
-  /// NameWrapper owner, fuses and expiry for the name's own node.
-  wrapperOwner: Address;
-  wrapperFuses: number;
-  wrapperExpiry: bigint;
-  /// BaseRegistrar registrant of the 2LD. For a wrapped name this is the
-  /// NameWrapper itself.
-  registrant: Address;
-  /// The same wrapper reading for a child's parent 2LD.
-  parentWrapperOwner?: Address;
-  parentWrapperFuses?: number;
-  parentWrapperExpiry?: bigint;
-  /// Seconds since the epoch the plan is built against.
-  now: bigint;
-};
-
-/// A name, or a child's parent, the handover cannot move, and why.
-export type HandoverSkip = { subject: string; reason: string };
-
-export type HandoverPlan = {
-  calls: PlannedCall[];
-  skips: HandoverSkip[];
-  /// Addresses the plan moves a token away from. Each has to approve the
-  /// batcher before the batch runs.
-  holders: Address[];
-  /// Who holds the name itself right now — which is what a later check has to
-  /// compare against, since it may not be the actor the corpus declares.
-  nameHolder: Address;
-};
-
-/// Mirrors `NameWrapper._beforeTransfer`: an emancipated name is frozen once it
-/// expires, and a live one is frozen by `CANNOT_TRANSFER`. Reproducing the rule
-/// here turns a whole batch that would revert on one member into a name that is
-/// reported as left behind.
-function wrapperTransferBlock(
-  fuses: number,
-  expiry: bigint,
-  now: bigint,
-): string | null {
-  const effective =
-    fuses & FUSES.IS_DOT_ETH ? expiry - WRAPPER_GRACE_PERIOD : expiry;
-  if (effective < now) {
-    return fuses & FUSES.PARENT_CANNOT_CONTROL ? "expired" : null;
-  }
-  return fuses & FUSES.CANNOT_TRANSFER ? "CANNOT_TRANSFER burned" : null;
-}
-
-/// Calls that give one seeded name to `to`, planned against what the chain
-/// currently says rather than against the plan that shaped it.
-///
-/// Every call is sent by the batcher, which the holders approve as an operator
-/// beforehand, so a cohort moves in batches rather than one transaction per
-/// name. A name already at the target plans nothing, which makes a rerun a
-/// no-op and lets an interrupted run resume.
-///
-/// A child's parent moves too: it stays wrapped to the batcher throughout
-/// setup, and the helper refuses a subname whose parent has not migrated, so a
-/// recipient holding only the child could never migrate it.
-export function planHandover(
-  row: FixtureEnvelope,
-  ctx: PlanContext,
-  to: Address,
-  state: HandoverState,
-): HandoverPlan {
-  const scenario = row.scenario;
-  const form = v1Form(scenario);
-  const topLabel = scenario.top_level_label;
-  const wrapped = isWrapped(form);
-
-  type Subject = {
-    subject: string;
-    wrapped: boolean;
-    holder: Address;
-    fuses: number;
-    expiry: bigint;
-    tokenId: bigint;
-    node: Hex;
-  };
-
-  /// Why this subject cannot move, or null when it can. A subject already at
-  /// the recipient needs no calls and blocks nothing.
-  const refusal = (s: Subject): string | null => {
-    if (sameAddress(s.holder, to)) return null;
-    if (s.holder === zeroAddress) return "no v1 holder";
-    if (!s.wrapped && sameAddress(s.holder, ctx.addresses.wrapper)) {
-      return "held by the NameWrapper";
-    }
-    return s.wrapped
-      ? wrapperTransferBlock(s.fuses, s.expiry, state.now)
-      : null;
-  };
-
-  const name: Subject = {
-    subject: scenario.name,
-    wrapped,
-    holder: wrapped ? state.wrapperOwner : state.registrant,
-    fuses: state.wrapperFuses,
-    expiry: state.wrapperExpiry,
-    tokenId: tokenIdOf(topLabel),
-    node: namehash(scenario.name) as Hex,
-  };
-
-  // A subname and the name above it are one unit. The helper refuses a subname
-  // whose parent has not migrated, and only the parent's owner can migrate the
-  // parent — so a wallet holding one without the other can drive neither. Both
-  // are therefore decided before either is scheduled: whichever is refused, the
-  // pair stays put.
-  const subjects: Subject[] = [name];
-  if (isChild(form)) {
-    subjects.push({
-      subject: `${topLabel}.eth`,
-      wrapped: true,
-      holder: state.parentWrapperOwner ?? zeroAddress,
-      fuses: state.parentWrapperFuses ?? 0,
-      expiry: state.parentWrapperExpiry ?? 0n,
-      tokenId: tokenIdOf(topLabel),
-      node: namehash(`${topLabel}.eth`) as Hex,
-    });
-  }
-
-  const refusals = subjects.map((s) => ({ subject: s, reason: refusal(s) }));
-  const refused = refusals.find((r) => r.reason);
-  if (refused) {
-    return {
-      calls: [],
-      skips: refusals.map((r) => ({
-        subject: r.subject.subject,
-        reason:
-          r.reason ??
-          (r.subject === name ? "its parent stayed" : "its child stayed"),
-      })),
-      holders: [],
-      nameHolder: name.holder,
-    };
-  }
-
-  const calls: PlannedCall[] = [];
-  const holders: Address[] = [];
-  for (const s of subjects) {
-    if (sameAddress(s.holder, to)) continue;
-    holders.push(s.holder);
-    calls.push(
-      ...transferNameCalls({
-        wrapped: s.wrapped,
-        signer: BATCHER,
-        from: s.holder,
-        to,
-        tokenId: s.tokenId,
-        node: s.node,
-        addresses: ctx.addresses,
-        label:
-          s.subject === scenario.name
-            ? `${row.fixture_id} handover`
-            : `${row.fixture_id} handover (${s.subject})`,
-      }),
-    );
-  }
-
-  return { calls, skips: [], holders, nameHolder: name.holder };
 }

--- a/contracts/script/migrationFixture/plan.ts
+++ b/contracts/script/migrationFixture/plan.ts
@@ -28,245 +28,46 @@ import {
   type SetupStep,
 } from "./types.js";
 
-/// Minimal explicit ABIs. The deployed PublicResolver exposes overloaded
-/// `setAddr`, which viem cannot disambiguate from a full artifact ABI, so the
-/// two arities are declared separately.
+import {
+  BaseRegistrar,
+  EnsRegistry,
+  EthRegistrarController,
+  NameWrapper,
+  PublicResolver,
+  ReverseRegistrar,
+} from "../abis.js";
+
+/// The v1 surfaces this planner writes through, each as narrow as the calls it
+/// makes. `setAddr` is overloaded, so the two arities stay apart: viem cannot
+/// pick between them from a single ABI.
 const RESOLVER_ABI = [
-  {
-    type: "function",
-    name: "setAddr",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "node", type: "bytes32" },
-      { name: "a", type: "address" },
-    ],
-    outputs: [],
-  },
-  {
-    type: "function",
-    name: "setText",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "node", type: "bytes32" },
-      { name: "key", type: "string" },
-      { name: "value", type: "string" },
-    ],
-    outputs: [],
-  },
-  {
-    type: "function",
-    name: "setContenthash",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "node", type: "bytes32" },
-      { name: "hash", type: "bytes" },
-    ],
-    outputs: [],
-  },
+  ...PublicResolver.setAddr,
+  ...PublicResolver.setText,
+  ...PublicResolver.setContenthash,
 ] as const;
-
-const RESOLVER_MULTICOIN_ABI = [
-  {
-    type: "function",
-    name: "setAddr",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "node", type: "bytes32" },
-      { name: "coinType", type: "uint256" },
-      { name: "a", type: "bytes" },
-    ],
-    outputs: [],
-  },
-] as const;
-
+const RESOLVER_MULTICOIN_ABI = PublicResolver.setAddrMulticoin;
 const REGISTRY_ABI = [
-  {
-    type: "function",
-    name: "setResolver",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "node", type: "bytes32" },
-      { name: "resolver", type: "address" },
-    ],
-    outputs: [],
-  },
-  {
-    type: "function",
-    name: "setTTL",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "node", type: "bytes32" },
-      { name: "ttl", type: "uint64" },
-    ],
-    outputs: [],
-  },
+  ...EnsRegistry.setResolver,
+  ...EnsRegistry.setTTL,
 ] as const;
-
 const WRAPPER_ABI = [
-  {
-    type: "function",
-    name: "wrapETH2LD",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "label", type: "string" },
-      { name: "wrappedOwner", type: "address" },
-      { name: "ownerControlledFuses", type: "uint16" },
-      { name: "resolver", type: "address" },
-    ],
-    outputs: [],
-  },
-  {
-    type: "function",
-    name: "unwrapETH2LD",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "labelhash", type: "bytes32" },
-      { name: "registrant", type: "address" },
-      { name: "controller", type: "address" },
-    ],
-    outputs: [],
-  },
-  {
-    type: "function",
-    name: "setSubnodeRecord",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "parentNode", type: "bytes32" },
-      { name: "label", type: "string" },
-      { name: "owner", type: "address" },
-      { name: "resolver", type: "address" },
-      { name: "ttl", type: "uint64" },
-      { name: "fuses", type: "uint32" },
-      { name: "expiry", type: "uint64" },
-    ],
-    outputs: [{ name: "node", type: "bytes32" }],
-  },
-  {
-    type: "function",
-    name: "setFuses",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "node", type: "bytes32" },
-      { name: "ownerControlledFuses", type: "uint16" },
-    ],
-    outputs: [{ name: "", type: "uint32" }],
-  },
-  {
-    type: "function",
-    name: "setResolver",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "node", type: "bytes32" },
-      { name: "resolver", type: "address" },
-    ],
-    outputs: [],
-  },
-  {
-    type: "function",
-    name: "setTTL",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "node", type: "bytes32" },
-      { name: "ttl", type: "uint64" },
-    ],
-    outputs: [],
-  },
-  {
-    type: "function",
-    name: "approve",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "to", type: "address" },
-      { name: "tokenId", type: "uint256" },
-    ],
-    outputs: [],
-  },
+  ...NameWrapper.wrapETH2LD,
+  ...NameWrapper.unwrapETH2LD,
+  ...NameWrapper.setSubnodeRecord,
+  ...NameWrapper.setFuses,
+  ...NameWrapper.setResolver,
+  ...NameWrapper.setTTL,
+  ...NameWrapper.approve,
 ] as const;
-
 const ERC721_ABI = [
-  {
-    type: "function",
-    name: "safeTransferFrom",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "from", type: "address" },
-      { name: "to", type: "address" },
-      { name: "tokenId", type: "uint256" },
-    ],
-    outputs: [],
-  },
-  {
-    type: "function",
-    name: "transferFrom",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "from", type: "address" },
-      { name: "to", type: "address" },
-      { name: "tokenId", type: "uint256" },
-    ],
-    outputs: [],
-  },
-  {
-    type: "function",
-    name: "reclaim",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "id", type: "uint256" },
-      { name: "owner", type: "address" },
-    ],
-    outputs: [],
-  },
-  {
-    type: "function",
-    name: "setApprovalForAll",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "operator", type: "address" },
-      { name: "approved", type: "bool" },
-    ],
-    outputs: [],
-  },
+  ...BaseRegistrar.safeTransferFrom,
+  ...BaseRegistrar.transferFrom,
+  ...BaseRegistrar.reclaim,
+  ...BaseRegistrar.setApprovalForAll,
 ] as const;
-
-const ERC1155_ABI = [
-  {
-    type: "function",
-    name: "safeTransferFrom",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "from", type: "address" },
-      { name: "to", type: "address" },
-      { name: "id", type: "uint256" },
-      { name: "amount", type: "uint256" },
-      { name: "data", type: "bytes" },
-    ],
-    outputs: [],
-  },
-] as const;
-
-const REVERSE_REGISTRAR_ABI = [
-  {
-    type: "function",
-    name: "setName",
-    stateMutability: "nonpayable",
-    inputs: [{ name: "name", type: "string" }],
-    outputs: [{ name: "", type: "bytes32" }],
-  },
-] as const;
-
-const CONTROLLER_RENEW_ABI = [
-  {
-    type: "function",
-    name: "renew",
-    stateMutability: "payable",
-    inputs: [
-      { name: "name", type: "string" },
-      { name: "duration", type: "uint256" },
-      { name: "referrer", type: "bytes32" },
-    ],
-    outputs: [],
-  },
-] as const;
+const ERC1155_ABI = NameWrapper.safeTransferFrom;
+const REVERSE_REGISTRAR_ABI = ReverseRegistrar.setName;
+const CONTROLLER_RENEW_ABI = EthRegistrarController.renew;
 
 /// Who must sign a planned call. `batcher` means the MigrationFixtureBatcher,
 /// which can be aggregated; an actor alias means a direct wallet transaction

--- a/contracts/script/migrationFixture/plan.ts
+++ b/contracts/script/migrationFixture/plan.ts
@@ -197,6 +197,17 @@ const ERC721_ABI = [
   },
   {
     type: "function",
+    name: "transferFrom",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "tokenId", type: "uint256" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
     name: "reclaim",
     stateMutability: "nonpayable",
     inputs: [
@@ -212,6 +223,22 @@ const ERC721_ABI = [
     inputs: [
       { name: "operator", type: "address" },
       { name: "approved", type: "bool" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+const ERC1155_ABI = [
+  {
+    type: "function",
+    name: "safeTransferFrom",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "id", type: "uint256" },
+      { name: "amount", type: "uint256" },
+      { name: "data", type: "bytes" },
     ],
     outputs: [],
   },
@@ -284,6 +311,78 @@ export function labelhashOf(label: string): Hex {
 
 export function tokenIdOf(label: string): bigint {
   return BigInt(labelhashOf(label));
+}
+
+/// Calls that move a v1 name to a new holder.
+///
+/// An unwrapped name lives in two places: the ERC-721 registration and the
+/// registry record the registrar can rewrite. The reclaim runs first, while the
+/// sender is still authorised over the token, so it can point the registry at
+/// the recipient itself; reclaiming after the transfer would need a signature
+/// from the recipient, which a handover to an address we hold no key for cannot
+/// produce. A wrapped name carries both in its ERC-1155 balance, so one
+/// transfer is the whole move.
+///
+/// The ERC-721 move is the plain transfer rather than the safe one: the receipt
+/// hook adds nothing for the accounts the corpus hands names to, and refusing a
+/// recipient is the job of the one check made before any name moves.
+///
+/// `signer` and `from` are separate because an approved operator may send on
+/// the holder's behalf, which is how a whole cohort moves in batches instead of
+/// one transaction per name.
+export function transferNameCalls(args: {
+  wrapped: boolean;
+  signer: Signer;
+  from: Address;
+  to: Address;
+  tokenId: bigint;
+  node: Hex;
+  addresses: PlanContext["addresses"];
+  label: string;
+}): PlannedCall[] {
+  const { wrapped, signer, from, to, tokenId, node, addresses, label } = args;
+  const call = (target: Address, suffix: string, data: Hex): PlannedCall => ({
+    signer,
+    target,
+    value: 0n,
+    allowFailure: false,
+    label: `${label} ${suffix}`,
+    data,
+  });
+
+  if (wrapped) {
+    return [
+      call(
+        addresses.wrapper,
+        "wrapper transfer",
+        encodeFunctionData({
+          abi: ERC1155_ABI,
+          functionName: "safeTransferFrom",
+          args: [from, to, BigInt(node), 1n, "0x"],
+        }),
+      ),
+    ];
+  }
+  return [
+    call(
+      addresses.baseRegistrar,
+      "reclaim",
+      encodeFunctionData({
+        abi: ERC721_ABI,
+        functionName: "reclaim",
+        args: [tokenId, to],
+      }),
+    ),
+    call(
+      addresses.baseRegistrar,
+      "transfer",
+      encodeFunctionData({
+        abi: ERC721_ABI,
+        functionName: "transferFrom",
+        args: [from, to, tokenId],
+      }),
+    ),
+  ];
 }
 
 /// Ownership of a fixture name over the course of its setup. Names are
@@ -1016,32 +1115,167 @@ export function planSetupSteps(
   // Hand the name to its terminal pre-migration owner if setup never moved it.
   const terminalOwner = preMigrationOwnerAlias(scenario);
   if (heldByBatcher && !child) {
-    const terminalAddress = resolveRef(terminalOwner, ctx);
-    calls.push({
-      signer: BATCHER,
-      target: ctx.addresses.baseRegistrar,
-      value: 0n,
-      allowFailure: false,
-      label: `${row.fixture_id} handover transfer`,
-      data: encodeFunctionData({
-        abi: ERC721_ABI,
-        functionName: "safeTransferFrom",
-        args: [ctx.batcher, terminalAddress, tokenId],
+    calls.push(
+      ...transferNameCalls({
+        wrapped: false,
+        signer: BATCHER,
+        from: ctx.batcher,
+        to: resolveRef(terminalOwner, ctx),
+        tokenId,
+        node,
+        addresses: ctx.addresses,
+        label: `${row.fixture_id} handover`,
       }),
-    });
-    calls.push({
-      signer: actorSigner(terminalOwner),
-      target: ctx.addresses.baseRegistrar,
-      value: 0n,
-      allowFailure: false,
-      label: `${row.fixture_id} handover reclaim`,
-      data: encodeFunctionData({
-        abi: ERC721_ABI,
-        functionName: "reclaim",
-        args: [tokenId, terminalAddress],
-      }),
-    });
+    );
   }
 
   return calls;
+}
+
+/// The wrapper treats a `.eth` 2LD as expiring when its grace period opens,
+/// which is what decides whether a transfer is refused.
+const WRAPPER_GRACE_PERIOD = 90n * 86_400n;
+
+/// What a name looks like on chain when a handover is planned, read once per
+/// name rather than replayed from the seeding plan — a name may have moved
+/// between actors during setup, and a rerun must see where it actually is.
+export type HandoverState = {
+  /// NameWrapper owner, fuses and expiry for the name's own node.
+  wrapperOwner: Address;
+  wrapperFuses: number;
+  wrapperExpiry: bigint;
+  /// BaseRegistrar registrant of the 2LD. For a wrapped name this is the
+  /// NameWrapper itself.
+  registrant: Address;
+  /// The same wrapper reading for a child's parent 2LD.
+  parentWrapperOwner?: Address;
+  parentWrapperFuses?: number;
+  parentWrapperExpiry?: bigint;
+  /// Seconds since the epoch the plan is built against.
+  now: bigint;
+};
+
+/// A name, or a child's parent, the handover cannot move, and why.
+export type HandoverSkip = { subject: string; reason: string };
+
+export type HandoverPlan = {
+  calls: PlannedCall[];
+  skips: HandoverSkip[];
+  /// Addresses the plan moves a token away from. Each has to approve the
+  /// batcher before the batch runs.
+  holders: Address[];
+};
+
+const sameAddress = (a: Address, b: Address): boolean =>
+  a.toLowerCase() === b.toLowerCase();
+
+/// Mirrors `NameWrapper._beforeTransfer`: an emancipated name is frozen once it
+/// expires, and a live one is frozen by `CANNOT_TRANSFER`. Reproducing the rule
+/// here turns a whole batch that would revert on one member into a name that is
+/// reported as left behind.
+function wrapperTransferBlock(
+  fuses: number,
+  expiry: bigint,
+  now: bigint,
+): string | null {
+  const effective =
+    fuses & FUSES.IS_DOT_ETH ? expiry - WRAPPER_GRACE_PERIOD : expiry;
+  if (effective < now) {
+    return fuses & FUSES.PARENT_CANNOT_CONTROL ? "expired" : null;
+  }
+  return fuses & FUSES.CANNOT_TRANSFER ? "CANNOT_TRANSFER burned" : null;
+}
+
+/// Calls that give one seeded name to `to`, planned against what the chain
+/// currently says rather than against the plan that shaped it.
+///
+/// Every call is sent by the batcher, which the holders approve as an operator
+/// beforehand, so a cohort moves in batches rather than one transaction per
+/// name. A name already at the target plans nothing, which makes a rerun a
+/// no-op and lets an interrupted run resume.
+///
+/// A child's parent moves too: it stays wrapped to the batcher throughout
+/// setup, and the helper refuses a subname whose parent has not migrated, so a
+/// recipient holding only the child could never migrate it.
+export function planHandover(
+  row: FixtureEnvelope,
+  ctx: PlanContext,
+  to: Address,
+  state: HandoverState,
+): HandoverPlan {
+  const scenario = row.scenario;
+  const form = v1Form(scenario);
+  const calls: PlannedCall[] = [];
+  const skips: HandoverSkip[] = [];
+  const holders: Address[] = [];
+
+  const move = (args: {
+    subject: string;
+    wrapped: boolean;
+    holder: Address;
+    fuses: number;
+    expiry: bigint;
+    tokenId: bigint;
+    node: Hex;
+  }): void => {
+    const { subject, wrapped, holder, fuses, expiry, tokenId, node } = args;
+    if (sameAddress(holder, to)) return;
+    if (holder === zeroAddress) {
+      skips.push({ subject, reason: "no v1 holder" });
+      return;
+    }
+    if (!wrapped && sameAddress(holder, ctx.addresses.wrapper)) {
+      skips.push({ subject, reason: "held by the NameWrapper" });
+      return;
+    }
+    const blocked = wrapped
+      ? wrapperTransferBlock(fuses, expiry, state.now)
+      : null;
+    if (blocked) {
+      skips.push({ subject, reason: blocked });
+      return;
+    }
+    holders.push(holder);
+    calls.push(
+      ...transferNameCalls({
+        wrapped,
+        signer: BATCHER,
+        from: holder,
+        to,
+        tokenId,
+        node,
+        addresses: ctx.addresses,
+        label:
+          subject === scenario.name
+            ? `${row.fixture_id} handover`
+            : `${row.fixture_id} handover (${subject})`,
+      }),
+    );
+  };
+
+  const topLabel = scenario.top_level_label;
+  const wrapped = isWrapped(form);
+  move({
+    subject: scenario.name,
+    wrapped,
+    holder: wrapped ? state.wrapperOwner : state.registrant,
+    fuses: state.wrapperFuses,
+    expiry: state.wrapperExpiry,
+    tokenId: tokenIdOf(topLabel),
+    node: namehash(scenario.name) as Hex,
+  });
+
+  if (isChild(form)) {
+    move({
+      subject: `${topLabel}.eth`,
+      wrapped: true,
+      holder: state.parentWrapperOwner ?? zeroAddress,
+      fuses: state.parentWrapperFuses ?? 0,
+      expiry: state.parentWrapperExpiry ?? 0n,
+      tokenId: tokenIdOf(topLabel),
+      node: namehash(`${topLabel}.eth`) as Hex,
+    });
+  }
+
+  return { calls, skips, holders };
 }

--- a/contracts/script/migrationFixture/plan.ts
+++ b/contracts/script/migrationFixture/plan.ts
@@ -1164,6 +1164,9 @@ export type HandoverPlan = {
   /// Addresses the plan moves a token away from. Each has to approve the
   /// batcher before the batch runs.
   holders: Address[];
+  /// Who holds the name itself right now — which is what a later check has to
+  /// compare against, since it may not be the actor the corpus declares.
+  nameHolder: Address;
 };
 
 const sameAddress = (a: Address, b: Address): boolean =>
@@ -1205,13 +1208,10 @@ export function planHandover(
 ): HandoverPlan {
   const scenario = row.scenario;
   const form = v1Form(scenario);
-  const calls: PlannedCall[] = [];
-  const skips: HandoverSkip[] = [];
-  const holders: Address[] = [];
+  const topLabel = scenario.top_level_label;
+  const wrapped = isWrapped(form);
 
-  /// Returns whether the subject ends up with the recipient — either because a
-  /// transfer was planned, or because it is already there.
-  const move = (args: {
+  type Subject = {
     subject: string;
     wrapped: boolean;
     holder: Address;
@@ -1219,46 +1219,22 @@ export function planHandover(
     expiry: bigint;
     tokenId: bigint;
     node: Hex;
-  }): boolean => {
-    const { subject, wrapped, holder, fuses, expiry, tokenId, node } = args;
-    if (sameAddress(holder, to)) return true;
-    if (holder === zeroAddress) {
-      skips.push({ subject, reason: "no v1 holder" });
-      return false;
-    }
-    if (!wrapped && sameAddress(holder, ctx.addresses.wrapper)) {
-      skips.push({ subject, reason: "held by the NameWrapper" });
-      return false;
-    }
-    const blocked = wrapped
-      ? wrapperTransferBlock(fuses, expiry, state.now)
-      : null;
-    if (blocked) {
-      skips.push({ subject, reason: blocked });
-      return false;
-    }
-    holders.push(holder);
-    calls.push(
-      ...transferNameCalls({
-        wrapped,
-        signer: BATCHER,
-        from: holder,
-        to,
-        tokenId,
-        node,
-        addresses: ctx.addresses,
-        label:
-          subject === scenario.name
-            ? `${row.fixture_id} handover`
-            : `${row.fixture_id} handover (${subject})`,
-      }),
-    );
-    return true;
   };
 
-  const topLabel = scenario.top_level_label;
-  const wrapped = isWrapped(form);
-  const moved = move({
+  /// Why this subject cannot move, or null when it can. A subject already at
+  /// the recipient needs no calls and blocks nothing.
+  const refusal = (s: Subject): string | null => {
+    if (sameAddress(s.holder, to)) return null;
+    if (s.holder === zeroAddress) return "no v1 holder";
+    if (!s.wrapped && sameAddress(s.holder, ctx.addresses.wrapper)) {
+      return "held by the NameWrapper";
+    }
+    return s.wrapped
+      ? wrapperTransferBlock(s.fuses, s.expiry, state.now)
+      : null;
+  };
+
+  const name: Subject = {
     subject: scenario.name,
     wrapped,
     holder: wrapped ? state.wrapperOwner : state.registrant,
@@ -1266,29 +1242,63 @@ export function planHandover(
     expiry: state.wrapperExpiry,
     tokenId: tokenIdOf(topLabel),
     node: namehash(scenario.name) as Hex,
-  });
+  };
 
-  // The parent travels only with a child that travels. Moving it alone splits a
-  // pair whose whole reason for going together is that neither wallet can drive
-  // the scenario without the other: the recipient could not migrate a subname it
-  // does not hold, and the actor left holding the subname could no longer
-  // migrate the parent above it.
+  // A subname and the name above it are one unit. The helper refuses a subname
+  // whose parent has not migrated, and only the parent's owner can migrate the
+  // parent — so a wallet holding one without the other can drive neither. Both
+  // are therefore decided before either is scheduled: whichever is refused, the
+  // pair stays put.
+  const subjects: Subject[] = [name];
   if (isChild(form)) {
-    const parent = `${topLabel}.eth`;
-    if (moved) {
-      move({
-        subject: parent,
-        wrapped: true,
-        holder: state.parentWrapperOwner ?? zeroAddress,
-        fuses: state.parentWrapperFuses ?? 0,
-        expiry: state.parentWrapperExpiry ?? 0n,
-        tokenId: tokenIdOf(topLabel),
-        node: namehash(parent) as Hex,
-      });
-    } else {
-      skips.push({ subject: parent, reason: "its child stayed" });
-    }
+    subjects.push({
+      subject: `${topLabel}.eth`,
+      wrapped: true,
+      holder: state.parentWrapperOwner ?? zeroAddress,
+      fuses: state.parentWrapperFuses ?? 0,
+      expiry: state.parentWrapperExpiry ?? 0n,
+      tokenId: tokenIdOf(topLabel),
+      node: namehash(`${topLabel}.eth`) as Hex,
+    });
   }
 
-  return { calls, skips, holders };
+  const refusals = subjects.map((s) => ({ subject: s, reason: refusal(s) }));
+  const refused = refusals.find((r) => r.reason);
+  if (refused) {
+    return {
+      calls: [],
+      skips: refusals.map((r) => ({
+        subject: r.subject.subject,
+        reason:
+          r.reason ??
+          (r.subject === name ? "its parent stayed" : "its child stayed"),
+      })),
+      holders: [],
+      nameHolder: name.holder,
+    };
+  }
+
+  const calls: PlannedCall[] = [];
+  const holders: Address[] = [];
+  for (const s of subjects) {
+    if (sameAddress(s.holder, to)) continue;
+    holders.push(s.holder);
+    calls.push(
+      ...transferNameCalls({
+        wrapped: s.wrapped,
+        signer: BATCHER,
+        from: s.holder,
+        to,
+        tokenId: s.tokenId,
+        node: s.node,
+        addresses: ctx.addresses,
+        label:
+          s.subject === scenario.name
+            ? `${row.fixture_id} handover`
+            : `${row.fixture_id} handover (${s.subject})`,
+      }),
+    );
+  }
+
+  return { calls, skips: [], holders, nameHolder: name.holder };
 }

--- a/contracts/script/migrationFixture/types.ts
+++ b/contracts/script/migrationFixture/types.ts
@@ -140,6 +140,10 @@ export type FixtureRunName = {
   /// as it is registered, so an interrupted run can tell a finished name from
   /// one whose state is only part-shaped.
   setupComplete: boolean;
+  /// Address the name was given to after its state was shaped and checked.
+  /// Absent while the name is still held by the actor its scenario names, which
+  /// is what every other stage expects.
+  handedOverTo?: Address;
 };
 
 export type FixtureRunState = {
@@ -176,6 +180,8 @@ export type CommonOptions = {
   replicasPerVector?: string;
   scenarios?: string;
   rpcStateControls?: boolean;
+  /// Wallet the seeded names are given to once their state is checked.
+  handoverTo?: Address;
 };
 
 export type BatchCall = {

--- a/contracts/script/migrationFixture/types.ts
+++ b/contracts/script/migrationFixture/types.ts
@@ -144,6 +144,10 @@ export type FixtureRunName = {
   /// Absent while the name is still held by the actor its scenario names, which
   /// is what every other stage expects.
   handedOverTo?: Address;
+  /// Actor alias the name was taken from. The owner checks relax onto the
+  /// recipient only for this alias, so a name that moved off some other holder
+  /// keeps asserting what the corpus declares.
+  handedOverFrom?: string;
 };
 
 export type FixtureRunState = {

--- a/contracts/script/migrationFixture/types.ts
+++ b/contracts/script/migrationFixture/types.ts
@@ -175,18 +175,21 @@ export type CommonOptions = {
   deploymentNetwork?: string;
   v1DeploymentsDir?: string;
   v1DeploymentNetwork?: string;
-  privateKey?: Hex;
   v1OwnerKey?: Hex;
   v1Owner?: Address;
-  actorMnemonic?: string;
-  limit?: string;
-  tiers?: string;
-  ids?: string;
-  replicasPerVector?: string;
-  scenarios?: string;
   rpcStateControls?: boolean;
+  /// Everything naming the corpus carries the `fixture` prefix its flag does,
+  /// so the standalone commands and the rehearsals that mirror them spell each
+  /// option exactly once.
+  fixturePrivateKey?: Hex;
+  fixtureActorMnemonic?: string;
+  fixtureLimit?: string;
+  fixtureTiers?: string;
+  fixtureIds?: string;
+  fixtureReplicasPerVector?: string;
+  fixtureScenarios?: string;
   /// Wallet the seeded names are given to once their state is checked.
-  handoverTo?: Address;
+  fixtureHandoverTo?: Address;
 };
 
 export type BatchCall = {

--- a/contracts/script/migrationFixture/types.ts
+++ b/contracts/script/migrationFixture/types.ts
@@ -144,10 +144,11 @@ export type FixtureRunName = {
   /// Absent while the name is still held by the actor its scenario names, which
   /// is what every other stage expects.
   handedOverTo?: Address;
-  /// Actor alias the name was taken from. The owner checks relax onto the
-  /// recipient only for this alias, so a name that moved off some other holder
-  /// keeps asserting what the corpus declares.
-  handedOverFrom?: string;
+  /// Address the name was actually taken from, read off the chain rather than
+  /// assumed from the corpus. The owner checks relax onto the recipient only
+  /// when this is the holder the scenario declares, so a name that had drifted
+  /// to some other actor keeps asserting what the corpus says.
+  handedOverFrom?: Address;
 };
 
 export type FixtureRunState = {
@@ -180,7 +181,7 @@ export type CommonOptions = {
   actorMnemonic?: string;
   limit?: string;
   tiers?: string;
-  fixtureIds?: string;
+  ids?: string;
   replicasPerVector?: string;
   scenarios?: string;
   rpcStateControls?: boolean;

--- a/contracts/script/migrationFixture/types.ts
+++ b/contracts/script/migrationFixture/types.ts
@@ -1,5 +1,5 @@
 import type { Address, Hex } from "viem";
-import type { HDAccount } from "viem/accounts";
+import type { LocalAccount } from "viem/accounts";
 
 export const DAY = 86_400n;
 
@@ -119,7 +119,10 @@ export type FixtureEnvelope = {
   scenario: Scenario;
 };
 
-export type FixtureActor = { alias: string; account: HDAccount };
+/// An actor and the account that signs for it. The account is any local signer
+/// rather than specifically a derived one, because the owner aliases resolve to
+/// a supplied key when a run nominates an owner wallet.
+export type FixtureActor = { alias: string; account: LocalAccount };
 
 export type FixtureRunName = {
   fixtureId: string;
@@ -140,15 +143,6 @@ export type FixtureRunName = {
   /// as it is registered, so an interrupted run can tell a finished name from
   /// one whose state is only part-shaped.
   setupComplete: boolean;
-  /// Address the name was given to after its state was shaped and checked.
-  /// Absent while the name is still held by the actor its scenario names, which
-  /// is what every other stage expects.
-  handedOverTo?: Address;
-  /// Address the name was actually taken from, read off the chain rather than
-  /// assumed from the corpus. The owner checks relax onto the recipient only
-  /// when this is the holder the scenario declares, so a name that had drifted
-  /// to some other actor keeps asserting what the corpus says.
-  handedOverFrom?: Address;
 };
 
 export type FixtureRunState = {
@@ -188,8 +182,9 @@ export type CommonOptions = {
   fixtureIds?: string;
   fixtureReplicasPerVector?: string;
   fixtureScenarios?: string;
-  /// Wallet the seeded names are given to once their state is checked.
-  fixtureHandoverTo?: Address;
+  /// Key for the wallet that owns every seeded name. Collapses the three owner
+  /// aliases onto one account, so a tester owns the corpus from registration.
+  fixtureOwnerKey?: Hex;
 };
 
 export type BatchCall = {

--- a/contracts/script/migrationFixture/verifyV1.ts
+++ b/contracts/script/migrationFixture/verifyV1.ts
@@ -10,9 +10,11 @@ import {
   isChild,
   isWrapped,
   isLocked,
+  preMigrationOwnerAlias,
   resolveFuses,
   resolveOptionalRef,
   resolveRef,
+  stripActorPrefix,
   v1Form,
   type RefContext,
 } from "./scenario.js";
@@ -281,6 +283,7 @@ export function buildV1Checks(
   row: FixtureEnvelope,
   ctx: RefContext,
   addresses: V1Addresses,
+  handedOverTo?: Address,
 ): Check[] {
   const scenario = row.scenario;
   const pre = scenario.v1.expected_pre_migration;
@@ -295,7 +298,18 @@ export function buildV1Checks(
   const base = { fixtureId: row.fixture_id, name: scenario.name, form };
   const checks: Check[] = [];
 
-  const registryOwner = resolveRef(pre.registry_owner_ref, ctx);
+  // A name given away after seeding is held by its recipient wherever the
+  // corpus names the actor it was shaped under. Only that alias moves: refs
+  // naming the wrapper, a counterparty contract or a different actor still
+  // resolve as written, and so do the record values spelled with the same
+  // alias, which describe content rather than ownership.
+  const terminalAlias = preMigrationOwnerAlias(scenario);
+  const ownerRef = (ref: string | null | undefined): Address =>
+    handedOverTo && ref && stripActorPrefix(ref) === terminalAlias
+      ? handedOverTo
+      : resolveRef(ref, ctx);
+
+  const registryOwner = ownerRef(pre.registry_owner_ref);
   checks.push({
     ...base,
     field: "registry.owner",
@@ -350,7 +364,7 @@ export function buildV1Checks(
   });
 
   // The registrar token tracks the 2LD, which for a child scenario is its parent.
-  const registrarOwner = resolveRef(pre.base_registrar_owner_ref, ctx);
+  const registrarOwner = ownerRef(pre.base_registrar_owner_ref);
   checks.push({
     ...base,
     field: child ? "baseRegistrar.ownerOf(parent)" : "baseRegistrar.ownerOf",
@@ -370,7 +384,7 @@ export function buildV1Checks(
   });
 
   const wrapperOwner = pre.wrapper_owner_ref
-    ? resolveRef(pre.wrapper_owner_ref, ctx)
+    ? ownerRef(pre.wrapper_owner_ref)
     : zeroAddress;
   checks.push({
     ...base,
@@ -467,9 +481,12 @@ export async function verifySeededV1State(
   rows: FixtureEnvelope[],
   ctx: RefContext,
   addresses: V1Addresses,
+  handedOverTo: Map<string, Address> = new Map(),
   batchSize = 400,
 ): Promise<V1VerifyResult> {
-  const checks = rows.flatMap((row) => buildV1Checks(row, ctx, addresses));
+  const checks = rows.flatMap((row) =>
+    buildV1Checks(row, ctx, addresses, handedOverTo.get(row.fixture_id)),
+  );
   const issues: V1Issue[] = [];
 
   for (let i = 0; i < checks.length; i += batchSize) {

--- a/contracts/script/migrationFixture/verifyV1.ts
+++ b/contracts/script/migrationFixture/verifyV1.ts
@@ -26,107 +26,35 @@ import {
   type RecordSpec,
 } from "./types.js";
 
+import {
+  BaseRegistrar,
+  EnsRegistry,
+  NameWrapper,
+  PublicResolver,
+} from "../abis.js";
+
+/// The v1 surfaces this verification reads, each as narrow as the reads it
+/// makes: these go out in multicall batches, where a wide ABI costs the type
+/// checker its inference.
 const REGISTRY_READ_ABI = [
-  {
-    type: "function",
-    name: "owner",
-    stateMutability: "view",
-    inputs: [{ name: "node", type: "bytes32" }],
-    outputs: [{ name: "", type: "address" }],
-  },
-  {
-    type: "function",
-    name: "resolver",
-    stateMutability: "view",
-    inputs: [{ name: "node", type: "bytes32" }],
-    outputs: [{ name: "", type: "address" }],
-  },
-  {
-    type: "function",
-    name: "ttl",
-    stateMutability: "view",
-    inputs: [{ name: "node", type: "bytes32" }],
-    outputs: [{ name: "", type: "uint64" }],
-  },
+  ...EnsRegistry.owner,
+  ...EnsRegistry.resolver,
+  ...EnsRegistry.ttl,
 ] as const;
-
 const BASE_REGISTRAR_READ_ABI = [
-  {
-    type: "function",
-    name: "ownerOf",
-    stateMutability: "view",
-    inputs: [{ name: "tokenId", type: "uint256" }],
-    outputs: [{ name: "", type: "address" }],
-  },
-  {
-    type: "function",
-    name: "nameExpires",
-    stateMutability: "view",
-    inputs: [{ name: "id", type: "uint256" }],
-    outputs: [{ name: "", type: "uint256" }],
-  },
+  ...BaseRegistrar.ownerOf,
+  ...BaseRegistrar.nameExpires,
 ] as const;
-
 const WRAPPER_READ_ABI = [
-  {
-    type: "function",
-    name: "ownerOf",
-    stateMutability: "view",
-    inputs: [{ name: "id", type: "uint256" }],
-    outputs: [{ name: "", type: "address" }],
-  },
-  {
-    type: "function",
-    name: "getData",
-    stateMutability: "view",
-    inputs: [{ name: "id", type: "uint256" }],
-    outputs: [
-      { name: "owner", type: "address" },
-      { name: "fuses", type: "uint32" },
-      { name: "expiry", type: "uint64" },
-    ],
-  },
+  ...NameWrapper.ownerOf,
+  ...NameWrapper.getData,
 ] as const;
-
 const RESOLVER_READ_ABI = [
-  {
-    type: "function",
-    name: "addr",
-    stateMutability: "view",
-    inputs: [{ name: "node", type: "bytes32" }],
-    outputs: [{ name: "", type: "address" }],
-  },
-  {
-    type: "function",
-    name: "text",
-    stateMutability: "view",
-    inputs: [
-      { name: "node", type: "bytes32" },
-      { name: "key", type: "string" },
-    ],
-    outputs: [{ name: "", type: "string" }],
-  },
-  {
-    type: "function",
-    name: "contenthash",
-    stateMutability: "view",
-    inputs: [{ name: "node", type: "bytes32" }],
-    outputs: [{ name: "", type: "bytes" }],
-  },
+  ...PublicResolver.addr,
+  ...PublicResolver.text,
+  ...PublicResolver.contenthash,
 ] as const;
-
-const RESOLVER_MULTICOIN_READ_ABI = [
-  {
-    type: "function",
-    name: "addr",
-    stateMutability: "view",
-    inputs: [
-      { name: "node", type: "bytes32" },
-      { name: "coinType", type: "uint256" },
-    ],
-    outputs: [{ name: "", type: "bytes" }],
-  },
-] as const;
+const RESOLVER_MULTICOIN_READ_ABI = PublicResolver.addrMulticoin;
 
 export type V1Addresses = {
   registry: Address;

--- a/contracts/script/migrationFixture/verifyV1.ts
+++ b/contracts/script/migrationFixture/verifyV1.ts
@@ -286,7 +286,7 @@ export function buildV1Checks(
   row: FixtureEnvelope,
   ctx: RefContext,
   addresses: V1Addresses,
-  handover?: { to: Address; from?: string },
+  handover?: { to: Address; from?: Address },
 ): Check[] {
   const scenario = row.scenario;
   const pre = scenario.v1.expected_pre_migration;
@@ -308,11 +308,15 @@ export function buildV1Checks(
   // alias, which describe content rather than ownership.
   const terminalAlias = preMigrationOwnerAlias(scenario);
   // The relaxation is doubly gated: the ref has to name the terminal owner, and
-  // the handover has to have taken the name off that same alias. A name moved
-  // off any other holder keeps asserting exactly what the corpus declares.
+  // the name has to have been taken off the address that alias resolves to. A
+  // name that had drifted to some other holder before the handover keeps
+  // asserting exactly what the corpus declares, so the drift still surfaces.
+  // A name already at the recipient records no origin, and cannot: what it
+  // relaxes is the only reading left.
   const relaxes =
     handover &&
-    (handover.from === undefined || handover.from === terminalAlias);
+    (handover.from === undefined ||
+      addrEq(handover.from, resolveRef(terminalAlias, ctx)));
   let relaxed = 0;
   const ownerRef = (ref: string | null | undefined): Address => {
     if (relaxes && ref && stripActorPrefix(ref) === terminalAlias) {
@@ -499,7 +503,7 @@ export async function verifySeededV1State(
   rows: FixtureEnvelope[],
   ctx: RefContext,
   addresses: V1Addresses,
-  handedOver: Map<string, { to: Address; from?: string }> = new Map(),
+  handedOver: Map<string, { to: Address; from?: Address }> = new Map(),
   batchSize = 400,
 ): Promise<V1VerifyResult> {
   const checks = rows.flatMap((row) =>

--- a/contracts/script/migrationFixture/verifyV1.ts
+++ b/contracts/script/migrationFixture/verifyV1.ts
@@ -10,11 +10,9 @@ import {
   isChild,
   isWrapped,
   isLocked,
-  preMigrationOwnerAlias,
   resolveFuses,
   resolveOptionalRef,
   resolveRef,
-  stripActorPrefix,
   v1Form,
   type RefContext,
 } from "./scenario.js";
@@ -87,9 +85,6 @@ type Check = {
     ok: boolean,
     result: any,
   ) => { expected: string; actual: string } | null;
-  /// How many of this name's ownership assertions expect a handover recipient
-  /// instead of the actor the corpus declares.
-  relaxedOwners?: number;
 };
 
 const addrEq = (a: unknown, b: Address) =>
@@ -214,7 +209,6 @@ export function buildV1Checks(
   row: FixtureEnvelope,
   ctx: RefContext,
   addresses: V1Addresses,
-  handover?: { to: Address; from?: Address },
 ): Check[] {
   const scenario = row.scenario;
   const pre = scenario.v1.expected_pre_migration;
@@ -234,27 +228,7 @@ export function buildV1Checks(
   // naming the wrapper, a counterparty contract or a different actor still
   // resolve as written, and so do the record values spelled with the same
   // alias, which describe content rather than ownership.
-  const terminalAlias = preMigrationOwnerAlias(scenario);
-  // The relaxation is doubly gated: the ref has to name the terminal owner, and
-  // the name has to have been taken off the address that alias resolves to. A
-  // name that had drifted to some other holder before the handover keeps
-  // asserting exactly what the corpus declares, so the drift still surfaces.
-  // A name already at the recipient records no origin, and cannot: what it
-  // relaxes is the only reading left.
-  const relaxes =
-    handover &&
-    (handover.from === undefined ||
-      addrEq(handover.from, resolveRef(terminalAlias, ctx)));
-  let relaxed = 0;
-  const ownerRef = (ref: string | null | undefined): Address => {
-    if (relaxes && ref && stripActorPrefix(ref) === terminalAlias) {
-      relaxed += 1;
-      return handover.to;
-    }
-    return resolveRef(ref, ctx);
-  };
-
-  const registryOwner = ownerRef(pre.registry_owner_ref);
+  const registryOwner = resolveRef(pre.registry_owner_ref, ctx);
   checks.push({
     ...base,
     field: "registry.owner",
@@ -309,7 +283,7 @@ export function buildV1Checks(
   });
 
   // The registrar token tracks the 2LD, which for a child scenario is its parent.
-  const registrarOwner = ownerRef(pre.base_registrar_owner_ref);
+  const registrarOwner = resolveRef(pre.base_registrar_owner_ref, ctx);
   checks.push({
     ...base,
     field: child ? "baseRegistrar.ownerOf(parent)" : "baseRegistrar.ownerOf",
@@ -329,7 +303,7 @@ export function buildV1Checks(
   });
 
   const wrapperOwner = pre.wrapper_owner_ref
-    ? ownerRef(pre.wrapper_owner_ref)
+    ? resolveRef(pre.wrapper_owner_ref, ctx)
     : zeroAddress;
   checks.push({
     ...base,
@@ -409,7 +383,6 @@ export function buildV1Checks(
     ...recordChecks(row, ctx, resolver, node, pre.records ?? [], { form }),
   );
 
-  for (const check of checks) check.relaxedOwners = relaxed;
   return checks;
 }
 
@@ -418,10 +391,6 @@ export type V1VerifyResult = {
   checks: number;
   issues: V1Issue[];
   byField: Record<string, number>;
-  /// Ownership assertions that were satisfied against a handover recipient
-  /// rather than the actor the corpus declares. A non-zero count means the run
-  /// checked something weaker than its own summary line otherwise implies.
-  relaxedOwnerChecks: number;
 };
 
 /// Reads the shaped v1 state back and compares it with what each scenario says
@@ -431,16 +400,9 @@ export async function verifySeededV1State(
   rows: FixtureEnvelope[],
   ctx: RefContext,
   addresses: V1Addresses,
-  handedOver: Map<string, { to: Address; from?: Address }> = new Map(),
   batchSize = 400,
 ): Promise<V1VerifyResult> {
-  const checks = rows.flatMap((row) =>
-    buildV1Checks(row, ctx, addresses, handedOver.get(row.fixture_id)),
-  );
-  const relaxedOwnerChecks = rows.reduce((total, row) => {
-    const first = checks.find((c) => c.fixtureId === row.fixture_id);
-    return total + (first?.relaxedOwners ?? 0);
-  }, 0);
+  const checks = rows.flatMap((row) => buildV1Checks(row, ctx, addresses));
   const issues: V1Issue[] = [];
 
   for (let i = 0; i < checks.length; i += batchSize) {
@@ -469,11 +431,5 @@ export async function verifySeededV1State(
   for (const issue of issues) {
     byField[issue.field] = (byField[issue.field] ?? 0) + 1;
   }
-  return {
-    names: rows.length,
-    checks: checks.length,
-    issues,
-    byField,
-    relaxedOwnerChecks,
-  };
+  return { names: rows.length, checks: checks.length, issues, byField };
 }

--- a/contracts/script/migrationFixture/verifyV1.ts
+++ b/contracts/script/migrationFixture/verifyV1.ts
@@ -159,6 +159,9 @@ type Check = {
     ok: boolean,
     result: any,
   ) => { expected: string; actual: string } | null;
+  /// How many of this name's ownership assertions expect a handover recipient
+  /// instead of the actor the corpus declares.
+  relaxedOwners?: number;
 };
 
 const addrEq = (a: unknown, b: Address) =>
@@ -283,7 +286,7 @@ export function buildV1Checks(
   row: FixtureEnvelope,
   ctx: RefContext,
   addresses: V1Addresses,
-  handedOverTo?: Address,
+  handover?: { to: Address; from?: string },
 ): Check[] {
   const scenario = row.scenario;
   const pre = scenario.v1.expected_pre_migration;
@@ -304,10 +307,20 @@ export function buildV1Checks(
   // resolve as written, and so do the record values spelled with the same
   // alias, which describe content rather than ownership.
   const terminalAlias = preMigrationOwnerAlias(scenario);
-  const ownerRef = (ref: string | null | undefined): Address =>
-    handedOverTo && ref && stripActorPrefix(ref) === terminalAlias
-      ? handedOverTo
-      : resolveRef(ref, ctx);
+  // The relaxation is doubly gated: the ref has to name the terminal owner, and
+  // the handover has to have taken the name off that same alias. A name moved
+  // off any other holder keeps asserting exactly what the corpus declares.
+  const relaxes =
+    handover &&
+    (handover.from === undefined || handover.from === terminalAlias);
+  let relaxed = 0;
+  const ownerRef = (ref: string | null | undefined): Address => {
+    if (relaxes && ref && stripActorPrefix(ref) === terminalAlias) {
+      relaxed += 1;
+      return handover.to;
+    }
+    return resolveRef(ref, ctx);
+  };
 
   const registryOwner = ownerRef(pre.registry_owner_ref);
   checks.push({
@@ -464,6 +477,7 @@ export function buildV1Checks(
     ...recordChecks(row, ctx, resolver, node, pre.records ?? [], { form }),
   );
 
+  for (const check of checks) check.relaxedOwners = relaxed;
   return checks;
 }
 
@@ -472,6 +486,10 @@ export type V1VerifyResult = {
   checks: number;
   issues: V1Issue[];
   byField: Record<string, number>;
+  /// Ownership assertions that were satisfied against a handover recipient
+  /// rather than the actor the corpus declares. A non-zero count means the run
+  /// checked something weaker than its own summary line otherwise implies.
+  relaxedOwnerChecks: number;
 };
 
 /// Reads the shaped v1 state back and compares it with what each scenario says
@@ -481,12 +499,16 @@ export async function verifySeededV1State(
   rows: FixtureEnvelope[],
   ctx: RefContext,
   addresses: V1Addresses,
-  handedOverTo: Map<string, Address> = new Map(),
+  handedOver: Map<string, { to: Address; from?: string }> = new Map(),
   batchSize = 400,
 ): Promise<V1VerifyResult> {
   const checks = rows.flatMap((row) =>
-    buildV1Checks(row, ctx, addresses, handedOverTo.get(row.fixture_id)),
+    buildV1Checks(row, ctx, addresses, handedOver.get(row.fixture_id)),
   );
+  const relaxedOwnerChecks = rows.reduce((total, row) => {
+    const first = checks.find((c) => c.fixtureId === row.fixture_id);
+    return total + (first?.relaxedOwners ?? 0);
+  }, 0);
   const issues: V1Issue[] = [];
 
   for (let i = 0; i < checks.length; i += batchSize) {
@@ -515,5 +537,11 @@ export async function verifySeededV1State(
   for (const issue of issues) {
     byField[issue.field] = (byField[issue.field] ?? 0) + 1;
   }
-  return { names: rows.length, checks: checks.length, issues, byField };
+  return {
+    names: rows.length,
+    checks: checks.length,
+    issues,
+    byField,
+    relaxedOwnerChecks,
+  };
 }

--- a/contracts/script/preMigration.ts
+++ b/contracts/script/preMigration.ts
@@ -35,17 +35,9 @@ import {
 } from "./logger.js";
 
 import { loadArtifact, resolveChain } from "./scriptUtils.js";
+import { BaseRegistrar } from "./abis.js";
 
-// ABI fragments for v1 BaseRegistrar
-const BASE_REGISTRAR_ABI = [
-  {
-    inputs: [{ internalType: "uint256", name: "id", type: "uint256" }],
-    name: "nameExpires",
-    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-    stateMutability: "view",
-    type: "function",
-  },
-] as const;
+const BASE_REGISTRAR_ABI = BaseRegistrar.nameExpires;
 
 // Custom Errors
 export class UnexpectedOwnerError extends Error {

--- a/contracts/script/uploadCoverage.ts
+++ b/contracts/script/uploadCoverage.ts
@@ -37,23 +37,35 @@ if (codecov.exitCode !== 0) {
   codecovPath = "codecov";
 }
 
-const baseCmd = [
-  codecovPath,
-  "upload-coverage",
+const globalOpts = [
   `-t ${process.env.CC_TOKEN}`,
   ...(process.env.CC_GIT_SERVICE
     ? [`--git-service ${process.env.CC_GIT_SERVICE}`]
     : []),
   ...(process.env.CC_SHA ? [`--sha ${process.env.CC_SHA}`] : []),
-  ...(process.env.CC_PR ? [`--pr ${process.env.CC_PR}`] : []),
 ];
 
-const coverageFiles = readdirSync(coverageDir).filter(
-  (file) => file.startsWith(PREFIX) && file.endsWith(SUFFIX),
-);
+// release the queued reports once every job has finished uploading
+if (process.argv.includes("--notify")) {
+  await $`bash -c "${[codecovPath, "send-notifications", ...globalOpts].join(" ")}"`;
+} else {
+  const uploadCmd = [
+    codecovPath,
+    "upload-coverage",
+    ...globalOpts,
+    ...(process.env.CC_PR ? [`--pr ${process.env.CC_PR}`] : []),
+    // an explicit file is additive to whatever the search finds, so turn the
+    // search off to keep each flag scoped to its own report
+    "--disable-search",
+  ];
 
-for (const file of coverageFiles) {
-  const flagName = basename(file, SUFFIX).replace(PREFIX, "");
-  const filePath = join(coverageDir.pathname, file);
-  await $`bash -c "${baseCmd.join(" ")} --flag ${flagName} --file ${filePath}"`;
+  const coverageFiles = readdirSync(coverageDir).filter(
+    (file) => file.startsWith(PREFIX) && file.endsWith(SUFFIX),
+  );
+
+  for (const file of coverageFiles) {
+    const flagName = basename(file, SUFFIX).replace(PREFIX, "");
+    const filePath = join(coverageDir.pathname, file);
+    await $`bash -c "${uploadCmd.join(" ")} --flag ${flagName} --file ${filePath}"`;
+  }
 }

--- a/contracts/test/unit/abis.test.ts
+++ b/contracts/test/unit/abis.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import { toFunctionSignature, type AbiFunction } from "viem";
+
+import * as abis from "../../script/abis.js";
+
+/// The fragments are cut from the compiled artifacts, so they cannot disagree
+/// with the contracts — a renamed function resolves to `never` and fails the
+/// build. What is still fallible is the cut itself: a name that is overloaded
+/// yields more than one entry unless an arity says which, and an ABI carrying
+/// two arities of one name is one viem cannot encode against.
+/// Namespaces group a contract's fragments; a bare array is a composition of
+/// them, checked separately because its entries are the fragments themselves.
+const NAMESPACES = Object.entries(abis).filter(
+  ([, value]) => !Array.isArray(value),
+) as [string, Record<string, readonly unknown[]>][];
+
+const COMPOSITIONS = Object.entries(abis).filter(([, value]) =>
+  Array.isArray(value),
+) as [string, readonly unknown[]][];
+
+describe("shared ABI fragments", () => {
+  it("covers every contract the scripts call", () => {
+    expect(NAMESPACES.map(([name]) => name).sort()).toEqual([
+      "BaseRegistrar",
+      "EnsRegistry",
+      "EthRegistrarController",
+      "NameWrapper",
+      "PermissionedRegistry",
+      "PublicResolver",
+      "RegistrarOwnership",
+      "ReverseRegistrar",
+    ]);
+  });
+
+  for (const [contract, fragments] of NAMESPACES) {
+    for (const [name, fragment] of Object.entries(fragments)) {
+      it(`${contract}.${name} is a single function fragment`, () => {
+        expect(fragment).toHaveLength(1);
+        const entry = fragment[0] as AbiFunction;
+        expect(entry.type).toBe("function");
+        // Signature rather than name: it is what the selector is taken from,
+        // so it pins the arity an overload was picked by.
+        expect(() => toFunctionSignature(entry)).not.toThrow();
+      });
+    }
+  }
+
+  it("composes only fragments that are already checked", () => {
+    expect(COMPOSITIONS.map(([name]) => name)).toEqual([
+      "RegistrarOwnershipAbi",
+    ]);
+    const known = new Set(
+      NAMESPACES.flatMap(([, fragments]) =>
+        Object.values(fragments).map((f) =>
+          toFunctionSignature(f[0] as AbiFunction),
+        ),
+      ),
+    );
+    for (const [, composed] of COMPOSITIONS) {
+      for (const entry of composed) {
+        expect(known).toContain(toFunctionSignature(entry as AbiFunction));
+      }
+    }
+  });
+
+  it("separates the overloaded resolver arities", () => {
+    const sig = (f: readonly unknown[]) =>
+      toFunctionSignature(f[0] as AbiFunction);
+    expect(sig(abis.PublicResolver.addr)).toBe("addr(bytes32)");
+    expect(sig(abis.PublicResolver.addrMulticoin)).toBe(
+      "addr(bytes32,uint256)",
+    );
+    expect(sig(abis.PublicResolver.setAddr)).toBe("setAddr(bytes32,address)");
+    expect(sig(abis.PublicResolver.setAddrMulticoin)).toBe(
+      "setAddr(bytes32,uint256,bytes)",
+    );
+    expect(sig(abis.BaseRegistrar.safeTransferFrom)).toBe(
+      "safeTransferFrom(address,address,uint256)",
+    );
+    expect(sig(abis.NameWrapper.safeTransferFrom)).toBe(
+      "safeTransferFrom(address,address,uint256,uint256,bytes)",
+    );
+  });
+});

--- a/contracts/test/unit/migrationFixtureRecords.test.ts
+++ b/contracts/test/unit/migrationFixtureRecords.test.ts
@@ -1,28 +1,19 @@
 import { describe, expect, it } from "bun:test";
-import {
-  decodeFunctionData,
-  getAddress,
-  namehash,
-  zeroAddress,
-  type Address,
-} from "viem";
+import { zeroAddress, type Address } from "viem";
 
 import { isRetryableRpcRequest } from "../../script/migration.js";
 import {
   clearedRecord,
-  planHandover,
+  planSetupSteps,
   recordValue,
-  tokenIdOf,
-  type HandoverState,
   type PlanContext,
 } from "../../script/migrationFixture/plan.js";
+import { accounts } from "../../script/migrationFixture/config.js";
 import { assertSeedable } from "../../script/migrationFixture.js";
-import { buildV1Checks } from "../../script/migrationFixture/verifyV1.js";
 import type { RefContext } from "../../script/migrationFixture/scenario.js";
-import {
-  FUSES,
-  type FixtureEnvelope,
-  type RecordSpec,
+import type {
+  FixtureEnvelope,
+  RecordSpec,
 } from "../../script/migrationFixture/types.js";
 
 const OWNER = "0x00000000000000000000000000000000000000a1" as Address;
@@ -212,18 +203,82 @@ describe("retryable rpc requests", () => {
   });
 });
 
-const REGISTRAR = "0x00000000000000000000000000000000000000b1" as Address;
-const WRAPPER = "0x00000000000000000000000000000000000000b2" as Address;
-const BATCHER = "0x00000000000000000000000000000000000000b3" as Address;
-const TESTER = "0x00000000000000000000000000000000000000c1" as Address;
+const OWNER_KEY =
+  "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" as const;
+const KEY_ADDRESS = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8" as Address;
+const MNEMONIC = "test test test test test test test test test test test junk";
+
+describe("the wallet that owns the seeded names", () => {
+  it("derives every actor from the mnemonic when no owner is nominated", () => {
+    const derived = accounts({ fixtureActorMnemonic: MNEMONIC } as never);
+    expect(derived.map((a) => a.alias)).toEqual([
+      "owner_a",
+      "owner_b",
+      "owner_c",
+      "operator",
+      "attacker",
+    ]);
+    // Five accounts, five addresses.
+    expect(new Set(derived.map((a) => a.account.address)).size).toBe(5);
+  });
+
+  it("puts the three owner aliases on the nominated key", () => {
+    const derived = accounts({
+      fixtureActorMnemonic: MNEMONIC,
+      fixtureOwnerKey: OWNER_KEY,
+    } as never);
+    const address = (alias: string) =>
+      derived.find((a) => a.alias === alias)!.account.address;
+
+    for (const alias of ["owner_a", "owner_b", "owner_c"]) {
+      expect(address(alias)).toBe(KEY_ADDRESS);
+    }
+    // The counterparties stay separate: an operator or an attacker means
+    // nothing if it is the owner.
+    expect(address("operator")).not.toBe(KEY_ADDRESS);
+    expect(address("attacker")).not.toBe(KEY_ADDRESS);
+    expect(address("operator")).not.toBe(address("attacker"));
+  });
+
+  it("still needs the mnemonic, which the counterparties come from", () => {
+    expect(() => accounts({ fixtureOwnerKey: OWNER_KEY } as never)).toThrow(
+      /fixture-actor-mnemonic/,
+    );
+  });
+
+  it("refuses a key that is not one", () => {
+    expect(() =>
+      accounts({
+        fixtureActorMnemonic: MNEMONIC,
+        fixtureOwnerKey: "0xnope",
+      } as never),
+    ).toThrow(/fixture-owner-key/);
+  });
+});
+
+const PLAN_BATCHER = "0x00000000000000000000000000000000000000b3" as Address;
+const PLAN_WRAPPER = "0x00000000000000000000000000000000000000b2" as Address;
+const PARENT_OWNER = "0x00000000000000000000000000000000000000a2" as Address;
 
 const planCtx = {
-  ...ctx,
-  batcher: BATCHER,
+  actors: new Map([
+    ["owner_a", OWNER],
+    ["owner_b", PARENT_OWNER],
+  ]),
+  fixtureContracts: {},
+  v1Address: (name: string) => {
+    if (name === "PublicResolver")
+      return "0x00000000000000000000000000000000000000b6";
+    throw new Error(`unexpected v1 lookup: ${name}`);
+  },
+  v2Address: (name: string) => {
+    throw new Error(`unexpected v2 lookup: ${name}`);
+  },
+  batcher: PLAN_BATCHER,
   addresses: {
-    baseRegistrar: REGISTRAR,
+    baseRegistrar: "0x00000000000000000000000000000000000000b1",
     registry: "0x00000000000000000000000000000000000000b4",
-    wrapper: WRAPPER,
+    wrapper: PLAN_WRAPPER,
     controller: "0x00000000000000000000000000000000000000b5",
     publicResolver: "0x00000000000000000000000000000000000000b6",
     reverseRegistrar: "0x00000000000000000000000000000000000000b7",
@@ -231,456 +286,65 @@ const planCtx = {
   },
 } as unknown as PlanContext;
 
-const NOW = 2_000_000_000n;
-const YEAR_AHEAD = NOW + 31_536_000n;
-
-const handoverEnvelope = (
-  tags: string[],
-  overrides: Record<string, any> = {},
-): FixtureEnvelope =>
+const childRow = (parentOwner?: string): FixtureEnvelope =>
   ({
-    fixture_id: "FX-H01",
-    source_scenario_id: "FX-H",
-    label: "fxh",
-    name: "fxh.eth",
+    fixture_id: "FX-C01",
+    source_scenario_id: "FX-C",
+    label: "fxc",
+    name: "sub.fxc.eth",
     scenario: {
-      scenario_id: "FX-H01",
-      name: "fxh.eth",
-      top_level_label: "fxh",
-      child_label: null,
-      tags,
+      scenario_id: "FX-C01",
+      name: "sub.fxc.eth",
+      top_level_label: "fxc",
+      child_label: "sub",
+      tags: ["locked_child"],
       execution: { scenario: "live_now", expected_result: "success" },
       actors: { pre_migration_owner: "owner_a" },
       v1: {
-        registration: { label: "fxh", owner_actor: "owner_a" },
-        setup_steps: [],
+        registration: { label: "fxc", owner_actor: "owner_a" },
+        parent_fixture: parentOwner ? { owner_actor: parentOwner } : null,
+        setup_steps: [
+          {
+            action: "ensure_wrapped_parent_and_child",
+            wrapped_owner_actor: "owner_a",
+          },
+        ],
         expected_pre_migration: {},
       },
-      ...overrides,
     },
   }) as unknown as FixtureEnvelope;
 
-const liveState = (over: Partial<HandoverState> = {}): HandoverState => ({
-  wrapperOwner: zeroAddress,
-  wrapperFuses: 0,
-  wrapperExpiry: 0n,
-  registrant: zeroAddress,
-  now: NOW,
-  ...over,
-});
-
-const decoded = (call: { target: Address; data: `0x${string}` }) =>
-  decodeFunctionData({
-    abi: [...ERC721_HANDOVER_ABI, ...ERC1155_HANDOVER_ABI],
-    data: call.data,
-  });
-
-const ERC721_HANDOVER_ABI = [
-  {
-    type: "function",
-    name: "transferFrom",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "from", type: "address" },
-      { name: "to", type: "address" },
-      { name: "tokenId", type: "uint256" },
-    ],
-    outputs: [],
-  },
-  {
-    type: "function",
-    name: "reclaim",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "id", type: "uint256" },
-      { name: "owner", type: "address" },
-    ],
-    outputs: [],
-  },
-] as const;
-
-const ERC1155_HANDOVER_ABI = [
-  {
-    type: "function",
-    name: "safeTransferFrom",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "from", type: "address" },
-      { name: "to", type: "address" },
-      { name: "id", type: "uint256" },
-      { name: "amount", type: "uint256" },
-      { name: "data", type: "bytes" },
-    ],
-    outputs: [],
-  },
-] as const;
-
-describe("handing a seeded name to a wallet", () => {
-  it("reclaims an unwrapped name before transferring it", () => {
-    const plan = planHandover(
-      handoverEnvelope(["unwrapped"]),
-      planCtx,
-      TESTER,
-      liveState({ registrant: OWNER }),
+describe("a subname's parent", () => {
+  const parentTransfer = (row: FixtureEnvelope) =>
+    planSetupSteps(row, planCtx).filter((c) =>
+      c.label.includes("parent owner transfer"),
     );
 
-    expect(plan.skips).toEqual([]);
-    expect(plan.holders).toEqual([OWNER]);
-    expect(plan.calls.map((c) => c.signer.kind)).toEqual([
-      "batcher",
-      "batcher",
-    ]);
-    // Reclaim first: after the token moves the sender loses standing to make it.
-    const [reclaim, transfer] = plan.calls.map(decoded);
-    expect(reclaim.functionName).toBe("reclaim");
-    expect(reclaim.args?.[1]).toBe(getAddress(TESTER));
-    expect(transfer.functionName).toBe("transferFrom");
-    expect(transfer.args?.[0]).toBe(getAddress(OWNER));
-    expect(transfer.args?.[1]).toBe(getAddress(TESTER));
-    const tokenId = tokenIdOf("fxh");
-    expect(reclaim.args?.[0]).toBe(tokenId);
-    expect(transfer.args?.[2]).toBe(tokenId);
+  it("goes to the owner the corpus declares for it", () => {
+    // Creating the child needs the batcher to hold the parent, so seeding wraps
+    // it there. Left there, the holder of the subname could never migrate it.
+    const calls = parentTransfer(childRow("owner_b"));
+    expect(calls).toHaveLength(1);
+    expect(calls[0].signer).toEqual({ kind: "batcher" });
+    expect(calls[0].target).toBe(PLAN_WRAPPER);
   });
 
-  it("moves a wrapped name with one wrapper transfer", () => {
-    const plan = planHandover(
-      handoverEnvelope(["wrapped_unlocked"]),
-      planCtx,
-      TESTER,
-      liveState({ wrapperOwner: OWNER, wrapperExpiry: YEAR_AHEAD }),
-    );
-
-    expect(plan.calls).toHaveLength(1);
-    expect(plan.calls[0].target).toBe(WRAPPER);
-    const transfer = decoded(plan.calls[0]);
-    expect(transfer.functionName).toBe("safeTransferFrom");
-    expect(transfer.args?.slice(0, 2)).toEqual([
-      getAddress(OWNER),
-      getAddress(TESTER),
-    ]);
-    // The wrapper token is the namehash, not the registrar's labelhash id.
-    expect(transfer.args?.[2]).toBe(BigInt(namehash("fxh.eth")));
-    expect(transfer.args?.[3]).toBe(1n);
+  it("falls back to the child's owner when none is declared", () => {
+    expect(parentTransfer(childRow())).toHaveLength(1);
   });
 
-  it("leaves a name whose transfer fuse is burned", () => {
-    const plan = planHandover(
-      handoverEnvelope(["wrapped_locked"]),
-      planCtx,
-      TESTER,
-      liveState({
-        wrapperOwner: OWNER,
-        wrapperFuses: FUSES.CANNOT_TRANSFER,
-        wrapperExpiry: YEAR_AHEAD,
-      }),
-    );
-
-    expect(plan.calls).toEqual([]);
-    expect(plan.skips).toEqual([
-      { subject: "fxh.eth", reason: "CANNOT_TRANSFER burned" },
-    ]);
-  });
-
-  it("leaves an emancipated name that has reached its grace period", () => {
-    const plan = planHandover(
-      handoverEnvelope(["wrapped_locked"]),
-      planCtx,
-      TESTER,
-      liveState({
-        wrapperOwner: OWNER,
-        // The wrapper treats a .eth 2LD as expiring when its grace period opens.
-        wrapperFuses: FUSES.IS_DOT_ETH | FUSES.PARENT_CANNOT_CONTROL,
-        wrapperExpiry: NOW + 1n,
-      }),
-    );
-
-    expect(plan.calls).toEqual([]);
-    expect(plan.skips).toEqual([{ subject: "fxh.eth", reason: "expired" }]);
-  });
-
-  it("plans nothing for a name the wallet already holds", () => {
-    const plan = planHandover(
-      handoverEnvelope(["unwrapped"]),
-      planCtx,
-      TESTER,
-      liveState({ registrant: TESTER }),
-    );
-
-    expect(plan.calls).toEqual([]);
-    expect(plan.skips).toEqual([]);
-    expect(plan.holders).toEqual([]);
-  });
-
-  it("moves a child's parent as well, so the child can be migrated", () => {
-    const child = handoverEnvelope(["locked_child"], {
-      name: "sub.fxh.eth",
-      child_label: "sub",
-    });
-    const plan = planHandover(
-      child,
-      planCtx,
-      TESTER,
-      liveState({
-        wrapperOwner: OWNER,
-        wrapperExpiry: YEAR_AHEAD,
-        parentWrapperOwner: BATCHER,
-        parentWrapperExpiry: YEAR_AHEAD,
-      }),
-    );
-
-    expect(plan.calls).toHaveLength(2);
-    expect(plan.holders).toEqual([OWNER, BATCHER]);
-    const [childCall, parentCall] = plan.calls.map(decoded);
-    expect(plan.calls[0].target).toBe(WRAPPER);
-    expect(plan.calls[1].target).toBe(WRAPPER);
-    expect(childCall.args?.[0]).toBe(getAddress(OWNER));
-    expect(childCall.args?.[2]).toBe(BigInt(namehash("sub.fxh.eth")));
-    expect(parentCall.args?.[0]).toBe(getAddress(BATCHER));
-    expect(parentCall.args?.[2]).toBe(BigInt(namehash("fxh.eth")));
-    for (const call of [childCall, parentCall]) {
-      expect(call.args?.[1]).toBe(getAddress(TESTER));
-    }
-  });
-
-  it("keeps a refused child's parent with the batcher", () => {
-    const child = handoverEnvelope(["locked_child"], {
-      name: "sub.fxh.eth",
-      child_label: "sub",
-    });
-    const plan = planHandover(
-      child,
-      planCtx,
-      TESTER,
-      liveState({
-        wrapperOwner: OWNER,
-        wrapperFuses: FUSES.CANNOT_TRANSFER,
-        wrapperExpiry: YEAR_AHEAD,
-        parentWrapperOwner: BATCHER,
-        parentWrapperExpiry: YEAR_AHEAD,
-      }),
-    );
-
-    // Moving the parent alone would split the pair: the recipient cannot
-    // migrate a subname it does not hold, and the actor left holding the
-    // subname can no longer migrate the name above it.
-    expect(plan.calls).toEqual([]);
-    expect(plan.holders).toEqual([]);
-    expect(plan.skips).toEqual([
-      { subject: "sub.fxh.eth", reason: "CANNOT_TRANSFER burned" },
-      { subject: "fxh.eth", reason: "its child stayed" },
-    ]);
-  });
-
-  it("keeps a movable child with a parent that cannot move", () => {
-    const child = handoverEnvelope(["locked_child"], {
-      name: "sub.fxh.eth",
-      child_label: "sub",
-    });
-    const plan = planHandover(child, planCtx, TESTER, {
-      wrapperOwner: OWNER,
-      wrapperFuses: 0,
-      // The child is live...
-      wrapperExpiry: YEAR_AHEAD,
-      registrant: zeroAddress,
-      parentWrapperOwner: BATCHER,
-      // ...while its 2LD parent has entered the grace period the wrapper
-      // treats as expiry, which only the parent's fuses make fatal.
-      parentWrapperFuses: FUSES.IS_DOT_ETH | FUSES.PARENT_CANNOT_CONTROL,
-      parentWrapperExpiry: NOW + 1n,
-      now: NOW,
-    });
-
-    // Moving the child alone would leave a subname its holder can never
-    // migrate, because the helper reverts until the parent has.
-    expect(plan.calls).toEqual([]);
-    expect(plan.holders).toEqual([]);
-    expect(plan.skips).toEqual([
-      { subject: "sub.fxh.eth", reason: "its parent stayed" },
-      { subject: "fxh.eth", reason: "expired" },
-    ]);
-  });
-
-  it("leaves a name whose holder is gone, and one the wrapper holds", () => {
-    const absent = planHandover(
-      handoverEnvelope(["unwrapped"]),
-      planCtx,
-      TESTER,
-      liveState({ registrant: zeroAddress }),
-    );
-    expect(absent.calls).toEqual([]);
-    expect(absent.skips).toEqual([
-      { subject: "fxh.eth", reason: "no v1 holder" },
-    ]);
-
-    const wrapped = planHandover(
-      handoverEnvelope(["unwrapped"]),
-      planCtx,
-      TESTER,
-      liveState({ registrant: WRAPPER }),
-    );
-    expect(wrapped.calls).toEqual([]);
-    expect(wrapped.skips).toEqual([
-      { subject: "fxh.eth", reason: "held by the NameWrapper" },
-    ]);
-  });
-
-  it("moves an expired name that was never emancipated", () => {
-    const plan = planHandover(
-      handoverEnvelope(["wrapped_unlocked"]),
-      planCtx,
-      TESTER,
-      liveState({
-        wrapperOwner: OWNER,
-        // Expired, but PARENT_CANNOT_CONTROL is clear, so the wrapper still
-        // allows the transfer.
-        wrapperFuses: 0,
-        wrapperExpiry: NOW - 1n,
-      }),
-    );
-    expect(plan.skips).toEqual([]);
-    expect(plan.calls).toHaveLength(1);
-  });
-});
-
-describe("checking a handed-over name against its scenario", () => {
-  const RESOLVER = "0x00000000000000000000000000000000000000d4" as Address;
-  const OTHER_ACTOR = "0x00000000000000000000000000000000000000a2" as Address;
-  const V1 = {
-    registry: "0x00000000000000000000000000000000000000d1",
-    baseRegistrar: "0x00000000000000000000000000000000000000d2",
-    nameWrapper: "0x00000000000000000000000000000000000000d3",
-  } as const;
-
-  const refCtx = {
-    actors: new Map([
-      ["owner_a", OWNER],
-      ["owner_b", OTHER_ACTOR],
-    ]),
-    fixtureContracts: {},
-    v1Address: (name: string) => {
-      if (name === "NameWrapper") return V1.nameWrapper;
-      if (name === "PublicResolver") return RESOLVER;
-      throw new Error(`unexpected v1 lookup: ${name}`);
-    },
-    v2Address: (name: string) => {
-      throw new Error(`unexpected v2 lookup: ${name}`);
-    },
-  } as unknown as RefContext;
-
-  const row = (pre: Record<string, any>, tags: string[]): FixtureEnvelope =>
-    ({
-      fixture_id: "FX-V01",
-      label: "fxv",
-      name: "fxv.eth",
+  it("is not emitted for a name that has no parent", () => {
+    const flat = {
+      ...childRow(),
+      name: "fxc.eth",
       scenario: {
-        scenario_id: "FX-V01",
-        name: "fxv.eth",
-        top_level_label: "fxv",
-        tags,
-        actors: { pre_migration_owner: "owner_a" },
-        v1: {
-          registration: { label: "fxv", owner_actor: "owner_a" },
-          setup_steps: [],
-          expected_pre_migration: pre,
-        },
+        ...childRow().scenario,
+        name: "fxc.eth",
+        child_label: null,
+        tags: ["unwrapped"],
+        v1: { ...childRow().scenario.v1, setup_steps: [] },
       },
-    }) as unknown as FixtureEnvelope;
-
-  const expectedFor = (checks: any[], field: string) =>
-    checks.find((c) => c.field === field)?.assert(true, zeroAddress)?.expected;
-
-  it("expects the recipient on both owner records of an unwrapped name", () => {
-    const checks = buildV1Checks(
-      row(
-        { registry_owner_ref: "owner_a", base_registrar_owner_ref: "owner_a" },
-        ["unwrapped"],
-      ),
-      refCtx,
-      V1,
-      { to: TESTER, from: OWNER },
-    );
-    expect(expectedFor(checks, "registry.owner")).toBe(TESTER);
-    expect(expectedFor(checks, "baseRegistrar.ownerOf")).toBe(TESTER);
-  });
-
-  it("relaxes only the wrapper owner of a wrapped name", () => {
-    const checks = buildV1Checks(
-      row(
-        {
-          registry_owner_ref: "v1.NameWrapper",
-          base_registrar_owner_ref: "v1.NameWrapper",
-          wrapper_owner_ref: "owner_a",
-        },
-        ["wrapped_unlocked"],
-      ),
-      refCtx,
-      V1,
-      { to: TESTER, from: OWNER },
-    );
-    expect(expectedFor(checks, "nameWrapper.ownerOf")).toBe(TESTER);
-    expect(expectedFor(checks, "registry.owner")).toBe(V1.nameWrapper);
-    expect(expectedFor(checks, "baseRegistrar.ownerOf")).toBe(V1.nameWrapper);
-  });
-
-  it("leaves a record spelled with the same alias resolving to the actor", () => {
-    const checks = buildV1Checks(
-      row(
-        {
-          registry_owner_ref: "owner_a",
-          base_registrar_owner_ref: "owner_a",
-          resolver_ref: "v1.PublicResolver",
-          records: [{ kind: "addr", coin_type: 60, value_actor: "owner_a" }],
-        },
-        ["unwrapped"],
-      ),
-      refCtx,
-      V1,
-      { to: TESTER, from: OWNER },
-    );
-    // The alias names ownership in one place and content in the other; only the
-    // ownership reading moves.
-    expect(expectedFor(checks, "registry.owner")).toBe(TESTER);
-    expect(expectedFor(checks, "record addr(60)")).toBe(OWNER);
-  });
-
-  it("treats an unknown origin as unknown, not as the recipient", () => {
-    // A name found already at the recipient records no origin: its history is
-    // gone. Reading that absence as "it came from the recipient" would refuse
-    // to relax and fail every later check against the actor it left.
-    const checks = buildV1Checks(
-      row(
-        { registry_owner_ref: "owner_a", base_registrar_owner_ref: "owner_a" },
-        ["unwrapped"],
-      ),
-      refCtx,
-      V1,
-      { to: TESTER },
-    );
-    expect(expectedFor(checks, "registry.owner")).toBe(TESTER);
-
-    // Recording the recipient as the origin is what must never happen.
-    const wrong = buildV1Checks(
-      row(
-        { registry_owner_ref: "owner_a", base_registrar_owner_ref: "owner_a" },
-        ["unwrapped"],
-      ),
-      refCtx,
-      V1,
-      { to: TESTER, from: TESTER },
-    );
-    expect(expectedFor(wrong, "registry.owner")).toBe(OWNER);
-  });
-
-  it("keeps asserting the declared owner when the name moved off another holder", () => {
-    const checks = buildV1Checks(
-      row(
-        { registry_owner_ref: "owner_a", base_registrar_owner_ref: "owner_a" },
-        ["unwrapped"],
-      ),
-      refCtx,
-      V1,
-      { to: TESTER, from: OTHER_ACTOR },
-    );
-    expect(expectedFor(checks, "registry.owner")).toBe(OWNER);
+    } as unknown as FixtureEnvelope;
+    expect(parentTransfer(flat)).toEqual([]);
   });
 });

--- a/contracts/test/unit/migrationFixtureRecords.test.ts
+++ b/contracts/test/unit/migrationFixtureRecords.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { zeroAddress, type Address } from "viem";
+import { parseEther, zeroAddress, type Address } from "viem";
 
 import { isRetryableRpcRequest } from "../../script/migration.js";
 import {
@@ -8,7 +8,10 @@ import {
   recordValue,
   type PlanContext,
 } from "../../script/migrationFixture/plan.js";
-import { accounts } from "../../script/migrationFixture/config.js";
+import {
+  accounts,
+  fundingTargets,
+} from "../../script/migrationFixture/config.js";
 import { assertSeedable, refContext } from "../../script/migrationFixture.js";
 import type { RefContext } from "../../script/migrationFixture/scenario.js";
 import type {
@@ -256,11 +259,60 @@ describe("the wallet that owns the seeded names", () => {
   });
 });
 
+describe("the accounts a funding run tops up", () => {
+  const FLOOR = "0.5";
+  const floor = parseEther(FLOOR);
+
+  it("charges one floor per account when every alias has its own", () => {
+    const targets = fundingTargets(
+      accounts({ fixtureActorMnemonic: MNEMONIC } as never),
+      FLOOR,
+    );
+    expect(targets).toHaveLength(5);
+    for (const target of targets) {
+      expect(target.aliases).toHaveLength(1);
+      expect(target.required).toBe(floor);
+    }
+  });
+
+  it("charges the shared owner account every alias it carries", () => {
+    const targets = fundingTargets(
+      accounts({
+        fixtureActorMnemonic: MNEMONIC,
+        fixtureOwnerKey: OWNER_KEY,
+      } as never),
+      FLOOR,
+    );
+    // Five aliases, three accounts: the nominated wallet and two counterparties.
+    expect(targets).toHaveLength(3);
+
+    const owner = targets.find((t) => t.address === KEY_ADDRESS)!;
+    // Actor order, so the receipt label a run prints is stable.
+    expect(owner.aliases).toEqual(["owner_a", "owner_b", "owner_c"]);
+    expect(owner.required).toBe(floor * 3n);
+
+    for (const target of targets.filter((t) => t !== owner)) {
+      expect(target.aliases).toHaveLength(1);
+      expect(target.required).toBe(floor);
+    }
+  });
+
+  it("covers every actor exactly once", () => {
+    const derived = accounts({
+      fixtureActorMnemonic: MNEMONIC,
+      fixtureOwnerKey: OWNER_KEY,
+    } as never);
+    expect(fundingTargets(derived, FLOOR).flatMap((t) => t.aliases)).toEqual(
+      derived.map((a) => a.alias),
+    );
+  });
+});
+
 describe("the actors a run is checked against", () => {
   it("resolves aliases from the addresses the run recorded", () => {
     const recorded = { owner_a: KEY_ADDRESS, operator: OWNER };
     // No mnemonic and no owner key: reading the state back must not depend on
-    // either, since the key is nominated on seed-v1 alone.
+    // either, since nothing after seeding nominates one.
     const ctx = refContext({} as never, {}, recorded);
     expect(ctx.actors.get("owner_a")).toBe(KEY_ADDRESS);
     expect(ctx.actors.get("operator")).toBe(OWNER);

--- a/contracts/test/unit/migrationFixtureRecords.test.ts
+++ b/contracts/test/unit/migrationFixtureRecords.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   decodeFunctionData,
   getAddress,
+  namehash,
   zeroAddress,
   type Address,
 } from "viem";
@@ -16,6 +17,7 @@ import {
   type PlanContext,
 } from "../../script/migrationFixture/plan.js";
 import { assertSeedable } from "../../script/migrationFixture.js";
+import { buildV1Checks } from "../../script/migrationFixture/verifyV1.js";
 import type { RefContext } from "../../script/migrationFixture/scenario.js";
 import {
   FUSES,
@@ -356,6 +358,8 @@ describe("handing a seeded name to a wallet", () => {
       getAddress(OWNER),
       getAddress(TESTER),
     ]);
+    // The wrapper token is the namehash, not the registrar's labelhash id.
+    expect(transfer.args?.[2]).toBe(BigInt(namehash("fxh.eth")));
     expect(transfer.args?.[3]).toBe(1n);
   });
 
@@ -426,9 +430,199 @@ describe("handing a seeded name to a wallet", () => {
 
     expect(plan.calls).toHaveLength(2);
     expect(plan.holders).toEqual([OWNER, BATCHER]);
-    for (const call of plan.calls) {
-      expect(call.target).toBe(WRAPPER);
-      expect(decoded(call).args?.[1]).toBe(getAddress(TESTER));
+    const [childCall, parentCall] = plan.calls.map(decoded);
+    expect(plan.calls[0].target).toBe(WRAPPER);
+    expect(plan.calls[1].target).toBe(WRAPPER);
+    expect(childCall.args?.[0]).toBe(getAddress(OWNER));
+    expect(childCall.args?.[2]).toBe(BigInt(namehash("sub.fxh.eth")));
+    expect(parentCall.args?.[0]).toBe(getAddress(BATCHER));
+    expect(parentCall.args?.[2]).toBe(BigInt(namehash("fxh.eth")));
+    for (const call of [childCall, parentCall]) {
+      expect(call.args?.[1]).toBe(getAddress(TESTER));
     }
+  });
+
+  it("keeps a refused child's parent with the batcher", () => {
+    const child = handoverEnvelope(["locked_child"], {
+      name: "sub.fxh.eth",
+      child_label: "sub",
+    });
+    const plan = planHandover(
+      child,
+      planCtx,
+      TESTER,
+      liveState({
+        wrapperOwner: OWNER,
+        wrapperFuses: FUSES.CANNOT_TRANSFER,
+        wrapperExpiry: YEAR_AHEAD,
+        parentWrapperOwner: BATCHER,
+        parentWrapperExpiry: YEAR_AHEAD,
+      }),
+    );
+
+    // Moving the parent alone would split the pair: the recipient cannot
+    // migrate a subname it does not hold, and the actor left holding the
+    // subname can no longer migrate the name above it.
+    expect(plan.calls).toEqual([]);
+    expect(plan.holders).toEqual([]);
+    expect(plan.skips).toEqual([
+      { subject: "sub.fxh.eth", reason: "CANNOT_TRANSFER burned" },
+      { subject: "fxh.eth", reason: "its child stayed" },
+    ]);
+  });
+
+  it("leaves a name whose holder is gone, and one the wrapper holds", () => {
+    const absent = planHandover(
+      handoverEnvelope(["unwrapped"]),
+      planCtx,
+      TESTER,
+      liveState({ registrant: zeroAddress }),
+    );
+    expect(absent.calls).toEqual([]);
+    expect(absent.skips).toEqual([
+      { subject: "fxh.eth", reason: "no v1 holder" },
+    ]);
+
+    const wrapped = planHandover(
+      handoverEnvelope(["unwrapped"]),
+      planCtx,
+      TESTER,
+      liveState({ registrant: WRAPPER }),
+    );
+    expect(wrapped.calls).toEqual([]);
+    expect(wrapped.skips).toEqual([
+      { subject: "fxh.eth", reason: "held by the NameWrapper" },
+    ]);
+  });
+
+  it("moves an expired name that was never emancipated", () => {
+    const plan = planHandover(
+      handoverEnvelope(["wrapped_unlocked"]),
+      planCtx,
+      TESTER,
+      liveState({
+        wrapperOwner: OWNER,
+        // Expired, but PARENT_CANNOT_CONTROL is clear, so the wrapper still
+        // allows the transfer.
+        wrapperFuses: 0,
+        wrapperExpiry: NOW - 1n,
+      }),
+    );
+    expect(plan.skips).toEqual([]);
+    expect(plan.calls).toHaveLength(1);
+  });
+});
+
+describe("checking a handed-over name against its scenario", () => {
+  const RESOLVER = "0x00000000000000000000000000000000000000d4" as Address;
+  const V1 = {
+    registry: "0x00000000000000000000000000000000000000d1",
+    baseRegistrar: "0x00000000000000000000000000000000000000d2",
+    nameWrapper: "0x00000000000000000000000000000000000000d3",
+  } as const;
+
+  const refCtx = {
+    actors: new Map([
+      ["owner_a", OWNER],
+      ["owner_b", "0x00000000000000000000000000000000000000a2"],
+    ]),
+    fixtureContracts: {},
+    v1Address: (name: string) => {
+      if (name === "NameWrapper") return V1.nameWrapper;
+      if (name === "PublicResolver") return RESOLVER;
+      throw new Error(`unexpected v1 lookup: ${name}`);
+    },
+    v2Address: (name: string) => {
+      throw new Error(`unexpected v2 lookup: ${name}`);
+    },
+  } as unknown as RefContext;
+
+  const row = (pre: Record<string, any>, tags: string[]): FixtureEnvelope =>
+    ({
+      fixture_id: "FX-V01",
+      label: "fxv",
+      name: "fxv.eth",
+      scenario: {
+        scenario_id: "FX-V01",
+        name: "fxv.eth",
+        top_level_label: "fxv",
+        tags,
+        actors: { pre_migration_owner: "owner_a" },
+        v1: {
+          registration: { label: "fxv", owner_actor: "owner_a" },
+          setup_steps: [],
+          expected_pre_migration: pre,
+        },
+      },
+    }) as unknown as FixtureEnvelope;
+
+  const expectedFor = (checks: any[], field: string) =>
+    checks.find((c) => c.field === field)?.assert(true, zeroAddress)?.expected;
+
+  it("expects the recipient on both owner records of an unwrapped name", () => {
+    const checks = buildV1Checks(
+      row(
+        { registry_owner_ref: "owner_a", base_registrar_owner_ref: "owner_a" },
+        ["unwrapped"],
+      ),
+      refCtx,
+      V1,
+      { to: TESTER, from: "owner_a" },
+    );
+    expect(expectedFor(checks, "registry.owner")).toBe(TESTER);
+    expect(expectedFor(checks, "baseRegistrar.ownerOf")).toBe(TESTER);
+  });
+
+  it("relaxes only the wrapper owner of a wrapped name", () => {
+    const checks = buildV1Checks(
+      row(
+        {
+          registry_owner_ref: "v1.NameWrapper",
+          base_registrar_owner_ref: "v1.NameWrapper",
+          wrapper_owner_ref: "owner_a",
+        },
+        ["wrapped_unlocked"],
+      ),
+      refCtx,
+      V1,
+      { to: TESTER, from: "owner_a" },
+    );
+    expect(expectedFor(checks, "nameWrapper.ownerOf")).toBe(TESTER);
+    expect(expectedFor(checks, "registry.owner")).toBe(V1.nameWrapper);
+    expect(expectedFor(checks, "baseRegistrar.ownerOf")).toBe(V1.nameWrapper);
+  });
+
+  it("leaves a record spelled with the same alias resolving to the actor", () => {
+    const checks = buildV1Checks(
+      row(
+        {
+          registry_owner_ref: "owner_a",
+          base_registrar_owner_ref: "owner_a",
+          resolver_ref: "v1.PublicResolver",
+          records: [{ kind: "addr", coin_type: 60, value_actor: "owner_a" }],
+        },
+        ["unwrapped"],
+      ),
+      refCtx,
+      V1,
+      { to: TESTER, from: "owner_a" },
+    );
+    // The alias names ownership in one place and content in the other; only the
+    // ownership reading moves.
+    expect(expectedFor(checks, "registry.owner")).toBe(TESTER);
+    expect(expectedFor(checks, "record addr(60)")).toBe(OWNER);
+  });
+
+  it("keeps asserting the declared owner when the name moved off another alias", () => {
+    const checks = buildV1Checks(
+      row(
+        { registry_owner_ref: "owner_a", base_registrar_owner_ref: "owner_a" },
+        ["unwrapped"],
+      ),
+      refCtx,
+      V1,
+      { to: TESTER, from: "owner_b" },
+    );
+    expect(expectedFor(checks, "registry.owner")).toBe(OWNER);
   });
 });

--- a/contracts/test/unit/migrationFixtureRecords.test.ts
+++ b/contracts/test/unit/migrationFixtureRecords.test.ts
@@ -643,6 +643,34 @@ describe("checking a handed-over name against its scenario", () => {
     expect(expectedFor(checks, "record addr(60)")).toBe(OWNER);
   });
 
+  it("treats an unknown origin as unknown, not as the recipient", () => {
+    // A name found already at the recipient records no origin: its history is
+    // gone. Reading that absence as "it came from the recipient" would refuse
+    // to relax and fail every later check against the actor it left.
+    const checks = buildV1Checks(
+      row(
+        { registry_owner_ref: "owner_a", base_registrar_owner_ref: "owner_a" },
+        ["unwrapped"],
+      ),
+      refCtx,
+      V1,
+      { to: TESTER },
+    );
+    expect(expectedFor(checks, "registry.owner")).toBe(TESTER);
+
+    // Recording the recipient as the origin is what must never happen.
+    const wrong = buildV1Checks(
+      row(
+        { registry_owner_ref: "owner_a", base_registrar_owner_ref: "owner_a" },
+        ["unwrapped"],
+      ),
+      refCtx,
+      V1,
+      { to: TESTER, from: TESTER },
+    );
+    expect(expectedFor(wrong, "registry.owner")).toBe(OWNER);
+  });
+
   it("keeps asserting the declared owner when the name moved off another holder", () => {
     const checks = buildV1Checks(
       row(

--- a/contracts/test/unit/migrationFixtureRecords.test.ts
+++ b/contracts/test/unit/migrationFixtureRecords.test.ts
@@ -9,7 +9,7 @@ import {
   type PlanContext,
 } from "../../script/migrationFixture/plan.js";
 import { accounts } from "../../script/migrationFixture/config.js";
-import { assertSeedable } from "../../script/migrationFixture.js";
+import { assertSeedable, refContext } from "../../script/migrationFixture.js";
 import type { RefContext } from "../../script/migrationFixture/scenario.js";
 import type {
   FixtureEnvelope,
@@ -253,6 +253,25 @@ describe("the wallet that owns the seeded names", () => {
         fixtureOwnerKey: "0xnope",
       } as never),
     ).toThrow(/fixture-owner-key/);
+  });
+});
+
+describe("the actors a run is checked against", () => {
+  it("resolves aliases from the addresses the run recorded", () => {
+    const recorded = { owner_a: KEY_ADDRESS, operator: OWNER };
+    // No mnemonic and no owner key: reading the state back must not depend on
+    // either, since the key is nominated on seed-v1 alone.
+    const ctx = refContext({} as never, {}, recorded);
+    expect(ctx.actors.get("owner_a")).toBe(KEY_ADDRESS);
+    expect(ctx.actors.get("operator")).toBe(OWNER);
+  });
+
+  it("derives them when nothing was recorded", () => {
+    const ctx = refContext({ fixtureActorMnemonic: MNEMONIC } as never, {});
+    const derived = accounts({ fixtureActorMnemonic: MNEMONIC } as never);
+    for (const actor of derived) {
+      expect(ctx.actors.get(actor.alias)).toBe(actor.account.address);
+    }
   });
 });
 

--- a/contracts/test/unit/migrationFixtureRecords.test.ts
+++ b/contracts/test/unit/migrationFixtureRecords.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { Command } from "commander";
 import { parseEther, zeroAddress, type Address } from "viem";
 
 import { isRetryableRpcRequest } from "../../script/migration.js";
@@ -13,6 +14,7 @@ import {
   fundingTargets,
 } from "../../script/migrationFixture/config.js";
 import {
+  addFixtureSubcommands,
   assertSeedable,
   refContext,
   reportReverseClaimOverlap,
@@ -477,5 +479,106 @@ describe("a subname's parent", () => {
       },
     } as unknown as FixtureEnvelope;
     expect(parentTransfer(flat)).toEqual([]);
+  });
+});
+
+describe("the fixture command line", () => {
+  /// Parses one command line the way the CLI does, and hands back the options
+  /// the command would have run with.
+  ///
+  /// The parse is the real one — an unregistered option throws here exactly as
+  /// it does for an operator — with only the action replaced, so a dry run does
+  /// not go looking for a corpus or an RPC. `exitOverride` turns a parse error
+  /// into a thrown error rather than an exit that would take the runner with it.
+  const run = async (argv: string[]): Promise<Record<string, unknown>> => {
+    const program = addFixtureSubcommands(new Command("migration-fixture"));
+    const silent = { writeErr: () => {}, writeOut: () => {} };
+    let parsed: Record<string, unknown> | undefined;
+    program.exitOverride().configureOutput(silent);
+    for (const command of program.commands) {
+      command
+        .exitOverride()
+        .configureOutput(silent)
+        .action((raw: Record<string, unknown>) => {
+          parsed = raw;
+        });
+    }
+    await program.parseAsync(argv, { from: "user" });
+    if (!parsed) throw new Error("no fixture command ran");
+    return parsed;
+  };
+
+  const argvFor = (command: string, ...rest: string[]) => [
+    command,
+    "--network",
+    "sepolia",
+    "--rpc-url",
+    "http://127.0.0.1:8545",
+    "--fixture-root",
+    "csv-data/migration-fixture",
+    "--work-dir",
+    ".dev/fixture",
+    "--fixture-actor-mnemonic",
+    MNEMONIC,
+    ...rest,
+  ];
+
+  const optionsOf = (command: string) => {
+    const program = addFixtureSubcommands(new Command("migration-fixture"));
+    const found = program.commands.find((c) => c.name() === command);
+    if (!found) throw new Error(`no such fixture command: ${command}`);
+    return found.options.map((o) => o.long);
+  };
+
+  it("carries the owner key from the dry run's argv through to the actors", async () => {
+    // The whole point of the dry run: the cohort it plans is the cohort seeding
+    // will register, down to which account each owner alias is.
+    const parsed = await run(
+      argvFor("verify", "--fixture-owner-key", OWNER_KEY),
+    );
+    expect(parsed.fixtureOwnerKey).toBe(OWNER_KEY);
+
+    const derived = accounts(parsed as never);
+    const address = (alias: string) =>
+      derived.find((a) => a.alias === alias)!.account.address;
+    for (const alias of ["owner_a", "owner_b", "owner_c"]) {
+      expect(address(alias)).toBe(KEY_ADDRESS);
+    }
+  });
+
+  it("plans the default three-owner layout when no wallet is nominated", async () => {
+    const parsed = await run(argvFor("verify"));
+    expect(parsed.fixtureOwnerKey).toBeUndefined();
+    // Five aliases, five accounts: the layout the dry run has always planned.
+    const derived = accounts(parsed as never);
+    expect(new Set(derived.map((a) => a.account.address)).size).toBe(5);
+  });
+
+  it("lets the dry run take every option the run it previews takes", () => {
+    // A plan is worth previewing only if it is the plan that will run. An
+    // option seeding accepts and the dry run rejects makes the two diverge with
+    // nothing to show for it, which is how --fixture-owner-key came to be
+    // previewable through its environment variable alone.
+    for (const long of optionsOf("seed-v1")) {
+      expect(optionsOf("verify")).toContain(long);
+    }
+  });
+
+  it("takes the owner key everywhere the owner aliases are resolved", async () => {
+    for (const command of ["verify", "fund-actors", "seed-v1"]) {
+      const parsed = await run(
+        argvFor(command, "--fixture-owner-key", OWNER_KEY),
+      );
+      expect(parsed.fixtureOwnerKey).toBe(OWNER_KEY);
+    }
+  });
+
+  it("refuses the owner key once the names exist, whose owner it cannot change", async () => {
+    // verify-v1 resolves each alias against the addresses the seeding run
+    // recorded, so a key here could only contradict them. Its refusal is also
+    // what proves this harness sees an unregistered option at all.
+    await expect(
+      run(argvFor("verify-v1", "--fixture-owner-key", OWNER_KEY)),
+    ).rejects.toThrow(/unknown option/);
   });
 });

--- a/contracts/test/unit/migrationFixtureRecords.test.ts
+++ b/contracts/test/unit/migrationFixtureRecords.test.ts
@@ -471,6 +471,35 @@ describe("handing a seeded name to a wallet", () => {
     ]);
   });
 
+  it("keeps a movable child with a parent that cannot move", () => {
+    const child = handoverEnvelope(["locked_child"], {
+      name: "sub.fxh.eth",
+      child_label: "sub",
+    });
+    const plan = planHandover(child, planCtx, TESTER, {
+      wrapperOwner: OWNER,
+      wrapperFuses: 0,
+      // The child is live...
+      wrapperExpiry: YEAR_AHEAD,
+      registrant: zeroAddress,
+      parentWrapperOwner: BATCHER,
+      // ...while its 2LD parent has entered the grace period the wrapper
+      // treats as expiry, which only the parent's fuses make fatal.
+      parentWrapperFuses: FUSES.IS_DOT_ETH | FUSES.PARENT_CANNOT_CONTROL,
+      parentWrapperExpiry: NOW + 1n,
+      now: NOW,
+    });
+
+    // Moving the child alone would leave a subname its holder can never
+    // migrate, because the helper reverts until the parent has.
+    expect(plan.calls).toEqual([]);
+    expect(plan.holders).toEqual([]);
+    expect(plan.skips).toEqual([
+      { subject: "sub.fxh.eth", reason: "its parent stayed" },
+      { subject: "fxh.eth", reason: "expired" },
+    ]);
+  });
+
   it("leaves a name whose holder is gone, and one the wrapper holds", () => {
     const absent = planHandover(
       handoverEnvelope(["unwrapped"]),
@@ -515,6 +544,7 @@ describe("handing a seeded name to a wallet", () => {
 
 describe("checking a handed-over name against its scenario", () => {
   const RESOLVER = "0x00000000000000000000000000000000000000d4" as Address;
+  const OTHER_ACTOR = "0x00000000000000000000000000000000000000a2" as Address;
   const V1 = {
     registry: "0x00000000000000000000000000000000000000d1",
     baseRegistrar: "0x00000000000000000000000000000000000000d2",
@@ -524,7 +554,7 @@ describe("checking a handed-over name against its scenario", () => {
   const refCtx = {
     actors: new Map([
       ["owner_a", OWNER],
-      ["owner_b", "0x00000000000000000000000000000000000000a2"],
+      ["owner_b", OTHER_ACTOR],
     ]),
     fixtureContracts: {},
     v1Address: (name: string) => {
@@ -567,7 +597,7 @@ describe("checking a handed-over name against its scenario", () => {
       ),
       refCtx,
       V1,
-      { to: TESTER, from: "owner_a" },
+      { to: TESTER, from: OWNER },
     );
     expect(expectedFor(checks, "registry.owner")).toBe(TESTER);
     expect(expectedFor(checks, "baseRegistrar.ownerOf")).toBe(TESTER);
@@ -585,7 +615,7 @@ describe("checking a handed-over name against its scenario", () => {
       ),
       refCtx,
       V1,
-      { to: TESTER, from: "owner_a" },
+      { to: TESTER, from: OWNER },
     );
     expect(expectedFor(checks, "nameWrapper.ownerOf")).toBe(TESTER);
     expect(expectedFor(checks, "registry.owner")).toBe(V1.nameWrapper);
@@ -605,7 +635,7 @@ describe("checking a handed-over name against its scenario", () => {
       ),
       refCtx,
       V1,
-      { to: TESTER, from: "owner_a" },
+      { to: TESTER, from: OWNER },
     );
     // The alias names ownership in one place and content in the other; only the
     // ownership reading moves.
@@ -613,7 +643,7 @@ describe("checking a handed-over name against its scenario", () => {
     expect(expectedFor(checks, "record addr(60)")).toBe(OWNER);
   });
 
-  it("keeps asserting the declared owner when the name moved off another alias", () => {
+  it("keeps asserting the declared owner when the name moved off another holder", () => {
     const checks = buildV1Checks(
       row(
         { registry_owner_ref: "owner_a", base_registrar_owner_ref: "owner_a" },
@@ -621,7 +651,7 @@ describe("checking a handed-over name against its scenario", () => {
       ),
       refCtx,
       V1,
-      { to: TESTER, from: "owner_b" },
+      { to: TESTER, from: OTHER_ACTOR },
     );
     expect(expectedFor(checks, "registry.owner")).toBe(OWNER);
   });

--- a/contracts/test/unit/migrationFixtureRecords.test.ts
+++ b/contracts/test/unit/migrationFixtureRecords.test.ts
@@ -1,16 +1,26 @@
 import { describe, expect, it } from "bun:test";
-import { zeroAddress, type Address } from "viem";
+import {
+  decodeFunctionData,
+  getAddress,
+  zeroAddress,
+  type Address,
+} from "viem";
 
 import { isRetryableRpcRequest } from "../../script/migration.js";
 import {
   clearedRecord,
+  planHandover,
   recordValue,
+  tokenIdOf,
+  type HandoverState,
+  type PlanContext,
 } from "../../script/migrationFixture/plan.js";
 import { assertSeedable } from "../../script/migrationFixture.js";
 import type { RefContext } from "../../script/migrationFixture/scenario.js";
-import type {
-  FixtureEnvelope,
-  RecordSpec,
+import {
+  FUSES,
+  type FixtureEnvelope,
+  type RecordSpec,
 } from "../../script/migrationFixture/types.js";
 
 const OWNER = "0x00000000000000000000000000000000000000a1" as Address;
@@ -197,5 +207,228 @@ describe("retryable rpc requests", () => {
     expect(isRetryableRpcRequest([{ method: "eth_call" }])).toBe(false);
     expect(isRetryableRpcRequest(null)).toBe(false);
     expect(isRetryableRpcRequest({})).toBe(false);
+  });
+});
+
+const REGISTRAR = "0x00000000000000000000000000000000000000b1" as Address;
+const WRAPPER = "0x00000000000000000000000000000000000000b2" as Address;
+const BATCHER = "0x00000000000000000000000000000000000000b3" as Address;
+const TESTER = "0x00000000000000000000000000000000000000c1" as Address;
+
+const planCtx = {
+  ...ctx,
+  batcher: BATCHER,
+  addresses: {
+    baseRegistrar: REGISTRAR,
+    registry: "0x00000000000000000000000000000000000000b4",
+    wrapper: WRAPPER,
+    controller: "0x00000000000000000000000000000000000000b5",
+    publicResolver: "0x00000000000000000000000000000000000000b6",
+    reverseRegistrar: "0x00000000000000000000000000000000000000b7",
+    defaultReverseRegistrar: "0x00000000000000000000000000000000000000b8",
+  },
+} as unknown as PlanContext;
+
+const NOW = 2_000_000_000n;
+const YEAR_AHEAD = NOW + 31_536_000n;
+
+const handoverEnvelope = (
+  tags: string[],
+  overrides: Record<string, any> = {},
+): FixtureEnvelope =>
+  ({
+    fixture_id: "FX-H01",
+    source_scenario_id: "FX-H",
+    label: "fxh",
+    name: "fxh.eth",
+    scenario: {
+      scenario_id: "FX-H01",
+      name: "fxh.eth",
+      top_level_label: "fxh",
+      child_label: null,
+      tags,
+      execution: { scenario: "live_now", expected_result: "success" },
+      actors: { pre_migration_owner: "owner_a" },
+      v1: {
+        registration: { label: "fxh", owner_actor: "owner_a" },
+        setup_steps: [],
+        expected_pre_migration: {},
+      },
+      ...overrides,
+    },
+  }) as unknown as FixtureEnvelope;
+
+const liveState = (over: Partial<HandoverState> = {}): HandoverState => ({
+  wrapperOwner: zeroAddress,
+  wrapperFuses: 0,
+  wrapperExpiry: 0n,
+  registrant: zeroAddress,
+  now: NOW,
+  ...over,
+});
+
+const decoded = (call: { target: Address; data: `0x${string}` }) =>
+  decodeFunctionData({
+    abi: [...ERC721_HANDOVER_ABI, ...ERC1155_HANDOVER_ABI],
+    data: call.data,
+  });
+
+const ERC721_HANDOVER_ABI = [
+  {
+    type: "function",
+    name: "transferFrom",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "tokenId", type: "uint256" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "reclaim",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "id", type: "uint256" },
+      { name: "owner", type: "address" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+const ERC1155_HANDOVER_ABI = [
+  {
+    type: "function",
+    name: "safeTransferFrom",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "id", type: "uint256" },
+      { name: "amount", type: "uint256" },
+      { name: "data", type: "bytes" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+describe("handing a seeded name to a wallet", () => {
+  it("reclaims an unwrapped name before transferring it", () => {
+    const plan = planHandover(
+      handoverEnvelope(["unwrapped"]),
+      planCtx,
+      TESTER,
+      liveState({ registrant: OWNER }),
+    );
+
+    expect(plan.skips).toEqual([]);
+    expect(plan.holders).toEqual([OWNER]);
+    expect(plan.calls.map((c) => c.signer.kind)).toEqual([
+      "batcher",
+      "batcher",
+    ]);
+    // Reclaim first: after the token moves the sender loses standing to make it.
+    const [reclaim, transfer] = plan.calls.map(decoded);
+    expect(reclaim.functionName).toBe("reclaim");
+    expect(reclaim.args?.[1]).toBe(getAddress(TESTER));
+    expect(transfer.functionName).toBe("transferFrom");
+    expect(transfer.args?.[0]).toBe(getAddress(OWNER));
+    expect(transfer.args?.[1]).toBe(getAddress(TESTER));
+    const tokenId = tokenIdOf("fxh");
+    expect(reclaim.args?.[0]).toBe(tokenId);
+    expect(transfer.args?.[2]).toBe(tokenId);
+  });
+
+  it("moves a wrapped name with one wrapper transfer", () => {
+    const plan = planHandover(
+      handoverEnvelope(["wrapped_unlocked"]),
+      planCtx,
+      TESTER,
+      liveState({ wrapperOwner: OWNER, wrapperExpiry: YEAR_AHEAD }),
+    );
+
+    expect(plan.calls).toHaveLength(1);
+    expect(plan.calls[0].target).toBe(WRAPPER);
+    const transfer = decoded(plan.calls[0]);
+    expect(transfer.functionName).toBe("safeTransferFrom");
+    expect(transfer.args?.slice(0, 2)).toEqual([
+      getAddress(OWNER),
+      getAddress(TESTER),
+    ]);
+    expect(transfer.args?.[3]).toBe(1n);
+  });
+
+  it("leaves a name whose transfer fuse is burned", () => {
+    const plan = planHandover(
+      handoverEnvelope(["wrapped_locked"]),
+      planCtx,
+      TESTER,
+      liveState({
+        wrapperOwner: OWNER,
+        wrapperFuses: FUSES.CANNOT_TRANSFER,
+        wrapperExpiry: YEAR_AHEAD,
+      }),
+    );
+
+    expect(plan.calls).toEqual([]);
+    expect(plan.skips).toEqual([
+      { subject: "fxh.eth", reason: "CANNOT_TRANSFER burned" },
+    ]);
+  });
+
+  it("leaves an emancipated name that has reached its grace period", () => {
+    const plan = planHandover(
+      handoverEnvelope(["wrapped_locked"]),
+      planCtx,
+      TESTER,
+      liveState({
+        wrapperOwner: OWNER,
+        // The wrapper treats a .eth 2LD as expiring when its grace period opens.
+        wrapperFuses: FUSES.IS_DOT_ETH | FUSES.PARENT_CANNOT_CONTROL,
+        wrapperExpiry: NOW + 1n,
+      }),
+    );
+
+    expect(plan.calls).toEqual([]);
+    expect(plan.skips).toEqual([{ subject: "fxh.eth", reason: "expired" }]);
+  });
+
+  it("plans nothing for a name the wallet already holds", () => {
+    const plan = planHandover(
+      handoverEnvelope(["unwrapped"]),
+      planCtx,
+      TESTER,
+      liveState({ registrant: TESTER }),
+    );
+
+    expect(plan.calls).toEqual([]);
+    expect(plan.skips).toEqual([]);
+    expect(plan.holders).toEqual([]);
+  });
+
+  it("moves a child's parent as well, so the child can be migrated", () => {
+    const child = handoverEnvelope(["locked_child"], {
+      name: "sub.fxh.eth",
+      child_label: "sub",
+    });
+    const plan = planHandover(
+      child,
+      planCtx,
+      TESTER,
+      liveState({
+        wrapperOwner: OWNER,
+        wrapperExpiry: YEAR_AHEAD,
+        parentWrapperOwner: BATCHER,
+        parentWrapperExpiry: YEAR_AHEAD,
+      }),
+    );
+
+    expect(plan.calls).toHaveLength(2);
+    expect(plan.holders).toEqual([OWNER, BATCHER]);
+    for (const call of plan.calls) {
+      expect(call.target).toBe(WRAPPER);
+      expect(decoded(call).args?.[1]).toBe(getAddress(TESTER));
+    }
   });
 });

--- a/contracts/test/unit/migrationFixtureRecords.test.ts
+++ b/contracts/test/unit/migrationFixtureRecords.test.ts
@@ -12,7 +12,11 @@ import {
   accounts,
   fundingTargets,
 } from "../../script/migrationFixture/config.js";
-import { assertSeedable, refContext } from "../../script/migrationFixture.js";
+import {
+  assertSeedable,
+  refContext,
+  reportReverseClaimOverlap,
+} from "../../script/migrationFixture.js";
 import type { RefContext } from "../../script/migrationFixture/scenario.js";
 import type {
   FixtureEnvelope,
@@ -305,6 +309,62 @@ describe("the accounts a funding run tops up", () => {
     expect(fundingTargets(derived, FLOOR).flatMap((t) => t.aliases)).toEqual(
       derived.map((a) => a.alias),
     );
+  });
+});
+
+describe("the reverse claims a selection loses", () => {
+  const claim = (alias: string) =>
+    envelope({
+      v1: {
+        registration: { duration_seconds: 31536000 },
+        setup_steps: [
+          { action: "set_reverse_claim", address_actor: `actor.${alias}` },
+        ],
+        expected_pre_migration: { expiry_cohort: "long" },
+      },
+    });
+
+  const warningFor = (
+    rows: FixtureEnvelope[],
+    opts: Record<string, unknown>,
+  ) => {
+    const original = console.warn;
+    let warned: string | undefined;
+    console.warn = (message: string) => {
+      warned = message;
+    };
+    try {
+      reportReverseClaimOverlap(rows, accounts(opts as never));
+    } finally {
+      console.warn = original;
+    }
+    return warned;
+  };
+
+  it("says nothing when each alias claims once and is its own account", () => {
+    expect(
+      warningFor([claim("owner_a"), claim("owner_b"), claim("owner_c")], {
+        fixtureActorMnemonic: MNEMONIC,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("counts claims from aliases the owner key collapsed as one account", () => {
+    // Three aliases, one wallet: every claim writes the same reverse node, so
+    // one account loses two claims rather than three accounts losing none.
+    const warned = warningFor(
+      [claim("owner_a"), claim("owner_b"), claim("owner_c")],
+      { fixtureActorMnemonic: MNEMONIC, fixtureOwnerKey: OWNER_KEY },
+    );
+    expect(warned).toContain("3 reverse claims share 1 ");
+    expect(warned).toContain("owner_a+owner_b+owner_c (3)");
+  });
+
+  it("still reports an alias colliding with itself", () => {
+    const warned = warningFor([claim("owner_a"), claim("owner_a")], {
+      fixtureActorMnemonic: MNEMONIC,
+    });
+    expect(warned).toContain("owner_a (2)");
   });
 });
 

--- a/contracts/test/unit/migrationFixtureRecords.test.ts
+++ b/contracts/test/unit/migrationFixtureRecords.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { Command } from "commander";
-import { parseEther, zeroAddress, type Address } from "viem";
+import { parseEther, toHex, zeroAddress, type Address } from "viem";
+import { mnemonicToAccount } from "viem/accounts";
 
 import { isRetryableRpcRequest } from "../../script/migration.js";
 import {
@@ -11,8 +12,10 @@ import {
 } from "../../script/migrationFixture/plan.js";
 import {
   accounts,
+  ACTOR_ALIASES,
   fundingTargets,
 } from "../../script/migrationFixture/config.js";
+import { fundActors } from "../../script/migrationFixture/execute.js";
 import {
   addFixtureSubcommands,
   assertSeedable,
@@ -263,6 +266,26 @@ describe("the wallet that owns the seeded names", () => {
       } as never),
     ).toThrow(/fixture-owner-key/);
   });
+
+  // The corpus migrates as these two to prove they are turned away. Owning the
+  // names as one makes those calls authorised, and verification reads the same
+  // accounts, so nothing downstream would notice.
+  for (const alias of ["operator", "attacker"]) {
+    it(`refuses a key that is the ${alias}`, () => {
+      const index = ACTOR_ALIASES.indexOf(alias as never);
+      const key = toHex(
+        mnemonicToAccount(MNEMONIC, {
+          accountIndex: index,
+        }).getHdKey().privateKey!,
+      );
+      expect(() =>
+        accounts({
+          fixtureActorMnemonic: MNEMONIC,
+          fixtureOwnerKey: key,
+        } as never),
+      ).toThrow(new RegExp(`"${alias}"`));
+    });
+  }
 });
 
 describe("the accounts a funding run tops up", () => {
@@ -310,6 +333,95 @@ describe("the accounts a funding run tops up", () => {
     } as never);
     expect(fundingTargets(derived, FLOOR).flatMap((t) => t.aliases)).toEqual(
       derived.map((a) => a.alias),
+    );
+  });
+});
+
+describe("a funding run", () => {
+  const FLOOR = "0.5";
+  const floor = parseEther(FLOOR);
+  const STRANGER = "0x00000000000000000000000000000000000000f1" as Address;
+  /// The owner key of a run whose tester wallet also pays for the run.
+  const SHARED_KEY = toHex(mnemonicToAccount(MNEMONIC).getHdKey().privateKey!);
+  const SHARED = mnemonicToAccount(MNEMONIC).address;
+
+  /// A run against recorded balances. Nothing is signed, so the executor only
+  /// has to answer balances and collect what it was asked to send.
+  const run = (opts: {
+    funder: Address;
+    balances?: Record<Address, bigint>;
+    ownerKey?: string;
+  }) => {
+    const held = new Map(
+      Object.entries(opts.balances ?? {}).map(([a, v]) => [a.toLowerCase(), v]),
+    );
+    const sent: { to: Address; value: bigint }[] = [];
+    const actors = accounts({
+      fixtureActorMnemonic: MNEMONIC,
+      fixtureOwnerKey: opts.ownerKey,
+    } as never);
+    const ex = {
+      opts: {},
+      client: {
+        getBalance: async ({ address }: { address: Address }) =>
+          held.get(address.toLowerCase()) ?? 0n,
+        waitForTransactionReceipt: async () => ({ status: "success" }),
+      },
+      wallet: {
+        account: { address: opts.funder },
+        sendTransaction: async (tx: { to: Address; value: bigint }) => {
+          sent.push(tx);
+          return "0x" as const;
+        },
+      },
+      actors: new Map(actors.map((a) => [a.alias, a])),
+    } as never;
+    return { ex, sent, targets: fundingTargets(actors, FLOOR) };
+  };
+
+  it("tops each account up to what its aliases need", async () => {
+    const { ex, sent, targets } = run({ funder: STRANGER });
+    await fundActors(ex, FLOOR);
+    expect(sent).toEqual(
+      targets.map((t) => ({ to: t.address, value: t.required })),
+    );
+  });
+
+  it("leaves an account already holding enough alone", async () => {
+    const { targets } = run({ funder: STRANGER });
+    const { ex, sent } = run({
+      funder: STRANGER,
+      balances: Object.fromEntries(
+        targets.map((t) => [t.address, t.required]),
+      ) as Record<Address, bigint>,
+    });
+    await fundActors(ex, FLOOR);
+    expect(sent).toEqual([]);
+  });
+
+  // An account cannot be paid from itself: a transfer out and back leaves it
+  // poorer by the gas. The shortfall is reported rather than sent.
+  it("refuses to send the funding account its own money", async () => {
+    const { ex, sent } = run({
+      funder: SHARED,
+      balances: { [SHARED]: floor },
+      ownerKey: SHARED_KEY,
+    });
+    await expect(fundActors(ex, FLOOR)).rejects.toThrow(
+      /is the funding account/,
+    );
+    expect(sent).toEqual([]);
+  });
+
+  it("funds the rest when the funding account already holds its share", async () => {
+    const { ex, sent, targets } = run({
+      funder: SHARED,
+      balances: { [SHARED]: floor * 3n },
+      ownerKey: SHARED_KEY,
+    });
+    await fundActors(ex, FLOOR);
+    expect(sent.map((s) => s.to)).toEqual(
+      targets.filter((t) => t.address !== SHARED).map((t) => t.address),
     );
   });
 });


### PR DESCRIPTION
`--fixture-owner-key <key>` registers every seeded fixture name to the nominated wallet from the first block, so there is no transfer step. It covers the three owner aliases `owner_a`, `owner_b` and `owner_c`; `operator` and `attacker` stay on the actor mnemonic. `fork full` and `clean-testnet` take the same flag. The 196 names carrying `CANNOT_TRANSFER` are the owner's on the same terms as the rest.

Seeding also hands each subname's parent to its owner, using the corpus's declared `parent_fixture.owner_actor`, so a holder can migrate the subnames they own.

## The trade

One wallet collapses the three owner aliases onto one address: 356 `transfer_registrant` steps become self-transfers, 2,034 scenarios name an `alternate_owner` that is now the owner, and 16 of 48 helper batches stop spanning more than one owner. Nothing fails; the coverage is narrower. Seeding says so on every run, and the docs say when to seed without the flag.

## Also here

- **ABI fragments come from the compiled contracts.** `script/abis.ts` cuts each one out of its artifact with a `pick` that keeps the literal type, replacing 22 hand-written blocks across 8 files. Four had drifted — `wrapETH2LD` was declared as returning nothing when it returns its expiry.
- **Fixture flags are consistently prefixed.** All nine carry `--fixture-` everywhere, and the rehearsals share one definition.
- **Fixes a pre-existing `Check Types` failure on `post-audit-2`** — three batched reads inferring across full artifact ABIs exhausted TypeScript's instantiation budget.

## Verification

Mainnet Anvil fork, 7-name cohort spanning both `CANNOT_TRANSFER` cases and all three child forms: all 7 owned by the key, every parent with them, `verify-v1` passing with no override. `fork full --network sepolia` and `clean-testnet` on an Anvil Sepolia fork both run end to end. 75 unit tests, typecheck clean.
