### PR TITLE
fix(migration): let the dry run preview the layout it is about to seed

### DIFF
--- a/contracts/docs/migration.md
+++ b/contracts/docs/migration.md
@@ -467,10 +467,13 @@ controlled clock, a v2 state that needs the name already registered there, or a 
 controller's minimum. `fixture verify` applies the same check offline, so a cohort can be tested
 before a run starts. Every `live_now` scenario passes it.
 
-> **Reverse records are shared.** A reverse node derives from the account that claims it, and each
-> actor alias is one account, so scenarios claiming from the same alias all write the same node and
-> only the last survives. Seeding reports the overlap. Nothing else the corpus shapes or checks
-> depends on it, and no migration route reads a reverse record.
+> **Reverse records are shared.** A reverse node derives from the account that claims it, so
+> scenarios claiming from the same account all write the same node and only the last survives. Which
+> claims collide therefore depends on the layout: by default an alias is an account; with a
+> [nominated wallet](#choosing-who-owns-the-seeded-names) the three owner aliases are one account, so
+> claims that were distinct now overwrite each other. Both `verify` and seeding report the overlap,
+> counted per account. Nothing else the corpus shapes or checks depends on it, and no migration route
+> reads a reverse record.
 
 `--fixture-scenarios live_now --fixture-replicas-per-vector 4` is the recommended default: it covers every scenario
 the public network can express, several times over, without the long tail of replicas that adds
@@ -493,6 +496,13 @@ bun run migration -- fixture verify --network sepolia \
   --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
   --fixture-scenarios live_now --fixture-replicas-per-vector 4
 ```
+
+**Dry-run the layout you intend to seed.** `verify` takes `--fixture-owner-key` for the same reason
+`fund-actors` does: nominating a wallet decides which accounts the owner aliases resolve to, and so
+which plan there is to preview. Pass it and the preview is the run you are about to make. Omit it and
+the preview is the [default three-owner layout](#choosing-who-owns-the-seeded-names), whatever key
+seeding is later given. The reported `owner` is the wallet the plan registers to, and `null` when no
+wallet is nominated.
 
 Planning is not a state check. It confirms every call can be *built*; whether the resulting state is
 reachable on-chain is what [`verify-v1`](#checking-the-shaped-state) answers, after seeding.
@@ -582,10 +592,17 @@ wallet](#choosing-who-owns-the-seeded-names) is checked against that wallet.
 
 By default the corpus is owned by the five actor accounts the mnemonic derives, which is fine when
 nobody but the tooling needs to touch it. To put it in a tester's hands, nominate the wallet with
-`--fixture-owner-key` and seeding shapes every name into it rather than into a mnemonic account. Both
-commands take the key, and both need it:
+`--fixture-owner-key` and seeding shapes every name into it rather than into a mnemonic account.
+Every command up to and including registration takes the key, and each needs it: the dry run to
+preview this layout rather than the default one, funding to top up the wallet that will sign, and
+seeding to register to it.
 
 ```bash
+bun run migration -- fixture verify --network sepolia \
+  --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
+  --fixture-scenarios live_now --fixture-replicas-per-vector 4 \
+  --fixture-owner-key 0x<tester key>
+
 bun run migration -- fixture fund-actors --network sepolia \
   --fixture-root csv-data/migration-fixture --work-dir .dev/fixture \
   --fixture-owner-key 0x<tester key>
@@ -596,7 +613,9 @@ bun run migration -- fixture seed-v1 --network sepolia \
   --fixture-owner-key 0x<tester key>
 ```
 
-Export `MIGRATION_FIXTURE_OWNER_KEY` instead if you would rather not repeat it; both commands read it.
+Export `MIGRATION_FIXTURE_OWNER_KEY` instead if you would rather not repeat it; all three read it.
+Nothing after registration takes it: `verify-v1` resolves each alias against the addresses the
+seeding run recorded, and no command can change who owns a name once it is seeded.
 
 `fork full` and `clean-testnet` take the same flag. It is a **key**, not an address, and that is the
 whole trick: shaping a name means signing as its owner — reverse claims, operator approvals, unwraps,
@@ -860,7 +879,7 @@ and idempotency rules.
 | `premigration resume` | Resume pre-migration from the checkpoint |
 | `premigration status` | Print the current pre-migration checkpoint JSON (local; `--work-dir` only) |
 | `premigration verify` | Verify eligible CSV names were reserved or registered on v2 |
-| `fixture verify` | Offline: validate a fixture selection and plan every scenario's calls |
+| `fixture verify` | Offline: validate a fixture selection and plan every scenario's calls. Takes the same `--fixture-owner-key` as `seed-v1`, so the previewed plan is the one seeding will execute |
 | `fixture fund-actors` | Top up the fixture actor accounts from the operator key. Takes the same `--fixture-owner-key` as `seed-v1`, so the wallet that will own the names is the one funded; `--floor` (default 0.5 ETH) is charged per alias, so an account carrying all three owner aliases is topped up to three floors |
 | `fixture deploy-fixtures` | Deploy the fixture batcher and the corpus counterparty contracts |
 | `fixture seed-v1` | Register the ENSv1 fixture corpus, shape each name's pre-migration state, and emit the label subset pre-migration reserves (after phase 1, before phase 3) |
@@ -928,7 +947,7 @@ flags/env). See `bunx hardhat migration <task> --help` for options.
 | `PREMIGRATION_PRIVATE_KEY`, `BATCH_REGISTRAR_OWNER_KEY`, `DEPLOYER_KEY` | BatchRegistrar owner key fallbacks for `premigration run` / `resume` |
 | `MIGRATION_FIXTURE_ACTOR_MNEMONIC` | Dedicated mnemonic for the five `fixture` actor accounts — never reuse a mnemonic held elsewhere |
 | `MIGRATION_FIXTURE_PRIVATE_KEY` | Fixture operator key (`fixture` commands) when `--fixture-private-key` is omitted |
-| `MIGRATION_FIXTURE_OWNER_KEY` | Key for the wallet that should own every seeded name, when `--fixture-owner-key` is omitted; read by `fixture fund-actors` and `fixture seed-v1` alike |
+| `MIGRATION_FIXTURE_OWNER_KEY` | Key for the wallet that should own every seeded name, when `--fixture-owner-key` is omitted; read by `fixture verify`, `fixture fund-actors` and `fixture seed-v1` alike |
 | `MIGRATION_FIXTURE_V1_OWNER` | v1 owner address used only when `fixture seed-v1` finds v1 registration already frozen |
 | `MIGRATION_FIXTURE_COMMIT_BATCH_SIZE`, `MIGRATION_FIXTURE_REGISTER_BATCH_SIZE` | Fixture registration batch sizes (default 80 and 12) |
 | `THEGRAPH_API_KEY` / `GRAPH_API_KEY` | TheGraph Gateway key for `fetch-data` |

--- a/contracts/script/migrationFixture.ts
+++ b/contracts/script/migrationFixture.ts
@@ -596,10 +596,16 @@ async function verify(opts: CommonOptions): Promise<void> {
 
   // Placeholder addresses are enough to prove every action resolves, and keep
   // the check runnable without deployments or an RPC.
+  //
+  // The actors are the exception: they are derived, not deployed, so the plan
+  // is built against the very addresses a run will use. A placeholder per alias
+  // would give the three owner aliases three addresses even when a nominated
+  // wallet has collapsed them onto one, which is the difference between the
+  // preview and the run that a dry run exists to rule out.
   const placeholder = (n: number) =>
     `0x${n.toString(16).padStart(40, "0")}` as Address;
   const ctx: PlanContext = {
-    actors: new Map(actors.map((a, i) => [a.alias, placeholder(0x1000 + i)])),
+    actors: new Map(actors.map((a) => [a.alias, a.account.address])),
     fixtureContracts: Object.fromEntries(
       FIXTURE_ARTIFACTS.map((f, i) => [f.name, placeholder(0x2000 + i)]),
     ),
@@ -649,6 +655,9 @@ async function verify(opts: CommonOptions): Promise<void> {
     JSON.stringify(
       {
         selected: rows.length,
+        // Null unless a wallet is nominated, so a preview says whose the names
+        // will be rather than leaving it to be read off the command line.
+        owner: ownerAddress(opts),
         sourceScenarios: perVector.size,
         replicasPerVector: {
           min: Math.min(...perVector.values()),
@@ -1205,12 +1214,14 @@ function addCommon(command: Command): Command {
     );
 }
 
-/// Nominates the wallet that will own every seeded name. The commands up to and
-/// including registration take it: seeding registers to that wallet, and funding
-/// has to top up the accounts seeding will sign from, which once a wallet is
-/// nominated are that wallet rather than the mnemonic's owner accounts. Nothing
-/// after registration takes it, where it would instead read as a way to change
-/// who owns the names, which no command can do.
+/// Nominates the wallet that will own every seeded name. Every command up to and
+/// including registration takes it, because each resolves the owner aliases:
+/// planning resolves them to preview the layout seeding will register rather
+/// than the default three-owner one, seeding registers to that wallet, and
+/// funding has to top up the accounts seeding will sign from, which once a
+/// wallet is nominated are that wallet rather than the mnemonic's owner
+/// accounts. Nothing after registration takes it, where it would instead read as
+/// a way to change who owns the names, which no command can do.
 function addOwnerKeyOption(command: Command): Command {
   return command.option(
     "--fixture-owner-key <key>",
@@ -1257,9 +1268,11 @@ function normalizeOptions(raw: any): CommonOptions {
 /// drift apart on options or behaviour.
 export function addFixtureSubcommands(program: Command): Command {
   program.addCommand(
-    addCommon(
-      new Command("verify").description(
-        "Offline: validate the selection and plan every scenario's calls",
+    addOwnerKeyOption(
+      addCommon(
+        new Command("verify").description(
+          "Offline: validate the selection and plan every scenario's calls",
+        ),
       ),
     ).action((raw) => verify(normalizeOptions(raw))),
   );

--- a/contracts/test/unit/migrationFixtureRecords.test.ts
+++ b/contracts/test/unit/migrationFixtureRecords.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { Command } from "commander";
 import { parseEther, zeroAddress, type Address } from "viem";
 
 import { isRetryableRpcRequest } from "../../script/migration.js";
@@ -13,6 +14,7 @@ import {
   fundingTargets,
 } from "../../script/migrationFixture/config.js";
 import {
+  addFixtureSubcommands,
   assertSeedable,
   refContext,
   reportReverseClaimOverlap,
@@ -477,5 +479,106 @@ describe("a subname's parent", () => {
       },
     } as unknown as FixtureEnvelope;
     expect(parentTransfer(flat)).toEqual([]);
+  });
+});
+
+describe("the fixture command line", () => {
+  /// Parses one command line the way the CLI does, and hands back the options
+  /// the command would have run with.
+  ///
+  /// The parse is the real one — an unregistered option throws here exactly as
+  /// it does for an operator — with only the action replaced, so a dry run does
+  /// not go looking for a corpus or an RPC. `exitOverride` turns a parse error
+  /// into a thrown error rather than an exit that would take the runner with it.
+  const run = async (argv: string[]): Promise<Record<string, unknown>> => {
+    const program = addFixtureSubcommands(new Command("migration-fixture"));
+    const silent = { writeErr: () => {}, writeOut: () => {} };
+    let parsed: Record<string, unknown> | undefined;
+    program.exitOverride().configureOutput(silent);
+    for (const command of program.commands) {
+      command
+        .exitOverride()
+        .configureOutput(silent)
+        .action((raw: Record<string, unknown>) => {
+          parsed = raw;
+        });
+    }
+    await program.parseAsync(argv, { from: "user" });
+    if (!parsed) throw new Error("no fixture command ran");
+    return parsed;
+  };
+
+  const argvFor = (command: string, ...rest: string[]) => [
+    command,
+    "--network",
+    "sepolia",
+    "--rpc-url",
+    "http://127.0.0.1:8545",
+    "--fixture-root",
+    "csv-data/migration-fixture",
+    "--work-dir",
+    ".dev/fixture",
+    "--fixture-actor-mnemonic",
+    MNEMONIC,
+    ...rest,
+  ];
+
+  const optionsOf = (command: string) => {
+    const program = addFixtureSubcommands(new Command("migration-fixture"));
+    const found = program.commands.find((c) => c.name() === command);
+    if (!found) throw new Error(`no such fixture command: ${command}`);
+    return found.options.map((o) => o.long);
+  };
+
+  it("carries the owner key from the dry run's argv through to the actors", async () => {
+    // The whole point of the dry run: the cohort it plans is the cohort seeding
+    // will register, down to which account each owner alias is.
+    const parsed = await run(
+      argvFor("verify", "--fixture-owner-key", OWNER_KEY),
+    );
+    expect(parsed.fixtureOwnerKey).toBe(OWNER_KEY);
+
+    const derived = accounts(parsed as never);
+    const address = (alias: string) =>
+      derived.find((a) => a.alias === alias)!.account.address;
+    for (const alias of ["owner_a", "owner_b", "owner_c"]) {
+      expect(address(alias)).toBe(KEY_ADDRESS);
+    }
+  });
+
+  it("plans the default three-owner layout when no wallet is nominated", async () => {
+    const parsed = await run(argvFor("verify"));
+    expect(parsed.fixtureOwnerKey).toBeUndefined();
+    // Five aliases, five accounts: the layout the dry run has always planned.
+    const derived = accounts(parsed as never);
+    expect(new Set(derived.map((a) => a.account.address)).size).toBe(5);
+  });
+
+  it("lets the dry run take every option the run it previews takes", () => {
+    // A plan is worth previewing only if it is the plan that will run. An
+    // option seeding accepts and the dry run rejects makes the two diverge with
+    // nothing to show for it, which is how --fixture-owner-key came to be
+    // previewable through its environment variable alone.
+    for (const long of optionsOf("seed-v1")) {
+      expect(optionsOf("verify")).toContain(long);
+    }
+  });
+
+  it("takes the owner key everywhere the owner aliases are resolved", async () => {
+    for (const command of ["verify", "fund-actors", "seed-v1"]) {
+      const parsed = await run(
+        argvFor(command, "--fixture-owner-key", OWNER_KEY),
+      );
+      expect(parsed.fixtureOwnerKey).toBe(OWNER_KEY);
+    }
+  });
+
+  it("refuses the owner key once the names exist, whose owner it cannot change", async () => {
+    // verify-v1 resolves each alias against the addresses the seeding run
+    // recorded, so a key here could only contradict them. Its refusal is also
+    // what proves this harness sees an unregistered option at all.
+    await expect(
+      run(argvFor("verify-v1", "--fixture-owner-key", OWNER_KEY)),
+    ).rejects.toThrow(/unknown option/);
   });
 });


### PR DESCRIPTION
## The gap

`fixture verify` rejected `--fixture-owner-key`, so the plan an operator previewed was never the plan a nominated-wallet run would execute.

- Dry-run the three-owner layout.
- Seed the one-owner layout.
- The plan previewed is not the plan run.

What separates the two is visible: 356 `transfer_registrant` steps become self-transfers, and reverse claims are counted against one account rather than three. Until now none of it could be seen before the gas was spent.

## Why it was there

The flag inherited its attachment set from the flag it replaced. `--fixture-handover-to` was an **address**, applied after registration, and rightly changed nothing about the plan. When `a5dc925` made it a **key** — which decides *who the actors are*, a plan-time input — the commands it was attached to were carried over unchanged. `6900ff3` then added it to `fund-actors` and reasoned about the set in terms of writes, so the read-only dry run fell outside it a second time.

Three things kept it quiet:

1. The environment variable already worked. `accounts()` reads `MIGRATION_FIXTURE_OWNER_KEY` whichever command is running, so `MIGRATION_FIXTURE_OWNER_KEY=0x… fixture verify` previewed the correct plan all along. Only the command-line spelling was missing.
2. No test built the CLI. Every fixture test called `accounts()`, `fundingTargets()` and `reportReverseClaimOverlap()` with plain option objects, so an unregistered commander option was invisible to all of them.
3. A rehearsal never runs the dry run. `runFixtureSeedStage` calls `seedV1` then `verifyV1`, so `fork full --fixture-owner-key` exercised every path except this one.

## The change

- `verify` takes `--fixture-owner-key`, alongside `fund-actors` and `seed-v1`.
- `verify` plans against the actor addresses a run will use, rather than one placeholder per alias. Aliases a nominated wallet collapses onto one account are now one address in the preview too. Contract addresses stay placeholders, so the check still needs no deployments and no RPC.
- The output reports `owner`: the wallet the plan registers to, `null` when none is nominated.
- Nothing after registration takes the key. `verify-v1` resolves each alias against the addresses the seeding run recorded, so a key there could only contradict them.

## Tests

The new tests build the CLI and parse a real command line, with only the action replaced:

- The owner key is followed from `verify`'s argv through to the three accounts it collapses onto the nominated wallet.
- Without a key, the dry run still plans five aliases across five accounts.
- `verify` accepts every option `seed-v1` does, so the two cannot drift apart again.
- `verify-v1` refuses the key, which is also what proves the harness sees an unregistered option at all.

## Verification

`bun test test/unit/migrationFixtureRecords.test.ts` after `hardhat compile`: **36 pass, 0 fail**.

Reverting the one-line CLI registration and rerunning fails 3 of them with `CommanderError: error: unknown option '--fixture-owner-key'`, so the tests catch the reported bug rather than merely covering the new code.

Two caveats about where that ran. The bun preload starts a devnet that needs a `forge`/`anvil` toolchain this container lacks, so the file was run with `contracts/bunfig.toml` moved aside — these tests need no chain. And `viem`'s pinned `ox` build comes from `pkg.pr.new`, which the environment's proxy could not reach, so the lockfile was regenerated for the run (`viem` resolved to 2.56.3 rather than the pinned 2.51.0) and then restored. Nothing in either detour is committed; CI runs the pinned tree.

## Docs

`contracts/docs/migration.md`: the dry-run section now says the flag belongs there and what omitting it previews; the owner-wallet section lists three commands rather than two; the reverse-record note explains that which claims collide depends on the layout; the command and environment tables are updated.

