### PR TITLE
fix: require a zero subregistry for HCA session registrations

### DIFF
--- a/contracts/src/hca/HCAOwnerAndSessionValidator.sol
+++ b/contracts/src/hca/HCAOwnerAndSessionValidator.sol
@@ -33,6 +33,7 @@ import {HCASmartSessionLib} from "./libraries/HCASmartSessionLib.sol";
 /// @dev Owner signatures use Rhinestone's existing HCA format. Session operations carry a
 ///      reusable owner authorization and are consumed through the IntentExecutor's ERC-1271 path.
 ///      The permission checks remain hardcoded here rather than in dynamic policy modules.
+///      Session registrations require a zero subregistry; this policy does not restrict owner calls.
 contract HCAOwnerAndSessionValidator is HCAValidatorBase {
     ////////////////////////////////////////////////////////////////////////
     // Types
@@ -669,8 +670,9 @@ contract HCAOwnerAndSessionValidator is HCAValidatorBase {
                 if (!_isAuthorizedRegistrar(execution.target, state)) {
                     revert ActionNotAllowed(execution.target, selector);
                 }
-                (address registrant, address resolver) = _registerFields(execution.callData);
-                if (registrant != owner || resolver != allowedResolver) {
+                (address registrant, address subregistry, address resolver) =
+                    _registerFields(execution.callData);
+                if (registrant != owner || subregistry != address(0) || resolver != allowedResolver) {
                     revert PolicyRuleFailed();
                 }
                 state.usesResolver = true;
@@ -1003,11 +1005,12 @@ contract HCAOwnerAndSessionValidator is HCAValidatorBase {
     /// @dev Reads only the needed ABI head words instead of decoding the full register tuple.
     /// @param callData ABI-encoded register call data.
     /// @return registrant The owner argument of the register call.
+    /// @return subregistry The initial subregistry argument of the register call.
     /// @return resolver The resolver argument of the register call.
     function _registerFields(bytes memory callData)
         internal
         pure
-        returns (address registrant, address resolver)
+        returns (address registrant, address subregistry, address resolver)
     {
         return HCARegistrarPolicyLib.registrationFields(callData);
     }

--- a/contracts/src/hca/libraries/HCARegistrarPolicyLib.sol
+++ b/contracts/src/hca/libraries/HCARegistrarPolicyLib.sol
@@ -84,17 +84,19 @@ library HCARegistrarPolicyLib {
         return !seenRegistration || isPaymentToken(registrar, token);
     }
 
-    /// @notice Reads the registrant and resolver from an encoded registration call.
+    /// @notice Reads the registrant, subregistry, and resolver from an encoded registration call.
     /// @dev Reads fixed ABI head words without decoding the dynamic label argument.
     /// @param callData ABI-encoded registrar call data.
     /// @return registrant The owner argument of the registration.
+    /// @return subregistry The initial subregistry argument of the registration.
     /// @return resolver The resolver argument of the registration.
     function registrationFields(bytes memory callData)
         internal
         pure
-        returns (address registrant, address resolver)
+        returns (address registrant, address subregistry, address resolver)
     {
         registrant = HCAExecutionLib.readAddress(callData, 4 + 32);
+        subregistry = HCAExecutionLib.readAddress(callData, 4 + 96);
         resolver = HCAExecutionLib.readAddress(callData, 4 + 128);
     }
 }

--- a/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
+++ b/contracts/test/unit/hca/StandaloneSingleOwnerHCA.t.sol
@@ -28,6 +28,7 @@ import {
 import {Execution} from "nexus/types/DataTypes.sol";
 import {ERC1271_MAGICVALUE} from "nexus/types/Constants.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {Test} from "forge-std/Test.sol";
 
@@ -49,6 +50,8 @@ import {StandaloneSingleOwnerHCA} from "~src/hca/StandaloneSingleOwnerHCA.sol";
 import {IStandaloneHCAFactory} from "~src/hca/interfaces/IStandaloneHCAFactory.sol";
 import {IStandaloneHCAOwner} from "~src/hca/interfaces/IStandaloneHCAOwner.sol";
 import {IRentPriceOracle} from "~src/registrar/interfaces/IRentPriceOracle.sol";
+import {IETHRegistrar} from "~src/registrar/interfaces/IETHRegistrar.sol";
+import {IRegistry} from "~src/registry/interfaces/IRegistry.sol";
 import {IRentPriceOracleProvider} from "~src/registrar/interfaces/IRentPriceOracleProvider.sol";
 import {IPermissionedRegistry} from "~src/registry/interfaces/IPermissionedRegistry.sol";
 import {RegistryRolesLib} from "~src/registry/libraries/RegistryRolesLib.sol";
@@ -117,7 +120,7 @@ contract StandaloneSingleOwnerHCATest is Test {
     address dai = makeAddr("dai");
     address resolver = makeAddr("resolver");
     address otherResolver = makeAddr("other-resolver");
-    address subregistry = makeAddr("subregistry");
+    address subregistry;
     address entryPoint = makeAddr("entry-point");
     address intentExecutor = makeAddr("intent-executor");
     address gasRefundPaymaster = makeAddr("gas-refund-paymaster");
@@ -140,7 +143,11 @@ contract StandaloneSingleOwnerHCATest is Test {
         ethRegistry = IPermissionedRegistry(
             deployCode(
                 PERMISSIONED_REGISTRY_ARTIFACT,
-                abi.encode(address(0), address(this), RegistryRolesLib.ROLE_REGISTRAR_ADMIN)
+                abi.encode(
+                    deployCode("src/utils/LabelStore.sol:LabelStore", abi.encode(address(0))),
+                    address(this),
+                    RegistryRolesLib.ROLE_REGISTRAR_ADMIN
+                )
             )
         );
         ethRegistrar = _deployRegistrarWithOracle(_defaultPaymentTokens());
@@ -373,6 +380,61 @@ contract StandaloneSingleOwnerHCATest is Test {
         vm.prank(owner);
         account.executeByOwner(executions);
         assertEq(firstTarget.value(), 7);
+    }
+
+    function test_standaloneSingleOwnerHCA_ownerRegistersWithNonzeroSubregistry() public {
+        subregistry = makeAddr("subregistry");
+        StandaloneSingleOwnerHCA implementation =
+            _newOwnerValidatedAccount(new MockExecutorModule());
+        StandaloneSingleOwnerHCA account =
+            StandaloneSingleOwnerHCA(
+                payable(
+                    VerifiableFactory(verifiableFactory).deployProxy(
+                        address(implementation),
+                        2,
+                        abi.encodeCall(
+                            StandaloneSingleOwnerHCA.initializeAccount,
+                            (abi.encode(owner))
+                        )
+                    )
+                )
+            );
+        IETHRegistrar registrar = IETHRegistrar(ethRegistrar);
+        bytes32 commitment =
+            registrar.makeCommitment(
+                "alice",
+                owner,
+                bytes32("secret"),
+                IRegistry(subregistry),
+                resolver,
+                uint64(365 days),
+                bytes32(0)
+            );
+        vm.warp(365 days);
+        Execution[] memory executions = new Execution[](1);
+        executions[0] = Execution({target: ethRegistrar, value: 0, callData: abi.encodeCall(
+            IETHRegistrar.commit,
+            (commitment)
+        )});
+        vm.prank(owner);
+        account.executeByOwner(executions);
+
+        vm.warp(block.timestamp + 1 minutes);
+        vm.mockCall(
+            address(IRentPriceOracleProvider(ethRegistrar).rentPriceOracle()),
+            abi.encodeWithSelector(IRentPriceOracle.getRegisterPrice.selector),
+            abi.encode(uint256(0), uint256(0))
+        );
+        vm.mockCall(
+            usdc,
+            abi.encodeCall(IERC20.transferFrom, (address(account), address(this), 0)),
+            abi.encode(true)
+        );
+        executions[0].callData = _registerCallData(owner, resolver);
+        vm.prank(owner);
+        account.executeByOwner(executions);
+
+        assertEq(address(ethRegistry.getSubregistry("alice")), subregistry);
     }
 
     function test_standaloneSingleOwnerHCA_rejectsNftReceivers() public {
@@ -1208,6 +1270,24 @@ contract StandaloneSingleOwnerHCATest is Test {
             owner,
             address(0),
             executions
+        );
+    }
+
+    function test_validator_acceptsRegistrationWithZeroSubregistry() public view {
+        validatorHarness.checkRegistrationPolicyHarness(
+            address(hca),
+            owner,
+            resolver,
+            _registrationOperationData(owner, resolver)
+        );
+    }
+
+    function test_validator_rejectsRegistrationWithNonzeroSubregistry() public {
+        subregistry = makeAddr("subregistry");
+        _expectValidationRevert(
+            _registrationOperationData(owner, resolver),
+            resolver,
+            HCAOwnerAndSessionValidator.PolicyRuleFailed.selector
         );
     }
 

--- a/docs/HCA.md
+++ b/docs/HCA.md
@@ -393,6 +393,7 @@ The session permits:
 The validator applies these rules:
 
 - Registration must assign the name to the HCA owner.
+- Registration must set the subregistry to `address(0)`.
 - Registration must use the resolver in the session.
 - Every registrar call and registrar payment-token approval in a batch must use the same registrar.
 - A new resolver must use the approved `PermissionedResolver` implementation, grant root `ROLES.ALL` to exactly the HCA and wallet, and include only supported resolver setters in its initializer multicall.
@@ -404,7 +405,7 @@ The validator applies these rules:
 
 The validator does not store this authorization. Each destination signature carries the reusable proof, and the HCA session nonce invalidates it globally. The session key can select labels, records, and primary-name strings. The owner does not pre-sign one fixed registration. The session can register more than one name before expiry or revocation.
 
-Registrar-role governance is therefore part of the session trust boundary: granting the role makes that registrar available to already-authorized, short-lived sessions, while revocation removes it. The remaining selector, registrant, and resolver checks still apply to every authorized registrar.
+Registrar-role governance is therefore part of the session trust boundary: granting the role makes that registrar available to already-authorized, short-lived sessions, while revocation removes it. The remaining selector, registrant, subregistry, and resolver checks still apply to every authorized registrar.
 
 The session does not permit:
 


### PR DESCRIPTION
session registrations currently accept any subregistry address, even though it isn't bound into the owner's session authorization.

changes:
- require a zero subregistry alongside the existing registrant and resolver checks
- keep owner-authorized registration with a nonzero subregistry supported
- update the session policy documentation
